### PR TITLE
add Refresh() to mock passwordConnector

### DIFF
--- a/connector/mock/connectortest.go
+++ b/connector/mock/connectortest.go
@@ -33,6 +33,7 @@ var (
 	_ connector.CallbackConnector = &Callback{}
 
 	_ connector.PasswordConnector = passwordConnector{}
+	_ connector.RefreshConnector  = passwordConnector{}
 )
 
 // Callback is a connector that requires no user interaction and always returns the same identity.
@@ -113,3 +114,7 @@ func (p passwordConnector) Login(ctx context.Context, s connector.Scopes, userna
 }
 
 func (p passwordConnector) Prompt() string { return "" }
+
+func (p passwordConnector) Refresh(_ context.Context, _ connector.Scopes, identity connector.Identity) (connector.Identity, error) {
+	return identity, nil
+}


### PR DESCRIPTION
we've been using the mock passwordConnector for some internal testing, but it doesn't satisfy the `RefreshConnector` interface. this change fixes that.