### PR TITLE
Issue #1102 - Add config to explicitly enable loading all github groups

### DIFF
--- a/Documentation/connectors/github.md
+++ b/Documentation/connectors/github.md
@@ -45,8 +45,8 @@ connectors:
     # If orgs are specified in the config then user MUST be a member of at least one of the specified orgs to
     # authenticate with dex.
     #
-    # If neither 'org' nor 'orgs' are specified in the config then user authenticate with ALL user's Github groups.
-    # Typical use case for this setup:
+    # If neither 'org' nor 'orgs' are specified in the config and 'loadAllGroups' setting set to true then user
+    # authenticate with ALL user's Github groups. Typical use case for this setup:
     # provide read-only access to everyone and give full permissions if user has 'my-organization:admins-team' group claim.  
     orgs:
     - name: my-organization
@@ -56,6 +56,8 @@ connectors:
       teams:
       - red-team
       - blue-team
+    # Flag which indicates that all user groups and teams should be loaded.
+    loadAllGroups: false
 
     # Optional choice between 'name' (default) or 'slug'.
     #


### PR DESCRIPTION
I've discovered that new behavior implemented in https://github.com/dexidp/dex/pull/1340 might be undesired for some users. The user might be part of multiple orgs and teams, so if all groups are loaded then JWT token does not fit into cookie. 

With changes from https://github.com/dexidp/dex/pull/1340 applications which uses Dex + github without configuring orgs now might get a token which does not fit into cookie. Although it is a rare case I think it worth adding new setting which explicitly enable github connector to load all user groups. 