### PR TITLE
fix bogus conformance failure due to time zones

### DIFF
--- a/storage/conformance/conformance.go
+++ b/storage/conformance/conformance.go
@@ -341,6 +341,20 @@ func testRefreshTokenCRUD(t *testing.T, s storage.Storage) {
 			t.Errorf("get refresh: %v", err)
 			return
 		}
+
+		if diff := pretty.Compare(gr.CreatedAt.UnixNano(), gr.CreatedAt.UnixNano()); diff != "" {
+			t.Errorf("refresh token created timestamp retrieved from storage did not match: %s", diff)
+		}
+
+		if diff := pretty.Compare(gr.LastUsed.UnixNano(), gr.LastUsed.UnixNano()); diff != "" {
+			t.Errorf("refresh token last used timestamp retrieved from storage did not match: %s", diff)
+		}
+
+		gr.CreatedAt = time.Time{}
+		gr.LastUsed = time.Time{}
+		want.CreatedAt = time.Time{}
+		want.LastUsed = time.Time{}
+
 		if diff := pretty.Compare(want, gr); diff != "" {
 			t.Errorf("refresh token retrieved from storage did not match: %s", diff)
 		}


### PR DESCRIPTION
this failed on my machine due to the unexported 'loc' field of the time structure - it was nil in one and set to a ton of timezone data in the other. not sure why, but I don't think it's critical to compare these hidden fields so long as the timestamp's actual value is equal.