### PR TITLE
RPM Build

### DIFF
--- a/.tito/packages/.readme
+++ b/.tito/packages/.readme
@@ -1,0 +1,3 @@
+the .tito/packages directory contains metadata files
+named after their packages. Each file has the latest tagged
+version and the project's relative directory.

--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -1,0 +1,5 @@
+[buildconfig]
+builder = tito.builder.Builder
+tagger = tito.tagger.VersionTagger
+changelog_do_not_remove_cherrypick = 0
+changelog_format = %s (%ae)

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ check-go-version:
 clean:
 	@rm -rf bin/
 
-rpm:
+rpm: FORCE
 	tito build --rpm --test
 
 testall: testrace vet fmt lint

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ group=$(shell id -g -n)
 
 export GOBIN=$(PWD)/bin
 
-LD_FLAGS="-w -X $(REPO_PATH)/version.Version=$(VERSION)"
+LD_FLAGS="$(LDFLAGS) -w -X $(REPO_PATH)/version.Version=$(VERSION)"
 
 build: bin/dex bin/example-app bin/grpc-client
 
@@ -81,6 +81,9 @@ check-go-version:
 
 clean:
 	@rm -rf bin/
+
+rpm:
+	tito build --rpm --test
 
 testall: testrace vet fmt lint
 

--- a/dex.spec
+++ b/dex.spec
@@ -1,0 +1,65 @@
+Name: dex
+Version: v2.11.0
+Release: 1%{?dist}
+License: ASL 2.0
+Summary: OpenID Connect Identity (OIDC) Provider
+
+URL: https://github.com/dexidp/dex
+Source0: %{name}-%{version}.tar.gz
+
+%description
+OpenID Connect Identity (OIDC) and OAuth 2.0 Provider with Pluggable Connectors
+
+%pre
+# Add the "dex" user
+/usr/sbin/useradd -c "Dex" \
+	-s /sbin/nologin -r -d %{_datarootdir}/dex/ dex 2> /dev/null || :
+
+%post
+if [ $1 -eq 1 ] ; then
+        # Initial installation
+        systemctl preset dex.service >/dev/null 2>&1 || :
+fi
+
+%preun
+if [ $1 -eq 0 ] ; then
+        # Package removal, not upgrade
+        systemctl --no-reload disable dex.service > /dev/null 2>&1 || :
+        systemctl stop dex.service > /dev/null 2>&1 || :
+fi
+
+%postun
+systemctl daemon-reload >/dev/null 2>&1 || :
+
+%prep
+%setup -q
+
+%build
+export LDFLAGS=-linkmode=external
+mkdir -p ./_build/src/github.com/dexidp
+ln -s $(pwd) ./_build/src/github.com/dexidp/dex
+export GOPATH=$(pwd)/_build:%{gopath}
+export VERSION=%{version}
+make bin/dex
+make bin/grpc-client
+
+%install
+install -m 755 -d %{buildroot}%{_sysconfdir}/dex/
+install -m 755 -d %{buildroot}%{_bindir}
+install -m -o dex -g dex 750 -d %{buildroot}%{_localstatedir}/dex/
+install -m 755 -d %{buildroot}%{_datarootdir}/dex/
+install -m 755 -d %{buildroot}%{_sysconfdir}/systemd/system/
+install -m 755 -d %{buildroot}%{_sysconfdir}/systemd/system
+install -p -m 755 -t %{buildroot}%{_bindir} bin/dex
+install -p -m 755 -t %{buildroot}%{_bindir} bin/grpc-client
+install -p -m 644 -t %{buildroot}%{_sysconfdir}/systemd/system rpm/dex.service
+install -p -m -o dex -g dex 640 -t %{buildroot}%{_sysconfdir}/dex rpm/config.yaml
+cp -a web %{buildroot}%{_datarootdir}/dex
+
+%files
+%{_bindir}/dex
+%{_bindir}/grpc-client
+%{_datarootdir}/dex/*
+%{_sysconfdir}/dex rpm/config.yaml
+%{_sysconfdir}/systemd/system/dex.service
+%{_localstatedir}/dex

--- a/dex.spec
+++ b/dex.spec
@@ -1,5 +1,5 @@
 Name: dex
-Version: v2.11.0
+Version: v2.12.0
 Release: 1%{?dist}
 License: ASL 2.0
 Summary: OpenID Connect Identity (OIDC) Provider

--- a/dex.spec
+++ b/dex.spec
@@ -11,8 +11,9 @@ Source0: %{name}-%{version}.tar.gz
 OpenID Connect Identity (OIDC) and OAuth 2.0 Provider with Pluggable Connectors
 
 %pre
-# Add the "dex" user
-/usr/sbin/useradd -c "Dex" \
+# Add the "dex" user and group
+/usr/sbin/groupadd -r dex 2> /dev/null || :
+/usr/sbin/useradd -c "Dex" -g dex \
 	-s /sbin/nologin -r -d %{_datarootdir}/dex/ dex 2> /dev/null || :
 
 %post
@@ -46,20 +47,20 @@ make bin/grpc-client
 %install
 install -m 755 -d %{buildroot}%{_sysconfdir}/dex/
 install -m 755 -d %{buildroot}%{_bindir}
-install -m -o dex -g dex 750 -d %{buildroot}%{_localstatedir}/dex/
+install -m 750 -d %{buildroot}%{_sharedstatedir}/dex/
 install -m 755 -d %{buildroot}%{_datarootdir}/dex/
 install -m 755 -d %{buildroot}%{_sysconfdir}/systemd/system/
 install -m 755 -d %{buildroot}%{_sysconfdir}/systemd/system
 install -p -m 755 -t %{buildroot}%{_bindir} bin/dex
 install -p -m 755 -t %{buildroot}%{_bindir} bin/grpc-client
 install -p -m 644 -t %{buildroot}%{_sysconfdir}/systemd/system rpm/dex.service
-install -p -m -o dex -g dex 640 -t %{buildroot}%{_sysconfdir}/dex rpm/config.yaml
+install -p -m 640 -t %{buildroot}%{_sysconfdir}/dex rpm/config.yaml
 cp -a web %{buildroot}%{_datarootdir}/dex
 
 %files
 %{_bindir}/dex
 %{_bindir}/grpc-client
 %{_datarootdir}/dex/*
-%{_sysconfdir}/dex rpm/config.yaml
+%attr(-, dex, dex) %{_sysconfdir}/dex/config.yaml
 %{_sysconfdir}/systemd/system/dex.service
-%{_localstatedir}/dex
+%attr(-, dex, dex) %{_sharedstatedir}/dex

--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -1,0 +1,6 @@
+FROM centos/systemd
+RUN yum install -y epel-release
+RUN yum install -y tito golang make
+COPY . /src
+WORKDIR /src
+RUN make rpm

--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -4,3 +4,6 @@ RUN yum install -y tito golang make
 COPY . /src
 WORKDIR /src
 RUN make rpm
+FROM centos/systemd
+COPY --from=0 /tmp/tito/x86_64/*rpm /tmp/
+RUN rpm -Uv /tmp/*rpm

--- a/rpm/config.yaml
+++ b/rpm/config.yaml
@@ -1,0 +1,89 @@
+# The base path of dex and the external name of the OpenID Connect service.
+# This is the canonical URL that all clients MUST use to refer to dex. If a
+# path is provided, dex's HTTP service will listen at a non-root URL.
+issuer: http://127.0.0.1:5556/dex
+
+# The storage configuration determines where dex stores its state. Supported
+# options include SQL flavors and Kubernetes third party resources.
+#
+# See the storage document at Documentation/storage.md for further information.
+storage:
+  type: sqlite3
+  config:
+    file: /var/lib/dex/dex.db
+
+# Configuration for the HTTP endpoints.
+web:
+  http: 0.0.0.0:5556
+  # Uncomment for HTTPS options.
+  # https: 127.0.0.1:5554
+  # tlsCert: /etc/dex/tls.crt
+  # tlsKey: /etc/dex/tls.key
+
+# Configuration for telemetry
+telemetry:
+  http: 0.0.0.0:5558
+
+# Uncomment this block to enable the gRPC API. This values MUST be different
+# from the HTTP endpoints.
+# grpc:
+#   addr: 127.0.0.1:5557
+#  tlsCert: examples/grpc-client/server.crt
+#  tlsKey: examples/grpc-client/server.key
+#  tlsClientCA: /etc/dex/client.crt
+
+# Uncomment this block to enable configuration for the expiration time durations.
+# expiry:
+#   signingKeys: "6h"
+#   idTokens: "24h"
+
+# Options for controlling the logger.
+# logger:
+#   level: "debug"
+#   format: "text" # can also be "json"
+
+# Uncomment this block to control which response types dex supports. For example
+# the following response types enable the implicit flow for web-only clients.
+# Defaults to ["code"], the code flow.
+# oauth2:
+#   responseTypes: ["code", "token", "id_token"]
+
+# Instead of reading from an external storage, use this list of clients.
+#
+# If this option isn't chosen clients may be added through the gRPC API.
+staticClients:
+- id: example-app
+  redirectURIs:
+  - 'http://127.0.0.1:5555/callback'
+  name: 'Example App'
+  secret: ZXhhbXBsZS1hcHAtc2VjcmV0
+
+connectors:
+- type: mockCallback
+  id: mock
+  name: Example
+# - type: oidc
+#   id: google
+#   name: Google
+#   config:
+#     issuer: https://accounts.google.com
+#     # Connector config values starting with a "$" will read from the environment.
+#     clientID: $GOOGLE_CLIENT_ID
+#     clientSecret: $GOOGLE_CLIENT_SECRET
+#     redirectURI: http://127.0.0.1:5556/dex/callback
+#     hostedDomains:
+#     - $GOOGLE_HOSTED_DOMAIN
+
+# Let dex keep a list of passwords which can be used to login to dex.
+enablePasswordDB: true
+
+# A static list of passwords to login the end user. By identifying here, dex
+# won't look in its underlying storage for passwords.
+#
+# If this option isn't chosen users may be added through the gRPC API.
+staticPasswords:
+- email: "admin@example.com"
+  # bcrypt hash of the string "password"
+  hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+  username: "admin"
+  userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"

--- a/rpm/dex.service
+++ b/rpm/dex.service
@@ -4,4 +4,4 @@ Description=dex
 User=dex
 WorkingDirectory=/usr/share/dex
 Environment="DEXCONFIG=/etc/dex/config.yaml"
-ExecStart=dex serve "$DEXCONFIG"
+ExecStart=/usr/bin/dex serve "$DEXCONFIG"

--- a/rpm/dex.service
+++ b/rpm/dex.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=dex
+[Service]
+User=dex
+WorkingDirectory=/usr/share/dex
+Environment="DEXCONFIG=/etc/dex/config.yaml"
+ExecStart=dex serve "$DEXCONFIG"


### PR DESCRIPTION
Relates to #811. Looked like progress on an RPM had stalled. I made one that works well on CentOS 7 with systemd. I made some assumptions that I'm happy to discuss/change. I figured you'd want it to run, so I included a sample configuration that's largely the example one except that it writes the database to /var/lib/dex/. It creates and runs as the dex user. I realize that all the cool kids are building RPMs with Bazel :-), but I didn't want to introduce that into your project at this time. I kept it simple and build with tito. If you're not running on a RHEL/CentOS system with tito installed, you can test the build by running docker build -f rpm/Dockerfile .

