### PR TITLE
Add support for Resource Owner Password Credentials Grant

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -94,6 +94,8 @@ type OAuth2 struct {
 	// If specified, do not prompt the user to approve client authorization. The
 	// act of logging in implies authorization.
 	SkipApprovalScreen bool `json:"skipApprovalScreen"`
+	// This is the connector that can be used for password grant
+	PasswordConnector string `json:"passwordConnector"`
 }
 
 // Web is the config format for the HTTP server.

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -208,6 +208,9 @@ func serve(cmd *cobra.Command, args []string) error {
 	if c.OAuth2.SkipApprovalScreen {
 		logger.Infof("config skipping approval screen")
 	}
+	if c.OAuth2.PasswordConnector != "" {
+		logger.Infof("config using password grant connector: %s", c.OAuth2.PasswordConnector)
+	}
 	if len(c.Web.AllowedOrigins) > 0 {
 		logger.Infof("config allowed origins: %s", c.Web.AllowedOrigins)
 	}
@@ -218,6 +221,7 @@ func serve(cmd *cobra.Command, args []string) error {
 	serverConfig := server.Config{
 		SupportedResponseTypes: c.OAuth2.ResponseTypes,
 		SkipApprovalScreen:     c.OAuth2.SkipApprovalScreen,
+		PasswordConnector:      c.OAuth2.PasswordConnector,
 		AllowedOrigins:         c.Web.AllowedOrigins,
 		Issuer:                 c.Issuer,
 		Storage:                s,

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -45,7 +45,9 @@ telemetry:
 # Uncomment this block to control which response types dex supports. For example
 # the following response types enable the implicit flow for web-only clients.
 # Defaults to ["code"], the code flow.
-# oauth2:
+# Uncommend the passwordConnector to use a specific connector for password grants
+#oauth2:
+#   passwordConnector: local
 #   responseTypes: ["code", "token", "id_token"]
 
 # Instead of reading from an external storage, use this list of clients.

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -117,6 +117,7 @@ const (
 const (
 	grantTypeAuthorizationCode = "authorization_code"
 	grantTypeRefreshToken      = "refresh_token"
+	grantTypePassword          = "password"
 )
 
 const (

--- a/server/server.go
+++ b/server/server.go
@@ -67,6 +67,9 @@ type Config struct {
 	// Logging in implies approval.
 	SkipApprovalScreen bool
 
+	// If set, the server will use this connector to handle password grants
+	PasswordConnector string
+
 	RotateKeysAfter  time.Duration // Defaults to 6 hours.
 	IDTokensValidFor time.Duration // Defaults to 24 hours
 
@@ -131,6 +134,9 @@ type Server struct {
 
 	// If enabled, don't prompt user for approval after logging in through connector.
 	skipApproval bool
+
+	// Used for password grant
+	passwordConnector string
 
 	supportedResponseTypes map[string]bool
 
@@ -197,6 +203,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 		supportedResponseTypes: supported,
 		idTokensValidFor:       value(c.IDTokensValidFor, 24*time.Hour),
 		skipApproval:           c.SkipApprovalScreen,
+		passwordConnector:      c.PasswordConnector,
 		now:                    now,
 		templates:              tmpls,
 		logger:                 c.Logger,


### PR DESCRIPTION
This PR adds support for Resource Owner Password Credentials Grant.
https://www.oauth.com/oauth2-servers/access-tokens/password-grant/

You enable it in the config by setting:
```
oauth2:
   passwordConnector: local
```
or replace local with whatever connector you wish to use for password grants.

You then request a token via a 

```
POST /dex/token
grant_type=password&client_id=example-app&client_secret=ZXhhbXBsZS1hcHAtc2VjcmV0&username=admin@example.com&password=password&scope=openid profile email&nonce=2OSwiYXRfaGFzaCI6Il9rMVBZT0ppcGFQc0pHSmlZV
```