### PR TITLE
Issue #1184 - Github connector now returns a full group list when no org is specified

### DIFF
--- a/connector/github/github_test.go
+++ b/connector/github/github_test.go
@@ -1,0 +1,121 @@
+package github
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/dexidp/dex/connector"
+)
+
+func TestUserGroups(t *testing.T) {
+
+	orgs := []org{
+		{Login: "org-1"},
+		{Login: "org-2"},
+		{Login: "org-3"},
+	}
+
+	teams := []team{
+		{Name: "team-1", Org: org{Login: "org-1"}},
+		{Name: "team-2", Org: org{Login: "org-1"}},
+		{Name: "team-3", Org: org{Login: "org-1"}},
+		{Name: "team-4", Org: org{Login: "org-2"}},
+	}
+
+	s := newTestServer(map[string]interface{}{
+		"/user/orgs":  orgs,
+		"/user/teams": teams,
+	})
+
+	connector := githubConnector{apiURL: s.URL}
+	groups, err := connector.userGroups(context.Background(), newClient())
+
+	expectNil(t, err)
+	expectEquals(t, groups, []string{
+		"org-1:team-1",
+		"org-1:team-2",
+		"org-1:team-3",
+		"org-2:team-4",
+		"org-3",
+	})
+
+	s.Close()
+}
+
+func TestUserGroupsWithoutOrgs(t *testing.T) {
+
+	s := newTestServer(map[string]interface{}{
+		"/user/orgs":  []org{},
+		"/user/teams": []team{},
+	})
+
+	connector := githubConnector{apiURL: s.URL}
+	groups, err := connector.userGroups(context.Background(), newClient())
+
+	expectNil(t, err)
+	expectEquals(t, len(groups), 0)
+
+	s.Close()
+}
+
+func TestUsernameIncludedInFederatedIdentity(t *testing.T) {
+
+	s := newTestServer(map[string]interface{}{
+		"/user": user{Login: "some-login"},
+		"/user/emails": []userEmail{{
+			Email:    "some@email.com",
+			Verified: true,
+			Primary:  true,
+		}},
+		"/login/oauth/access_token": map[string]interface{}{
+			"access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9",
+			"expires_in":   "30",
+		},
+	})
+
+	hostURL, err := url.Parse(s.URL)
+	expectNil(t, err)
+
+	req, err := http.NewRequest("GET", hostURL.String(), nil)
+	expectNil(t, err)
+
+	githubConnector := githubConnector{apiURL: s.URL, hostName: hostURL.Host, httpClient: newClient()}
+	identity, err := githubConnector.HandleCallback(connector.Scopes{}, req)
+
+	expectNil(t, err)
+	expectEquals(t, identity.Username, "some-login")
+
+	s.Close()
+}
+
+func newTestServer(responses map[string]interface{}) *httptest.Server {
+	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(responses[r.URL.Path])
+	}))
+}
+
+func newClient() *http.Client {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	return &http.Client{Transport: tr}
+}
+
+func expectNil(t *testing.T, a interface{}) {
+	if a != nil {
+		t.Errorf("Expected %+v to equal nil", a)
+	}
+}
+
+func expectEquals(t *testing.T, a interface{}, b interface{}) {
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("Expected %+v to equal %+v", a, b)
+	}
+}


### PR DESCRIPTION
Fixes #1102

PR contains a subset of changes implemented in https://github.com/dexidp/dex/pull/1184. Original PR had been closed without merging since it accumulated too many changes and authors decided to maintain a fork.

This change unblocks an important use case: give read-only access to anyone and give extra privileges to users which belongs to the specified group.