### PR TITLE
Issue #1263 - Render error message provided by connector if user authentication failed

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -386,7 +386,7 @@ func (s *Server) handleConnectorCallback(w http.ResponseWriter, r *http.Request)
 
 	if err != nil {
 		s.logger.Errorf("Failed to authenticate: %v", err)
-		s.renderError(w, http.StatusInternalServerError, "Failed to return user's identity.")
+		s.renderError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to authenticate: %v", err))
 		return
 	}
 


### PR DESCRIPTION
PR addresses issue https://github.com/dexidp/dex/issues/1263 and implement the following change:

On failed login user will see message provided by the connector instead of generic `Failed to return user's identity.` . Example: `Failed to authenticate: github: user "<username>" not in required orgs or teams`