### PR TITLE
server: add metrics for CORS handlers.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -257,7 +257,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 			corsOption := handlers.AllowedOrigins(c.AllowedOrigins)
 			handler = handlers.CORS(corsOption)(handler)
 		}
-		r.Handle(path.Join(issuerURL.Path, p), handler)
+		r.Handle(path.Join(issuerURL.Path, p), instrumentHandlerCounter(p, handler))
 	}
 	r.NotFoundHandler = http.HandlerFunc(http.NotFound)
 


### PR DESCRIPTION
I am troubleshooting an issue with my Dex setup where tokens fail to get refreshed (due to getting a 401 back on `/token`), and I realized that there are no metrics for the `/token` endpoint, which is a bit annoying as it makes it harder to track how frequently this issue is happening over time, is it the first time it happens, etc.  So I figured it be nice to add the same basic instrumentation that other handlers benefit from to the CORS handlers as well.