### PR TITLE
Dockerfile: update Go to 1.11.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.3-alpine
+FROM golang:1.11.5-alpine
 
 RUN apk add --no-cache --update alpine-sdk
 


### PR DESCRIPTION
Dex doesn't actively use ECDSA keys, but update anyway for CVE-2019-6486

https://groups.google.com/forum/#!topic/golang-announce/mVeX35iXuSw