### PR TITLE
Made work with Cisco Ping Federate Public OIDC Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 dist
 _output
+vendor

--- a/Dockerfile.localbuild
+++ b/Dockerfile.localbuild
@@ -1,0 +1,14 @@
+FROM debian:latest
+
+RUN echo "Install OS packages" && \
+    apt-get -y update && apt-get --no-install-recommends -y install \
+        ca-certificates && \
+    apt-get -y clean && apt-get -y autoremove && rm -rf /var/lib/apt/lists/*
+
+# Import frontend assets and set the correct CWD directory so the assets
+# are in the default path.
+COPY web /web
+COPY dex /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/dex"]
+CMD ["version"]

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ bin/grpc-client:
 .PHONY: release-binary
 release-binary:
 	@go build -o /go/bin/dex -v -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/dex
+	cp /go/bin/dex ./dex
 
 .PHONY: revendor
 revendor:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+# This fork
+
+This forked dex repository has been modified to:
+
+```
+    Made work with Cisco Ping Federate Public OIDC Implementation
+
+    * Smoothed over the quirks of Cisco Ping Federate
+    * The Cisco OIDC provider does not return email in claims.
+      * Get email from userInfo if it doesn't exist.
+    * Get groups from Ping Federate userinfo "memberof" key.
+      * Parse/filter groups to only match 'CN=(kube-.*?)'
+        groupnames such as 'kube-admin'
+    * Implemented the passthrough of Refresh token
+```
+
 # dex - A federated OpenID Connect provider
 
 [![Travis](https://api.travis-ci.org/dexidp/dex.svg)](https://travis-ci.org/dexidp/dex)

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,1 @@
+make release-binary && docker build -t dcwangmit01/dex:test  -f Dockerfile.localbuild . && docker push dcwangmit01/dex:test

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 12d0ad2fc0df4ab221e45c1ba7821708b908033c82741e250cc46dcd445b67eb
-updated: 2018-09-30T14:07:57.901347233-04:00
+updated: 2018-10-12T19:01:28.4155524Z
 imports:
 - name: github.com/beevik/etree
   version: 4cd0dd976db869f817248477718071a28e978df0
@@ -24,6 +24,10 @@ imports:
   - pkg/transport
 - name: github.com/coreos/go-oidc
   version: be73733bb8cc830d0205609b95d125215f8e9c70
+- name: github.com/davecgh/go-spew
+  version: d8f796af33cc11cb798c1aaeb27a4ebc5099927d
+  subpackages:
+  - spew
 - name: github.com/felixge/httpsnoop
   version: eadd4fad6aac69ae62379194fe0219f3dbc80fd3
 - name: github.com/ghodss/yaml


### PR DESCRIPTION
* Smoothed over the quirks of Cisco Ping Federate
* The Cisco OIDC provider does not return email in claims.
  * Get email from userInfo if it doesn't exist.
* Get groups from Ping Federate userinfo "memberof" key.
  * Parse/filter groups to only match 'CN=(kube-.*?)'
    groupnames such as 'kube-admin'
* Implemented the passthrough of Refresh token