### PR TITLE
Dockerfile: update to Go 1.11.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.1-alpine
+FROM golang:1.11.3-alpine
 
 RUN apk add --no-cache --update alpine-sdk
 


### PR DESCRIPTION
Go 1.11.3 and 1.10.6 were released to mitigate security issues.
These don't appear to impact dex, but update anyway.

Ref: https://groups.google.com/forum/#!topic/golang-announce/Kw31K8G7Fi0