### PR TITLE
Add option in oidc to hit the optional userinfo endpoint

### DIFF
--- a/Documentation/connectors/oidc.md
+++ b/Documentation/connectors/oidc.md
@@ -60,6 +60,12 @@ connectors:
     # or if they are acting as a proxy for another IDP etc AWS Cognito with an upstream SAML IDP
     # This can be overridden with the below option
     # insecureSkipEmailVerified: true 
+
+    # When enabled, the OpenID Connector will query the UserInfo endpoint for additional claims. UserInfo claims
+    # take priority over claims returned by the IDToken. This option should be used when the IDToken doesn't contain
+    # all the claims requested.
+    # https://openid.net/specs/openid-connect-core-1_0.html#UserInfo
+    # getUserInfo: true
 ```
 
 [oidc-doc]: openid-connect.md


### PR DESCRIPTION
Some oauth providers return "thin tokens" which won't include all of the
claims requested. This simply adds an option which will make the oidc
connector use the userinfo endpoint to fetch all the claims.

as an example of an IDP that does this: https://support.okta.com/help/s/article/Okta-Groups-or-Attribute-Missing-from-Id-Token