### PR TITLE
Update Docker build/image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.11.5-alpine
+FROM golang:1.12.4-alpine
 
 RUN apk add --no-cache --update alpine-sdk
 
 COPY . /go/src/github.com/dexidp/dex
 RUN cd /go/src/github.com/dexidp/dex && make release-binary
 
-FROM alpine:3.8
+FROM alpine:3.9
 # Dex connectors, such as GitHub and Google logins require root certificates.
 # Proper installations should manage those certificates, but it's a bad user
 # experience when this doesn't work out of the box.
@@ -13,6 +13,7 @@ FROM alpine:3.8
 # OpenSSL is required so wget can query HTTPS endpoints for health checking.
 RUN apk add --update ca-certificates openssl
 
+USER 1001:1001
 COPY --from=0 /go/bin/dex /usr/local/bin/dex
 
 # Import frontend assets and set the correct CWD directory so the assets


### PR DESCRIPTION
- Update build container to golang:1.12.4-alpine
- Update dex image to alpine:3.9
- Run dex as non-root user

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

Fixes: #1425 