### PR TITLE
Create a non-priviledged user in runtime container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ FROM alpine:3.9
 # experience when this doesn't work out of the box.
 #
 # OpenSSL is required so wget can query HTTPS endpoints for health checking.
-RUN apk add --update ca-certificates openssl
+RUN apk add --update ca-certificates openssl\
+  && addgroup --gid 1001 dex\
+  && adduser --disabled-password --no-create-home --home "$(pwd)" -u 1001 -G dex dex
 
 USER 1001:1001
 COPY --from=0 /go/bin/dex /usr/local/bin/dex


### PR DESCRIPTION
@justaugustus introduced (56f02b95c6490981602dbf8726a5c4a0e3d858dc) running dex as a non-root user, which is cool but such user doesn't exist inside Alpine container.

This PR makes sure user `1001:1001` exists:
```
dex:x:1001:1001:Linux User,,,:/:/bin/ash
```
other option would be to leverage some existing account, like:
```
guest:x:405:100:guest:/dev/null:/sbin/nologin
nobody:x:65534:65534:nobody:/:/sbin/nologin
```
unlike `root`
```
root:x:0:0:root:/root:/bin/ash
```
these accounts doesn't have shell.
