### PR TITLE
Add mention of `scopes` parameter in OIDC doc

### DIFF
--- a/Documentation/connectors/oidc.md
+++ b/Documentation/connectors/oidc.md
@@ -47,6 +47,14 @@ connectors:
     #
     # hostedDomains:
     #  - example.com
+
+    # List of additional scopes to request in token response
+    # Default is profile and email
+    # Full list at https://github.com/dexidp/dex/blob/master/Documentation/custom-scopes-claims-clients.md
+    # scopes:
+    #  - profile
+    #  - email
+    #  - groups
 ```
 
 [oidc-doc]: openid-connect.md


### PR DESCRIPTION
The OIDC connector documentation / example doesn't mention the scopes config parameter.  It probably should.

I'm not super excited about that 106-character line containing the URL, but the link to the documentation is relatively long.