### PR TITLE
postgres: expose database/sql tunables

### DIFF
--- a/cmd/dex/config_test.go
+++ b/cmd/dex/config_test.go
@@ -18,10 +18,14 @@ func TestUnmarshalConfig(t *testing.T) {
 	rawConfig := []byte(`
 issuer: http://127.0.0.1:5556/dex
 storage:
-  type: sqlite3
+  type: postgres
   config:
-    file: examples/dex.db
-
+    host: 10.0.0.1
+    port: 65432
+    maxOpenConns: 5
+    maxIdleConns: 3
+    connMaxLifetime: 30
+    connectionTimeout: 3
 web:
   http: 127.0.0.1:5556
 staticClients:
@@ -69,9 +73,14 @@ logger:
 	want := Config{
 		Issuer: "http://127.0.0.1:5556/dex",
 		Storage: Storage{
-			Type: "sqlite3",
-			Config: &sql.SQLite3{
-				File: "examples/dex.db",
+			Type: "postgres",
+			Config: &sql.Postgres{
+				Host:              "10.0.0.1",
+				Port:              65432,
+				MaxOpenConns:      5,
+				MaxIdleConns:      3,
+				ConnMaxLifetime:   30,
+				ConnectionTimeout: 3,
 			},
 		},
 		Web: Web{

--- a/storage/sql/postgres_test.go
+++ b/storage/sql/postgres_test.go
@@ -1,0 +1,48 @@
+// +build go1.11
+
+package sql
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPostgresTunables(t *testing.T) {
+	host := os.Getenv(testPostgresEnv)
+	if host == "" {
+		t.Skipf("test environment variable %q not set, skipping", testPostgresEnv)
+	}
+	baseCfg := &Postgres{
+		Database: getenv("DEX_POSTGRES_DATABASE", "postgres"),
+		User:     getenv("DEX_POSTGRES_USER", "postgres"),
+		Password: getenv("DEX_POSTGRES_PASSWORD", "postgres"),
+		Host:     host,
+		SSL: PostgresSSL{
+			Mode: sslDisable, // Postgres container doesn't support SSL.
+		}}
+
+	t.Run("with nothing set, uses defaults", func(t *testing.T) {
+		cfg := *baseCfg
+		c, err := cfg.open(logger, cfg.createDataSourceName())
+		if err != nil {
+			t.Fatalf("error opening connector: %s", err.Error())
+		}
+		defer c.db.Close()
+		if m := c.db.Stats().MaxOpenConnections; m != 5 {
+			t.Errorf("expected MaxOpenConnections to have its default (5), got %d", m)
+		}
+	})
+
+	t.Run("with something set, uses that", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.MaxOpenConns = 101
+		c, err := cfg.open(logger, cfg.createDataSourceName())
+		if err != nil {
+			t.Fatalf("error opening connector: %s", err.Error())
+		}
+		defer c.db.Close()
+		if m := c.db.Stats().MaxOpenConnections; m != 101 {
+			t.Errorf("expected MaxOpenConnections to be set to 101, got %d", m)
+		}
+	})
+}


### PR DESCRIPTION
This is for #1354.

I've not had a need for `MaxIdleConns` and `ConnMaxLifetime` myself, but it felt weird to only expose of the three settings.