### PR TITLE
cmd/dex/serve.go: log static client name instead of ID

### DIFF
--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -161,7 +161,7 @@ func serve(cmd *cobra.Command, args []string) error {
 
 	if len(c.StaticClients) > 0 {
 		for _, client := range c.StaticClients {
-			logger.Infof("config static client: %s", client.ID)
+			logger.Infof("config static client: %s", client.Name)
 		}
 		s = storage.WithStaticClients(s, c.StaticClients)
 	}


### PR DESCRIPTION
Hi,

According to https://www.oauth.com/oauth2-servers/client-registration/client-id-secret/, client ID should not be easily guessable and many people use random hex strings. It's therefore easier to identify clients in logs using their name instead of their ID.