### PR TITLE
[WIP] PreferredEmailDomain GitHub connector Config option

### DIFF
--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -40,13 +40,14 @@ var reLast = regexp.MustCompile("<([^>]+)>; rel=\"last\"")
 
 // Config holds configuration options for github logins.
 type Config struct {
-	ClientID     string `json:"clientID"`
-	ClientSecret string `json:"clientSecret"`
-	RedirectURI  string `json:"redirectURI"`
-	Org          string `json:"org"`
-	Orgs         []Org  `json:"orgs"`
-	HostName     string `json:"hostName"`
-	RootCA       string `json:"rootCA"`
+	ClientID             string `json:"clientID"`
+	ClientSecret         string `json:"clientSecret"`
+	RedirectURI          string `json:"redirectURI"`
+	Org                  string `json:"org"`
+	Orgs                 []Org  `json:"orgs"`
+	HostName             string `json:"hostName"`
+	RootCA               string `json:"rootCA"`
+	PreferredEmailDomain string `json:"preferredEmailDomain"`
 }
 
 // Org holds org-team filters, in which teams are optional.


### PR DESCRIPTION
Considering implementing this. Will help identify users by verified company email without asking them to mark it as primary.

Sample config:

```
-connectors:
  - type: github
    id: github
    name: GitHub
    config:
      clientID: 'REDACTED'
      clientSecret: 'REDACTED'
      redirectURI: 'https://dex.acme.org/dex/callback'
      orgs:
        - name: acme
      preferredEmailDomain: 'acme.org'
```