### PR TITLE
Ensure GitLab connector uses fullpath for subgroups

### DIFF
--- a/connector/gitlab/gitlab.go
+++ b/connector/gitlab/gitlab.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/coreos/dex/connector"
 	"github.com/sirupsen/logrus"
@@ -47,7 +48,7 @@ type gitlabUser struct {
 type gitlabGroup struct {
 	ID   int
 	Name string
-	Path string
+	Path string `json:"full_path"`
 }
 
 // Open returns a strategy for logging in through GitLab.
@@ -269,7 +270,7 @@ func (c *gitlabConnector) groups(ctx context.Context, client *http.Client) ([]st
 		}
 
 		for _, group := range gitlabGroups {
-			groups = append(groups, group.Name)
+			groups = append(groups, strings.Replace(group.Path, "/", "-", -1))
 		}
 
 		link := resp.Header.Get("Link")


### PR DESCRIPTION
Currently, the Gitlab connector pulls all of the groups and subgroups into a flat list without any concept of hierarchy – which is a potential security issue in the case of GitLab where people can create top level groups/project and sub-projects with non-unique names.

This PR fixes this behaviour by prefixing all of the subgroups with the parent name.

**Gitlab group scenario**

```
 +- foo
 |   +- bar
 +- bar
```

```
GET /api/v4/groups
[
  {
    "name": "Foo 1 Parent Group",
    "path": "foo1",
    "full_path": "foo1",
  },
  {
    "name": "Bar Subgroup",
    "path": "bar",
    "full_path": "foo/bar",
  },
  {
    "name": "Bar Parent Group",
    "path": "bar",
    "full_path": "bar",
  }
] 
```

**Dex's response to the authenticating application**

Before
```
{ "groups": [
     "foo"
     "foo"
     "bar"
 ]}
```

After
```
{ "groups": [
     "foo"
     "foo-bar"
     "bar"
 ]}
```
