### PR TITLE
connectors/ldap: treat 'constraint violation' on bind as bad credentials

### DIFF
--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -409,12 +409,17 @@ func (c *ldapConnector) Login(ctx context.Context, s connector.Scopes, username,
 		if err := conn.Bind(user.DN, password); err != nil {
 			// Detect a bad password through the LDAP error code.
 			if ldapErr, ok := err.(*ldap.Error); ok {
-				if ldapErr.ResultCode == ldap.LDAPResultInvalidCredentials {
+				switch ldapErr.ResultCode {
+				case ldap.LDAPResultInvalidCredentials:
 					c.logger.Errorf("ldap: invalid password for user %q", user.DN)
 					incorrectPass = true
 					return nil
+				case ldap.LDAPResultConstraintViolation:
+					c.logger.Errorf("ldap: constraint violation for user %q: %s", user.DN, ldapErr.Error())
+					incorrectPass = true
+					return nil
 				}
-			}
+			} // will also catch all ldap.Error without a case statement above
 			return fmt.Errorf("ldap: failed to bind as dn %q: %v", user.DN, err)
 		}
 		return nil


### PR DESCRIPTION
Some directory servers (I think it's Oracle) return

    Constraint Violation: Exceed password retry limit. Account locked.

when attempting to login too many times. While constraint violation can
mean many things, we're checking this as an error on BIND, so it's
more likely that something like this has happened than any other thing.

Hence, we should treat it as an "incorrect password" situation, not an
internal error.

It would of course be preferrable to surface more information about this
precise error (and similar ones), but I think this is beyond this small
change.

(This is some prior art: https://github.com/vesse/passport-ldapauth/issues/21 )