### PR TITLE
Add name claim to distinguish between name and username

### DIFF
--- a/connector/bitbucketcloud/bitbucketcloud.go
+++ b/connector/bitbucketcloud/bitbucketcloud.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/dexidp/dex/pkg/log"
 	"io/ioutil"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/dexidp/dex/pkg/log"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/bitbucket"
@@ -151,6 +152,7 @@ func (b *bitbucketConnector) HandleCallback(s connector.Scopes, r *http.Request)
 
 	identity = connector.Identity{
 		UserID:        user.UUID,
+		Name:          user.Username,
 		Username:      user.Username,
 		Email:         user.Email,
 		EmailVerified: true,
@@ -248,6 +250,7 @@ func (b *bitbucketConnector) Refresh(ctx context.Context, s connector.Scopes, id
 		return identity, fmt.Errorf("bitbucket: get user: %v", err)
 	}
 
+	identity.Name = user.Username
 	identity.Username = user.Username
 	identity.Email = user.Email
 

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -24,6 +24,7 @@ type Scopes struct {
 // Identity represents the ID Token claims supported by the server.
 type Identity struct {
 	UserID        string
+	Name          string
 	Username      string
 	Email         string
 	EmailVerified bool

--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -259,14 +259,15 @@ func (c *githubConnector) HandleCallback(s connector.Scopes, r *http.Request) (i
 		return identity, fmt.Errorf("github: get user: %v", err)
 	}
 
-	username := user.Name
-	if username == "" {
-		username = user.Login
+	name := user.Name
+	if name == "" {
+		name = user.Login
 	}
 
 	identity = connector.Identity{
 		UserID:        strconv.Itoa(user.ID),
-		Username:      username,
+		Name:          name,
+		Username:      user.Login,
 		Email:         user.Email,
 		EmailVerified: true,
 	}

--- a/connector/github/github_test.go
+++ b/connector/github/github_test.go
@@ -197,7 +197,8 @@ func TestLoginUsedAsIDWhenConfigured(t *testing.T) {
 
 	expectNil(t, err)
 	expectEquals(t, identity.UserID, "some-login")
-	expectEquals(t, identity.Username, "Joe Bloggs")
+	expectEquals(t, identity.Username, "some-login")
+	expectEquals(t, identity.Name, "Joe Bloggs")
 }
 
 func newTestServer(responses map[string]testResponse) *httptest.Server {

--- a/connector/gitlab/gitlab.go
+++ b/connector/gitlab/gitlab.go
@@ -136,6 +136,7 @@ func (c *gitlabConnector) HandleCallback(s connector.Scopes, r *http.Request) (i
 	}
 	identity = connector.Identity{
 		UserID:        strconv.Itoa(user.ID),
+		Name:          username,
 		Username:      username,
 		Email:         user.Email,
 		EmailVerified: true,
@@ -177,11 +178,12 @@ func (c *gitlabConnector) Refresh(ctx context.Context, s connector.Scopes, ident
 		return ident, fmt.Errorf("gitlab: get user: %v", err)
 	}
 
-	username := user.Name
-	if username == "" {
-		username = user.Email
+	name := user.Name
+	if name == "" {
+		name = user.Email
 	}
-	ident.Username = username
+	ident.Name = name
+	ident.Username = name
 	ident.Email = user.Email
 
 	if s.Groups {

--- a/connector/keystone/keystone.go
+++ b/connector/keystone/keystone.go
@@ -141,6 +141,7 @@ func (p *conn) Login(ctx context.Context, scopes connector.Scopes, username, pas
 		}
 		identity.Groups = groups
 	}
+	identity.Name = username
 	identity.Username = username
 	identity.UserID = tokenResp.Token.User.ID
 	return identity, true, nil

--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -335,8 +335,14 @@ func (c *ldapConnector) identityFromEntry(user ldap.Entry) (ident connector.Iden
 		missing = append(missing, c.UserSearch.IDAttr)
 	}
 
+	if c.UserSearch.Username != "" {
+		if ident.Username = getAttr(user, c.UserSearch.Username); ident.Username == "" {
+			missing = append(missing, c.UserSearch.Username)
+		}
+	}
+
 	if c.UserSearch.NameAttr != "" {
-		if ident.Username = getAttr(user, c.UserSearch.NameAttr); ident.Username == "" {
+		if ident.Name = getAttr(user, c.UserSearch.NameAttr); ident.Name == "" {
 			missing = append(missing, c.UserSearch.NameAttr)
 		}
 	}

--- a/connector/ldap/ldap_test.go
+++ b/connector/ldap/ldap_test.go
@@ -90,6 +90,7 @@ userpassword: bar
 			password: "foo",
 			want: connector.Identity{
 				UserID:        "cn=jane,ou=People,dc=example,dc=org",
+				Name:          "jane",
 				Username:      "jane",
 				Email:         "janedoe@example.com",
 				EmailVerified: true,
@@ -101,6 +102,7 @@ userpassword: bar
 			password: "bar",
 			want: connector.Identity{
 				UserID:        "cn=john,ou=People,dc=example,dc=org",
+				Name:          "john",
 				Username:      "john",
 				Email:         "johndoe@example.com",
 				EmailVerified: true,
@@ -164,6 +166,7 @@ userpassword: bar
 			password: "foo",
 			want: connector.Identity{
 				UserID:        "cn=jane,ou=People,dc=example,dc=org",
+				Name:          "jane",
 				Username:      "jane",
 				Email:         "jane@test.example.com",
 				EmailVerified: true,
@@ -175,6 +178,7 @@ userpassword: bar
 			password: "bar",
 			want: connector.Identity{
 				UserID:        "cn=john,ou=People,dc=example,dc=org",
+				Name:          "john",
 				Username:      "john",
 				Email:         "john@test.example.com",
 				EmailVerified: true,
@@ -248,6 +252,7 @@ userpassword: bar
 			password: "foo",
 			want: connector.Identity{
 				UserID:        "cn=jane,ou=People,ou=Seattle,dc=example,dc=org",
+				Name:          "jane",
 				Username:      "jane",
 				Email:         "janedoe@example.com",
 				EmailVerified: true,
@@ -259,6 +264,7 @@ userpassword: bar
 			password: "bar",
 			want: connector.Identity{
 				UserID:        "cn=john,ou=People,ou=Seattle,dc=example,dc=org",
+				Name:          "john",
 				Username:      "john",
 				Email:         "johndoe@example.com",
 				EmailVerified: true,
@@ -345,6 +351,7 @@ member: cn=jane,ou=People,dc=example,dc=org
 			groups:   true,
 			want: connector.Identity{
 				UserID:        "cn=jane,ou=People,dc=example,dc=org",
+				Name:          "jane",
 				Username:      "jane",
 				Email:         "janedoe@example.com",
 				EmailVerified: true,
@@ -358,6 +365,7 @@ member: cn=jane,ou=People,dc=example,dc=org
 			groups:   true,
 			want: connector.Identity{
 				UserID:        "cn=john,ou=People,dc=example,dc=org",
+				Name:          "john",
 				Username:      "john",
 				Email:         "johndoe@example.com",
 				EmailVerified: true,
@@ -443,6 +451,7 @@ gidNumber: 1002
 			groups:   true,
 			want: connector.Identity{
 				UserID:        "cn=jane,ou=People,dc=example,dc=org",
+				Name:          "jane",
 				Username:      "jane",
 				Email:         "janedoe@example.com",
 				EmailVerified: true,
@@ -456,6 +465,7 @@ gidNumber: 1002
 			groups:   true,
 			want: connector.Identity{
 				UserID:        "cn=john,ou=People,dc=example,dc=org",
+				Name:          "john",
 				Username:      "john",
 				Email:         "johndoe@example.com",
 				EmailVerified: true,
@@ -548,6 +558,7 @@ member: cn=jane,ou=People,dc=example,dc=org
 			groups:   true,
 			want: connector.Identity{
 				UserID:        "cn=jane,ou=People,dc=example,dc=org",
+				Name:          "jane",
 				Username:      "jane",
 				Email:         "janedoe@example.com",
 				EmailVerified: true,
@@ -561,6 +572,7 @@ member: cn=jane,ou=People,dc=example,dc=org
 			groups:   true,
 			want: connector.Identity{
 				UserID:        "cn=john,ou=People,dc=example,dc=org",
+				Name:          "john",
 				Username:      "john",
 				Email:         "johndoe@example.com",
 				EmailVerified: true,
@@ -606,6 +618,7 @@ userpassword: foo
 			password: "foo",
 			want: connector.Identity{
 				UserID:        "cn=jane,ou=People,dc=example,dc=org",
+				Name:          "jane",
 				Username:      "jane",
 				Email:         "janedoe@example.com",
 				EmailVerified: true,
@@ -649,6 +662,7 @@ userpassword: foo
 			password: "foo",
 			want: connector.Identity{
 				UserID:        "cn=jane,ou=People,dc=example,dc=org",
+				Name:          "jane",
 				Username:      "jane",
 				Email:         "janedoe@example.com",
 				EmailVerified: true,
@@ -692,6 +706,7 @@ userpassword: foo
 			password: "foo",
 			want: connector.Identity{
 				UserID:        "cn=jane,ou=People,dc=example,dc=org",
+				Name:          "jane",
 				Username:      "jane",
 				Email:         "janedoe@example.com",
 				EmailVerified: true,

--- a/connector/linkedin/linkedin.go
+++ b/connector/linkedin/linkedin.go
@@ -92,6 +92,7 @@ func (c *linkedInConnector) HandleCallback(s connector.Scopes, r *http.Request) 
 
 	identity = connector.Identity{
 		UserID:        profile.ID,
+		Name:          profile.fullname(),
 		Username:      profile.fullname(),
 		Email:         profile.Email,
 		EmailVerified: true,
@@ -125,6 +126,7 @@ func (c *linkedInConnector) Refresh(ctx context.Context, s connector.Scopes, ide
 		return ident, fmt.Errorf("linkedin: get profile: %v", err)
 	}
 
+	ident.Name = profile.fullname()
 	ident.Username = profile.fullname()
 	ident.Email = profile.Email
 

--- a/connector/microsoft/microsoft.go
+++ b/connector/microsoft/microsoft.go
@@ -136,6 +136,7 @@ func (c *microsoftConnector) HandleCallback(s connector.Scopes, r *http.Request)
 
 	identity = connector.Identity{
 		UserID:        user.ID,
+		Name:          user.Name,
 		Username:      user.Name,
 		Email:         user.Email,
 		EmailVerified: true,

--- a/connector/mock/connectortest.go
+++ b/connector/mock/connectortest.go
@@ -18,7 +18,7 @@ func NewCallbackConnector(logger log.Logger) connector.Connector {
 	return &Callback{
 		Identity: connector.Identity{
 			UserID:        "0-385-28089-0",
-			Username:      "Kilgore Trout",
+			Name:          "Kilgore Trout",
 			Email:         "kilgore@kilgore.trout",
 			EmailVerified: true,
 			Groups:        []string{"authors"},

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -186,7 +186,8 @@ func (c *oidcConnector) HandleCallback(s connector.Scopes, r *http.Request) (ide
 	}
 
 	var claims struct {
-		Username      string `json:"name"`
+		Name          string `json:"name"`
+		Username      string `json:"username"`
 		Email         string `json:"email"`
 		EmailVerified bool   `json:"email_verified"`
 		HostedDomain  string `json:"hd"`
@@ -211,6 +212,7 @@ func (c *oidcConnector) HandleCallback(s connector.Scopes, r *http.Request) (ide
 
 	identity = connector.Identity{
 		UserID:        idToken.Subject,
+		Name:          claims.Name,
 		Username:      claims.Username,
 		Email:         claims.Email,
 		EmailVerified: claims.EmailVerified,

--- a/connector/saml/saml.go
+++ b/connector/saml/saml.go
@@ -383,12 +383,13 @@ func (p *provider) HandlePOST(s connector.Scopes, samlResponse, inResponseTo str
 	ident.EmailVerified = true
 
 	// Grab the username.
-	if name, _ := attributes.get(p.usernameAttr); name == "" {
+	name, _ := attributes.get(p.usernameAttr)
+	if name == "" {
 		return ident, fmt.Errorf("no attribute with name %q: %s", p.usernameAttr, attributes.names())
-	} else {
-		ident.Name = name
-		ident.Username = name
 	}
+
+	ident.Name = name
+	ident.Username = name
 
 	if !s.Groups || p.groupsAttr == "" {
 		// Groups not requested or not configured. We're done.

--- a/connector/saml/saml.go
+++ b/connector/saml/saml.go
@@ -383,8 +383,11 @@ func (p *provider) HandlePOST(s connector.Scopes, samlResponse, inResponseTo str
 	ident.EmailVerified = true
 
 	// Grab the username.
-	if ident.Username, _ = attributes.get(p.usernameAttr); ident.Username == "" {
+	if name, _ := attributes.get(p.usernameAttr); name == "" {
 		return ident, fmt.Errorf("no attribute with name %q: %s", p.usernameAttr, attributes.names())
+	} else {
+		ident.Name = name
+		ident.Username = name
 	}
 
 	if !s.Groups || p.groupsAttr == "" {

--- a/connector/saml/saml_test.go
+++ b/connector/saml/saml_test.go
@@ -69,6 +69,7 @@ func TestGoodResponse(t *testing.T) {
 		redirectURI:  "http://127.0.0.1:5556/dex/callback",
 		wantIdent: connector.Identity{
 			UserID:        "eric.chiang+okta@coreos.com",
+			Name:          "Eric",
 			Username:      "Eric",
 			Email:         "eric.chiang+okta@coreos.com",
 			EmailVerified: true,
@@ -89,6 +90,7 @@ func TestGroups(t *testing.T) {
 		redirectURI:  "http://127.0.0.1:5556/dex/callback",
 		wantIdent: connector.Identity{
 			UserID:        "eric.chiang+okta@coreos.com",
+			Name:          "Eric",
 			Username:      "Eric",
 			Email:         "eric.chiang+okta@coreos.com",
 			EmailVerified: true,
@@ -110,6 +112,7 @@ func TestOkta(t *testing.T) {
 		redirectURI:  "http://127.0.0.1:5556/dex/callback",
 		wantIdent: connector.Identity{
 			UserID:        "eric.chiang+okta@coreos.com",
+			Name:          "Eric",
 			Username:      "Eric",
 			Email:         "eric.chiang+okta@coreos.com",
 			EmailVerified: true,
@@ -188,6 +191,7 @@ func TestAssertionSignedNotResponse(t *testing.T) {
 		redirectURI:  "http://127.0.0.1:5556/dex/callback",
 		wantIdent: connector.Identity{
 			UserID:        "eric.chiang+okta@coreos.com",
+			Name:          "Eric",
 			Username:      "Eric",
 			Email:         "eric.chiang+okta@coreos.com",
 			EmailVerified: true,
@@ -254,6 +258,7 @@ func TestTwoAssertionFirstSigned(t *testing.T) {
 		redirectURI:  "http://127.0.0.1:5556/dex/callback",
 		wantIdent: connector.Identity{
 			UserID:        "eric.chiang+okta@coreos.com",
+			Name:          "Eric",
 			Username:      "Eric",
 			Email:         "eric.chiang+okta@coreos.com",
 			EmailVerified: true,

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -462,6 +462,7 @@ func (s *Server) finalizeLogin(identity connector.Identity, authReq storage.Auth
 	claims := storage.Claims{
 		UserID:        identity.UserID,
 		Username:      identity.Username,
+		Name:          identity.Name,
 		Email:         identity.Email,
 		EmailVerified: identity.EmailVerified,
 		Groups:        identity.Groups,
@@ -935,6 +936,7 @@ func (s *Server) handleRefreshToken(w http.ResponseWriter, r *http.Request, clie
 	}
 	ident := connector.Identity{
 		UserID:        refresh.Claims.UserID,
+		Name:          refresh.Claims.Name,
 		Username:      refresh.Claims.Username,
 		Email:         refresh.Claims.Email,
 		EmailVerified: refresh.Claims.EmailVerified,
@@ -959,6 +961,7 @@ func (s *Server) handleRefreshToken(w http.ResponseWriter, r *http.Request, clie
 
 	claims := storage.Claims{
 		UserID:        ident.UserID,
+		Name:          ident.Name,
 		Username:      ident.Username,
 		Email:         ident.Email,
 		EmailVerified: ident.EmailVerified,
@@ -993,6 +996,7 @@ func (s *Server) handleRefreshToken(w http.ResponseWriter, r *http.Request, clie
 		// Update the claims of the refresh token.
 		//
 		// UserID intentionally ignored for now.
+		old.Claims.Name = ident.Name
 		old.Claims.Username = ident.Username
 		old.Claims.Email = ident.Email
 		old.Claims.EmailVerified = ident.EmailVerified

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -263,6 +263,7 @@ type idTokenClaims struct {
 type federatedIDClaims struct {
 	ConnectorID string `json:"connector_id,omitempty"`
 	UserID      string `json:"user_id,omitempty"`
+	Username    string `json:"user_name,omitempty"`
 }
 
 func (s *Server) newIDToken(clientID string, claims storage.Claims, scopes []string, nonce, accessToken, connID string) (idToken string, expiry time.Time, err error) {
@@ -320,11 +321,12 @@ func (s *Server) newIDToken(clientID string, claims storage.Claims, scopes []str
 		case scope == scopeGroups:
 			tok.Groups = claims.Groups
 		case scope == scopeProfile:
-			tok.Name = claims.Username
+			tok.Name = claims.Name
 		case scope == scopeFederatedID:
 			tok.FederatedIDClaims = &federatedIDClaims{
 				ConnectorID: connID,
 				UserID:      claims.UserID,
+				Username:    claims.Username,
 			}
 		default:
 			peerID, ok := parseCrossClientScope(scope)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -373,6 +373,7 @@ func TestOAuth2CodeFlow(t *testing.T) {
 				}
 
 				ident := connector.Identity{
+					Name:          "name",
 					UserID:        "fooid",
 					Username:      "foo",
 					Email:         "foo@bar.com",
@@ -382,12 +383,12 @@ func TestOAuth2CodeFlow(t *testing.T) {
 				conn.Identity = ident
 
 				type claims struct {
-					Username      string   `json:"name"`
+					Name          string   `json:"name"`
 					Email         string   `json:"email"`
 					EmailVerified bool     `json:"email_verified"`
 					Groups        []string `json:"groups"`
 				}
-				want := claims{ident.Username, ident.Email, ident.EmailVerified, ident.Groups}
+				want := claims{ident.Name, ident.Email, ident.EmailVerified, ident.Groups}
 
 				newToken, err := config.TokenSource(ctx, token).Token()
 				if err != nil {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -137,8 +137,10 @@ type Client struct {
 
 // Claims represents the ID Token claims supported by the server.
 type Claims struct {
-	UserID        string
-	Username      string
+	UserID   string
+	Username string
+	Name     string
+
 	Email         string
 	EmailVerified bool
 


### PR DESCRIPTION
Right now there is no way of exposing a third party username through existing claims. Some providers hijack the `name` claim, while others use the `name` claim for a user's full name. By separating these into two different claims we can expose both.

For backwards compatibility all existing connectors map the name and username to the same value where applicable. Moving forward connectors can use the username claim to differentiate between the user's full name and username.

In the end we expose the `username` in the federated claims. Maybe we want to make the username a top level claim?