### PR TITLE
allow it to disable CRD creation

### DIFF
--- a/storage/kubernetes/storage.go
+++ b/storage/kubernetes/storage.go
@@ -40,6 +40,7 @@ type Config struct {
 	InCluster      bool   `json:"inCluster"`
 	KubeConfigFile string `json:"kubeConfigFile"`
 	UseTPR         bool   `json:"useTPR"` // Flag option to use TPRs instead of CRDs
+	NoCrdCreation  bool   `json:"noCrdCreation"` // Flag to disable creation of CRDs at cluster level
 }
 
 // Open returns a storage using Kubernetes third party resource.
@@ -85,37 +86,38 @@ func (c *Config) open(logger logrus.FieldLogger, waitForResources bool) (*client
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	if !c.NoCrdCreation {
+		logger.Info("creating custom Kubernetes resources")
+		if !cli.registerCustomResources(c.UseTPR) {
+			if waitForResources {
+				cancel()
+				return nil, fmt.Errorf("failed creating custom resources")
+			}
 
-	logger.Info("creating custom Kubernetes resources")
-	if !cli.registerCustomResources(c.UseTPR) {
-		if waitForResources {
-			cancel()
-			return nil, fmt.Errorf("failed creating custom resources")
+			// Try to synchronously create the custom resources once. This doesn't mean
+			// they'll immediately be available, but ensures that the client will actually try
+			// once.
+			logger.Errorf("failed creating custom resources: %v", err)
+			go func() {
+				for {
+					if cli.registerCustomResources(c.UseTPR) {
+						return
+					}
+
+					select {
+					case <-ctx.Done():
+						return
+					case <-time.After(30 * time.Second):
+					}
+				}
+			}()
 		}
 
-		// Try to synchronously create the custom resources once. This doesn't mean
-		// they'll immediately be available, but ensures that the client will actually try
-		// once.
-		logger.Errorf("failed creating custom resources: %v", err)
-		go func() {
-			for {
-				if cli.registerCustomResources(c.UseTPR) {
-					return
-				}
-
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(30 * time.Second):
-				}
+		if waitForResources {
+			if err := cli.waitForCRDs(ctx); err != nil {
+				cancel()
+				return nil, err
 			}
-		}()
-	}
-
-	if waitForResources {
-		if err := cli.waitForCRDs(ctx); err != nil {
-			cancel()
-			return nil, err
 		}
 	}
 

--- a/storage/kubernetes/storage.go
+++ b/storage/kubernetes/storage.go
@@ -149,10 +149,12 @@ func (cli *client) registerCustomResources(useTPR bool) (ok bool) {
 		} else {
 			r := customResourceDefinitions[i]
 			var i interface{}
-			cli.logger.Infof("checking if resource %s has been created already...", r.ObjectMeta.Name)
+			cli.logger.Infof("checking if custom resource %s has been created already...", r.ObjectMeta.Name)
 			if err := cli.list(r.Spec.Names.Plural, &i); err == nil {
-				cli.logger.Infof("The custom resource already created %s, hence continue", r.ObjectMeta.Name)
+				cli.logger.Infof("The custom resource %s already available, skipping create", r.ObjectMeta.Name)
 				continue
+			} else {
+				cli.logger.Infof("failed to list custom resource %s, attempting to create: %v", r.ObjectMeta.Name, err)
 			}
 			err = cli.postResource("apiextensions.k8s.io/v1beta1", "", "customresourcedefinitions", r)
 			resourceName = r.ObjectMeta.Name


### PR DESCRIPTION
responding to this issue #1332 #1308 , this PR will provide a simple fix to disable CRD creation step. 

In our case, this feature will greatly reduce the need for cluster scope permission to create CRDs, providing that we already have got a DEX running at cluster level which means all necessary CRDs have been created already, and we want to deploy a separate DEX in a team's namespace with minimal permissions(kubernetes Role only, no clusterRole allowed.) in order to de-couple this DEX with the existing cluster-wide DEX.

Thanks! 