### PR TITLE
Make expiry of auth requests configurable

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -233,6 +233,9 @@ type Expiry struct {
 
 	// IdTokens defines the duration of time for which the IdTokens will be valid.
 	IDTokens string `json:"idTokens"`
+
+	// AuthRequests defines the duration of time for which the AuthRequests will be valid.
+	AuthRequests string `json:"authRequests"`
 }
 
 // Logger holds configuration required to customize logging for dex.

--- a/cmd/dex/config_test.go
+++ b/cmd/dex/config_test.go
@@ -64,6 +64,7 @@ staticPasswords:
 expiry:
   signingKeys: "6h"
   idTokens: "24h"
+  authRequests: "24h"
 
 logger:
   level: "debug"
@@ -131,8 +132,9 @@ logger:
 			},
 		},
 		Expiry: Expiry{
-			SigningKeys: "6h",
-			IDTokens:    "24h",
+			SigningKeys:  "6h",
+			IDTokens:     "24h",
+			AuthRequests: "24h",
 		},
 		Logger: Logger{
 			Level:  "debug",

--- a/cmd/dex/config_test.go
+++ b/cmd/dex/config_test.go
@@ -62,9 +62,9 @@ staticPasswords:
   userID: "41331323-6f44-45e6-b3b9-2c4b60c02be5"
 
 expiry:
-  signingKeys: "6h"
-  idTokens: "24h"
-  authRequests: "24h"
+  signingKeys: "7h"
+  idTokens: "25h"
+  authRequests: "25h"
 
 logger:
   level: "debug"
@@ -132,9 +132,9 @@ logger:
 			},
 		},
 		Expiry: Expiry{
-			SigningKeys:  "6h",
-			IDTokens:     "24h",
-			AuthRequests: "24h",
+			SigningKeys:  "7h",
+			IDTokens:     "25h",
+			AuthRequests: "25h",
 		},
 		Logger: Logger{
 			Level:  "debug",

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -242,6 +242,14 @@ func serve(cmd *cobra.Command, args []string) error {
 		logger.Infof("config id tokens valid for: %v", idTokens)
 		serverConfig.IDTokensValidFor = idTokens
 	}
+	if c.Expiry.AuthRequests != "" {
+		authRequests, err := time.ParseDuration(c.Expiry.AuthRequests)
+		if err != nil {
+			return fmt.Errorf("invalid config value %q for auth request expiry: %v", c.Expiry.AuthRequests, err)
+		}
+		logger.Infof("config auth requests valid for: %v", authRequests)
+		serverConfig.AuthRequestsValidFor = authRequests
+	}
 
 	serv, err := server.NewServer(context.Background(), serverConfig)
 	if err != nil {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -160,7 +160,7 @@ func (s *Server) handleAuthorization(w http.ResponseWriter, r *http.Request) {
 	// screen too long.
 	//
 	// See: https://github.com/dexidp/dex/issues/646
-	authReq.Expiry = s.now().Add(24 * time.Hour) // Totally arbitrary value.
+	authReq.Expiry = s.now().Add(s.authRequestsValidFor)
 	if err := s.storage.CreateAuthRequest(authReq); err != nil {
 		s.logger.Errorf("Failed to create authorization request: %v", err)
 		s.renderError(w, http.StatusInternalServerError, "Failed to connect to the database.")

--- a/server/server.go
+++ b/server/server.go
@@ -68,8 +68,9 @@ type Config struct {
 	// Logging in implies approval.
 	SkipApprovalScreen bool
 
-	RotateKeysAfter  time.Duration // Defaults to 6 hours.
-	IDTokensValidFor time.Duration // Defaults to 24 hours
+	RotateKeysAfter      time.Duration // Defaults to 6 hours.
+	IDTokensValidFor     time.Duration // Defaults to 24 hours
+	AuthRequestsValidFor time.Duration // Defaults to 24 hours
 
 	GCFrequency time.Duration // Defaults to 5 minutes
 
@@ -137,7 +138,8 @@ type Server struct {
 
 	now func() time.Time
 
-	idTokensValidFor time.Duration
+	idTokensValidFor     time.Duration
+	authRequestsValidFor time.Duration
 
 	logger logrus.FieldLogger
 }
@@ -197,6 +199,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 		storage:                newKeyCacher(c.Storage, now),
 		supportedResponseTypes: supported,
 		idTokensValidFor:       value(c.IDTokensValidFor, 24*time.Hour),
+		authRequestsValidFor:   value(c.AuthRequestsValidFor, 24*time.Hour),
 		skipApproval:           c.SkipApprovalScreen,
 		now:                    now,
 		templates:              tmpls,


### PR DESCRIPTION
This is a band-aid against #1292

I did not change the default from 24h, but I think it should be much lower for safety. 