### PR TITLE
ldap_test: add filter tests

### DIFF
--- a/connector/ldap/ldap_test.go
+++ b/connector/ldap/ldap_test.go
@@ -185,6 +185,102 @@ userpassword: bar
 	runTests(t, schema, connectLDAP, c, tests)
 }
 
+func TestUserFilter(t *testing.T) {
+	schema := `
+dn: dc=example,dc=org
+objectClass: dcObject
+objectClass: organization
+o: Example Company
+dc: example
+
+dn: ou=Seattle,dc=example,dc=org
+objectClass: organizationalUnit
+ou: Seattle
+
+dn: ou=Portland,dc=example,dc=org
+objectClass: organizationalUnit
+ou: Portland
+
+dn: ou=People,ou=Seattle,dc=example,dc=org
+objectClass: organizationalUnit
+ou: People
+
+dn: ou=People,ou=Portland,dc=example,dc=org
+objectClass: organizationalUnit
+ou: People
+
+dn: cn=jane,ou=People,ou=Seattle,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+sn: doe
+cn: jane
+mail: janedoe@example.com
+userpassword: foo
+
+dn: cn=jane,ou=People,ou=Portland,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+sn: doe
+cn: jane
+mail: janedoefromportland@example.com
+userpassword: baz
+
+dn: cn=john,ou=People,ou=Seattle,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+sn: doe
+cn: john
+mail: johndoe@example.com
+userpassword: bar
+`
+	c := &Config{}
+	c.UserSearch.BaseDN = "dc=example,dc=org"
+	c.UserSearch.NameAttr = "cn"
+	c.UserSearch.EmailAttr = "mail"
+	c.UserSearch.IDAttr = "DN"
+	c.UserSearch.Username = "cn"
+	c.UserSearch.Filter = "(ou:dn:=Seattle)"
+
+	tests := []subtest{
+		{
+			name:     "validpassword",
+			username: "jane",
+			password: "foo",
+			want: connector.Identity{
+				UserID:        "cn=jane,ou=People,ou=Seattle,dc=example,dc=org",
+				Username:      "jane",
+				Email:         "janedoe@example.com",
+				EmailVerified: true,
+			},
+		},
+		{
+			name:     "validpassword2",
+			username: "john",
+			password: "bar",
+			want: connector.Identity{
+				UserID:        "cn=john,ou=People,ou=Seattle,dc=example,dc=org",
+				Username:      "john",
+				Email:         "johndoe@example.com",
+				EmailVerified: true,
+			},
+		},
+		{
+			name:      "invalidpassword",
+			username:  "jane",
+			password:  "badpassword",
+			wantBadPW: true,
+		},
+		{
+			name:      "invaliduser",
+			username:  "idontexist",
+			password:  "foo",
+			wantBadPW: true, // Want invalid password, not a query error.
+		},
+	}
+
+	runTests(t, schema, connectLDAP, c, tests)
+}
+
 func TestGroupQuery(t *testing.T) {
 	schema := `
 dn: dc=example,dc=org
@@ -367,6 +463,112 @@ gidNumber: 1002
 			},
 		},
 	}
+	runTests(t, schema, connectLDAP, c, tests)
+}
+
+func TestGroupFilter(t *testing.T) {
+	schema := `
+dn: dc=example,dc=org
+objectClass: dcObject
+objectClass: organization
+o: Example Company
+dc: example
+
+dn: ou=People,dc=example,dc=org
+objectClass: organizationalUnit
+ou: People
+
+dn: cn=jane,ou=People,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+sn: doe
+cn: jane
+mail: janedoe@example.com
+userpassword: foo
+
+dn: cn=john,ou=People,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+sn: doe
+cn: john
+mail: johndoe@example.com
+userpassword: bar
+
+# Group definitions.
+
+dn: ou=Seattle,dc=example,dc=org
+objectClass: organizationalUnit
+ou: Seattle
+
+dn: ou=Portland,dc=example,dc=org
+objectClass: organizationalUnit
+ou: Portland
+
+dn: ou=Groups,ou=Seattle,dc=example,dc=org
+objectClass: organizationalUnit
+ou: Groups
+
+dn: ou=Groups,ou=Portland,dc=example,dc=org
+objectClass: organizationalUnit
+ou: Groups
+
+dn: cn=qa,ou=Groups,ou=Portland,dc=example,dc=org
+objectClass: groupOfNames
+cn: qa
+member: cn=john,ou=People,dc=example,dc=org
+
+dn: cn=admins,ou=Groups,ou=Seattle,dc=example,dc=org
+objectClass: groupOfNames
+cn: admins
+member: cn=john,ou=People,dc=example,dc=org
+member: cn=jane,ou=People,dc=example,dc=org
+
+dn: cn=developers,ou=Groups,ou=Seattle,dc=example,dc=org
+objectClass: groupOfNames
+cn: developers
+member: cn=jane,ou=People,dc=example,dc=org
+`
+	c := &Config{}
+	c.UserSearch.BaseDN = "ou=People,dc=example,dc=org"
+	c.UserSearch.NameAttr = "cn"
+	c.UserSearch.EmailAttr = "mail"
+	c.UserSearch.IDAttr = "DN"
+	c.UserSearch.Username = "cn"
+	c.GroupSearch.BaseDN = "dc=example,dc=org"
+	c.GroupSearch.UserAttr = "DN"
+	c.GroupSearch.GroupAttr = "member"
+	c.GroupSearch.NameAttr = "cn"
+	c.GroupSearch.Filter = "(ou:dn:=Seattle)" // ignore other groups
+
+	tests := []subtest{
+		{
+			name:     "validpassword",
+			username: "jane",
+			password: "foo",
+			groups:   true,
+			want: connector.Identity{
+				UserID:        "cn=jane,ou=People,dc=example,dc=org",
+				Username:      "jane",
+				Email:         "janedoe@example.com",
+				EmailVerified: true,
+				Groups:        []string{"admins", "developers"},
+			},
+		},
+		{
+			name:     "validpassword2",
+			username: "john",
+			password: "bar",
+			groups:   true,
+			want: connector.Identity{
+				UserID:        "cn=john,ou=People,dc=example,dc=org",
+				Username:      "john",
+				Email:         "johndoe@example.com",
+				EmailVerified: true,
+				Groups:        []string{"admins"},
+			},
+		},
+	}
+
 	runTests(t, schema, connectLDAP, c, tests)
 }
 


### PR DESCRIPTION
The filters for user and group searches hadn't been included in our LDAP
tests. Now they are.

The concrete test cases are somewhat contrived, but that shouldn't
matter too much. Also note that the example queries I've used are not
supported in AD: https://stackoverflow.com/a/10043452