### PR TITLE
*: update go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ language: go
 sudo: required
 
 go:
-  - 1.8
-  - 1.9
   - '1.10'
+  - '1.11'
 
 go_import_path: github.com/dexidp/dex
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.2-alpine
+FROM golang:1.11.1-alpine
 
 RUN apk add --no-cache --update alpine-sdk
 


### PR DESCRIPTION
Using an old version of Go was breaking the build. Update travis and the Docker image while we're at it.

https://travis-ci.org/dexidp/dex/builds/444775302