### PR TITLE
Round out logging interface with functions for all levels

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -6,10 +6,13 @@ package log
 // Logger serves as an adapter interface for logger libraries
 // so that dex does not depend on any of them directly.
 type Logger interface {
+	Debug(args ...interface{})
 	Info(args ...interface{})
 	Warn(args ...interface{})
+	Error(args ...interface{})
 
 	Debugf(format string, args ...interface{})
 	Infof(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
 	Errorf(format string, args ...interface{})
 }


### PR DESCRIPTION
The logging interface added in #1408 captured only logging methods used in dex itself. I understand the rationale, but I also find it awkward to see functions like `Warnf` left out when `Warn` exists. And similarly, having `Errorf` but not `Error`.

For projects that extend Dex to introduce additional connectors, for example, it feels awkward to have to use `fmt.Sprintf` for `Warn`, but not for `Error`.