### PR TITLE
fix timeout bug for etcd3 client connect

### DIFF
--- a/storage/etcd/config.go
+++ b/storage/etcd/config.go
@@ -42,7 +42,7 @@ func (p *Etcd) Open(logger logrus.FieldLogger) (storage.Storage, error) {
 func (p *Etcd) open(logger logrus.FieldLogger) (*conn, error) {
 	cfg := clientv3.Config{
 		Endpoints:   p.Endpoints,
-		DialTimeout: defaultDialTimeout * time.Second,
+		DialTimeout: defaultDialTimeout,
 		Username:    p.Username,
 		Password:    p.Password,
 	}


### PR DESCRIPTION
Heya! Subtle bug here for `etcd3` storage backend. The timeout was being unnecessarily multiplied by `time.Second` causing a near-infinite timeout before returning on connection errors. This makes debugging Dex with etcd storage very annoying :)

```
fmt.Printf("time 1: %v\n", 2 * time.Second)
fmt.Printf("time 2: %v\n", 2 * time.Second * time.Second)

output:
time 1: 2s
time 2: 555555h33m20s
```