### PR TITLE
.well-known/openid-configuration: update scopes and claims

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -111,11 +111,13 @@ func (s *Server) discoveryHandler() (http.HandlerFunc, error) {
 		Keys:        s.absURL("/keys"),
 		Subjects:    []string{"public"},
 		IDTokenAlgs: []string{string(jose.RS256)},
-		Scopes:      []string{"openid", "email", "groups", "profile", "offline_access"},
+		Scopes: []string{"openid", "email", "groups", "profile", "offline_access",
+			"federated:id", "audience:server:client_id:"},
 		AuthMethods: []string{"client_secret_basic"},
 		Claims: []string{
-			"aud", "email", "email_verified", "exp",
-			"iat", "iss", "locale", "name", "sub",
+			"aud", "at_hash", "azp", "email", "email_verified", "exp",
+			"federated_claims", "groups", "iat", "iss", "locale", "name", "nonce",
+			"sub",
 		},
 	}
 


### PR DESCRIPTION
As per [spec](https://openid.net/specs/openid-connect-discovery-1_0.html), none of these would have to be there; but I don't see why we should omit them.

> **scopes_supported**
>    RECOMMENDED. JSON array containing a list of the OAuth 2.0 [RFC6749] scope values that this server supports. The server MUST support the openid scope value. Servers MAY choose not to advertise some supported scope values even when this parameter is used, although those defined in [OpenID.Core] SHOULD be listed, if supported.

> **claims_supported**
>    RECOMMENDED. JSON array containing a list of the Claim Names of the Claims that the OpenID Provider MAY be able to supply values for. Note that for privacy or other reasons, this might not be an exhaustive list. 

I don't really know how to account for "nested claims", i.e., how `federated_claims` works, though...