### PR TITLE
Replace "GET", "POST" to http.MethodGet and http.MethodPost

### DIFF
--- a/cmd/example-app/main.go
+++ b/cmd/example-app/main.go
@@ -261,7 +261,7 @@ func (a *app) handleCallback(w http.ResponseWriter, r *http.Request) {
 	ctx := oidc.ClientContext(r.Context(), a.client)
 	oauth2Config := a.oauth2Config(nil)
 	switch r.Method {
-	case "GET":
+	case http.MethodGet:
 		// Authorization redirect callback from OAuth2 auth flow.
 		if errMsg := r.FormValue("error"); errMsg != "" {
 			http.Error(w, errMsg+": "+r.FormValue("error_description"), http.StatusBadRequest)
@@ -277,7 +277,7 @@ func (a *app) handleCallback(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		token, err = oauth2Config.Exchange(ctx, code)
-	case "POST":
+	case http.MethodPost:
 		// Form request from frontend to refresh a token.
 		refresh := r.FormValue("refresh_token")
 		if refresh == "" {

--- a/storage/kubernetes/client.go
+++ b/storage/kubernetes/client.go
@@ -137,7 +137,7 @@ func checkHTTPErr(r *http.Response, validStatusCodes ...int) error {
 	if r.StatusCode == http.StatusNotFound {
 		return storage.ErrNotFound
 	}
-	if r.Request.Method == "POST" && r.StatusCode == http.StatusConflict {
+	if r.Request.Method == http.MethodPost && r.StatusCode == http.StatusConflict {
 		return storage.ErrAlreadyExists
 	}
 


### PR DESCRIPTION
I think we should better use http.MethodGet instead of "GET", the same as "POST".