### PR TITLE
Kubernetes docs: clarify steps around use/creation of TLS assets.

### DIFF
--- a/Documentation/connectors/ldap.md
+++ b/Documentation/connectors/ldap.md
@@ -262,7 +262,7 @@ connectors:
     # freeIPA server's CA
     rootCA: ca.crt
     userSearch:
-      # Would translate to the query "(&(objectClass=person)(uid=<username>))".
+      # Would translate to the query "(&(objectClass=posixAccount)(uid=<username>))".
       baseDN: cn=users,dc=freeipa,dc=example,dc=com
       filter: "(objectClass=posixAccount)"
       username: uid

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -133,7 +133,7 @@ $ kubectl create secret \
 
 ### Deploy the Dex server
 
-Create the dex deployment, configmap, and node port service. This will also create RBAC bindings allowing the Dex pod access to manage [Custom Resource Definitions](https://github.com/dexidp/dex/blob/master/Documentation/storage.md#kubernetes-custom-resource-definitions-crds) within Kubernetes.
+Create the dex deployment, configmap, and node port service. This will also create RBAC bindings allowing the Dex pod access to manage [Custom Resource Definitions](storage.md#kubernetes-custom-resource-definitions-crds) within Kubernetes.
 
 ```
 $ kubectl create -f dex.yaml

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -14,7 +14,7 @@ The authentication flow looks like:
 3. Kubernetes uses dex's public keys to verify the ID Token.
 4. A claim designated as the username (and optionally group information) will be associated with that request.
 
-Username and group information can be combined with Kubernetes [authorization plugins][k8s-authz], such as roles based access control (RBAC), to enforce policy.
+Username and group information can be combined with Kubernetes [authorization plugins][k8s-authz], such as role based access control (RBAC), to enforce policy.
 
 ## Configuring the OpenID Connect plugin
 
@@ -133,13 +133,11 @@ $ kubectl create secret \
 
 ### Deploy the Dex server
 
-Create the dex deployment, configmap, and node port service.
+Create the dex deployment, configmap, and node port service. This will also create RBAC bindings allowing the Dex pod access to manage [Custom Resource Definitions](https://github.com/dexidp/dex/blob/master/Documentation/storage.md#kubernetes-custom-resource-definitions-crds) within Kubernetes.
 
 ```
 $ kubectl create -f dex.yaml
 ```
-
-The Dex pod requires access to manage [Custom Resource Definitions](https://github.com/dexidp/dex/blob/master/Documentation/storage.md#kubernetes-custom-resource-definitions-crds) within Kubernetes, so the example manifest also creates a service account and RBAC role bindings to provide these permissions.
 
 __Caveats:__ No health checking is configured because dex does its own TLS termination complicating the setup. This is a known issue and can be tracked [here][dex-healthz].
 

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -48,7 +48,7 @@ Additional notes:
 
 The dex repo contains scripts for running dex on a Kubernetes cluster with authentication through GitHub. The dex service is exposed using a [node port][node-port] on port 32000. This likely requires a custom `/etc/hosts` entry pointed at one of the cluster's workers.
 
-Because dex uses `ThirdPartyResources` to store state, no external database is needed. For more details see the [storage documentation](storage.md#kubernetes-third-party-resources).
+Because dex uses [CRDs](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/) to store state, no external database is needed. For more details see the [storage documentation](storage.md#kubernetes-third-party-resources).
 
 There are many different ways to spin up a Kubernetes development cluster, each with different host requirements and support for API server reconfiguration. At this time, this guide does not have copy-pastable examples, but can recommend the following methods for spinning up a cluster:
 
@@ -61,7 +61,6 @@ To run dex on Kubernetes perform the following steps:
 2. Spin up a Kubernetes cluster with the appropriate flags and CA volume mount.
 3. Create secrets for TLS and for your [GitHub OAuth2 client credentials][github-oauth2].
 4. Deploy dex.
-5. Create and assign 'dex' cluster role to dex service account ([to enable dex to manage its CRDs, if RBAC authorization is used](https://github.com/dexidp/dex/blob/master/Documentation/storage.md#kubernetes-custom-resource-definitions-crds)).
 
 ### Generate TLS assets
 
@@ -140,7 +139,7 @@ Create the dex deployment, configmap, and node port service.
 $ kubectl create -f dex.yaml
 ```
 
-Assign cluster role to dex service account so it can create third party resources [Kubernetes third party resources](storage.md).
+The Dex pod requires access to manage [Custom Resource Definitions](https://github.com/dexidp/dex/blob/master/Documentation/storage.md#kubernetes-custom-resource-definitions-crds) within Kubernetes, so the example manifest also creates a service account and RBAC role bindings to provide these permissions.
 
 __Caveats:__ No health checking is configured because dex does its own TLS termination complicating the setup. This is a known issue and can be tracked [here][dex-healthz].
 

--- a/Documentation/storage.md
+++ b/Documentation/storage.md
@@ -38,9 +38,9 @@ Etcd storage can be customized further using the following options:
 
 ## Kubernetes custom resource definitions (CRDs)
 
-__NOTE:__ CRDs are only supported by Kubernetes version 1.7+.
+Kubernetes [custom resource definitions](crd) are a way for applications to create new resources types in the Kubernetes API.
 
-Kubernetes [custom resource definitions](crd) are a way for applications to create new resources types in the Kubernetes API. The Custom Resource Definition (CRD) API object was introduced in Kubernetes version 1.7 to replace the Third Party Resource (TPR) extension. CRDs allows dex to run on top of an existing Kubernetes cluster without the need for an external database. While this storage may not be appropriate for a large number of users, it's extremely effective for many Kubernetes use cases.
+The Custom Resource Definition (CRD) API object was introduced in Kubernetes version 1.7 to replace the Third Party Resource (TPR) extension. CRDs allow dex to run on top of an existing Kubernetes cluster without the need for an external database. While this storage may not be appropriate for a large number of users, it's extremely effective for many Kubernetes use cases.
 
 The rest of this section will explore internal details of how dex uses CRDs. __Admins should not interact with these resources directly__, except while debugging. These resources are only designed to store state and aren't meant to be consumed by end users. For modifying dex's state dynamically see the [API documentation](api.md).
 

--- a/Documentation/storage.md
+++ b/Documentation/storage.md
@@ -115,11 +115,15 @@ subjects:
 ```
 
 
-## Kubernetes third party resources(TPRs)
+## DEPRECATED: Kubernetes third party resources(TPRs)
 
-__NOTE:__ TPRs will be deprecated by Kubernetes version 1.8.
+__NOTE:__ TPRs are deprecated as of Kubernetes version 1.8.
 
-The default behavior of dex from release v2.7.0 onwards is to utitlize CRDs to manage its custom resources. If users would like to use dex with a Kubernetes version lower than 1.7, they will have to force dex to use TPRs instead of CRDs by setting the `UseTPR` flag in the storage configuration as shown below:
+The default behavior of dex from release v2.7.0 onwards is to utilize CRDs to manage its custom resources. If users would like to use dex with a Kubernetes version lower than 1.7, they will have to force dex to use TPRs instead of CRDs.
+
+These instructions have been preserved for anybody who needs to use an older version of Dex and/or Kubernetes, but this is not the recommended approach. See [Migrating from TPRs to CRDs](#migrating-from-tprs-to-crds) below for information on migrating an existing installation to the new approach.
+
+If you do wish to use TPRs, you may do so by setting the `UseTPR` flag in the storage configuration as shown below:
 
 ```
 storage:

--- a/examples/k8s/dex.yaml
+++ b/examples/k8s/dex.yaml
@@ -11,6 +11,7 @@ spec:
       labels:
         app: dex
     spec:
+      serviceAccountName: dex # This is created below
       containers:
       - image: quay.io/dexidp/dex:v2.10.0
         name: dex
@@ -104,3 +105,35 @@ spec:
     nodePort: 32000
   selector:
     app: dex
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: dex
+  name: dex
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: dex
+rules:
+- apiGroups: ["dex.coreos.com"] # API group created by dex
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["create"] # To manage its own resources, dex must be able to create customresourcedefinitions
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: dex
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dex
+subjects:
+- kind: ServiceAccount
+  name: dex           # Service account assigned to the dex pod, created above
+  namespace: default  # The namespace dex is running in


### PR DESCRIPTION
Related to issue #1262 .

While not strictly related to TLS, I'd like to make one or more follow-up PRs to fix issues around old references to TPRs, missing instructions on creating the serviceAccount and roles for RBAC etc. But this is a first pass, hopefully it makes reviewing easier.