### PR TITLE
A simple implementation of userinfo endpoint

### DIFF
--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -265,6 +265,11 @@ type federatedIDClaims struct {
 	UserID      string `json:"user_id,omitempty"`
 }
 
+func (s *Server) newAccessToken(clientID string, claims storage.Claims, scopes []string, nonce, connID string) (accessToken string, err error) {
+	idToken, _, err := s.newIDToken(clientID, claims, scopes, nonce, storage.NewID(), connID)
+	return idToken, err
+}
+
 func (s *Server) newIDToken(clientID string, claims storage.Claims, scopes []string, nonce, accessToken, connID string) (idToken string, expiry time.Time, err error) {
 	keys, err := s.storage.GetKeys()
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -263,6 +263,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	// TODO(ericchiang): rate limit certain paths based on IP.
 	handleWithCORS("/token", s.handleToken)
 	handleWithCORS("/keys", s.handlePublicKeys)
+	handleWithCORS("/userinfo", s.handleUserInfo)
 	handleFunc("/auth", s.handleAuthorization)
 	handleFunc("/auth/{connector}", s.handleConnectorLogin)
 	r.HandleFunc(path.Join(issuerURL.Path, "/callback"), func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
A stop gap to solve #376. Borrowed mostly from #1133.

The way it works is we create a signed jwt token as access_token (same claims as id token), on requesting /userinfo, it verifies the token and check it's not expired etc, and return the claims in json

IMHO, the full solution should involve the storage to implement similar logic for refresh_token. i.e. serialise access token and save in storage and retrieve upon requesting user info. 

Because access token is opaque to the user, we can later roll in the proper solution without breaking API.