### PR TITLE
bug: remote whitespace so eval works

### DIFF
--- a/cmd/dexctl/command_client.go
+++ b/cmd/dexctl/command_client.go
@@ -45,7 +45,7 @@ func runNewClient(args []string) int {
 	stdout("DEX_APP_CLIENT_ID=%s", cc.ID)
 	stdout("DEX_APP_CLIENT_SECRET=%s", cc.Secret)
 	for i, u := range redirectURLs {
-		stdout(" DEX_APP_REDIRECTURL_%d=%s", i, u.String())
+		stdout("DEX_APP_REDIRECTURL_%d=%s", i, u.String())
 	}
 
 	return 0


### PR DESCRIPTION
Other nits include:
- docs reference "dex", when it should be "dex-worker"
- a few doc fixes that would have helped me:
  - what the db key is. I spent 20min creating a 32byte keyfile, when it should have been 32 chars on in the command line
  - that you need to run dex-overlord first, to run the migrations. Again, spent a bunch of time debugging dex-worker 
  - some docs/updates around the initial UI expectations. Going to localhost:5556 and seeing 404 feels a bit odd. Was hard to tell if it was working. 

Otherwise great stuff! 
