### PR TITLE
fix default baseURL for GitLab connector

### DIFF
--- a/Documentation/connectors/gitlab.md
+++ b/Documentation/connectors/gitlab.md
@@ -20,8 +20,8 @@ connectors:
     # Required field for connector name.
     name: GitLab
     config:
-      # optional, default = https://www.gitlab.com 
-      baseURL: https://www.gitlab.com
+      # optional, default = https://gitlab.com 
+      baseURL: https://gitlab.com
       # Credentials can be string literals or pulled from the environment.  
       clientID: $GITLAB_APPLICATION_ID 
       clientSecret: $GITLAB_CLIENT_SECRET

--- a/connector/gitlab/gitlab.go
+++ b/connector/gitlab/gitlab.go
@@ -53,7 +53,7 @@ type gitlabGroup struct {
 // Open returns a strategy for logging in through GitLab.
 func (c *Config) Open(id string, logger logrus.FieldLogger) (connector.Connector, error) {
 	if c.BaseURL == "" {
-		c.BaseURL = "https://www.gitlab.com"
+		c.BaseURL = "https://gitlab.com"
 	}
 	return &gitlabConnector{
 		baseURL:      c.BaseURL,


### PR DESCRIPTION
The URL `https://www.gitlab.com` which is the default baseURL for the GitLab connector does not work any more. According to the DNS entries it's still pointing to an Azure ip adress while the whole service has moved to google cloud. Since `https://gitlab.com` is main URL for GitLab anyway that's probably a better default anyway. 

Documentation also updated.