### PR TITLE
make userName configurable

### DIFF
--- a/Documentation/connectors/oidc.md
+++ b/Documentation/connectors/oidc.md
@@ -71,7 +71,11 @@ connectors:
     # Default: sub
     # Claims list at https://openid.net/specs/openid-connect-core-1_0.html#Claims
     #
-    # userIdKey: nickname
+    # userIDKey: nickname
+    
+    # The set claim is used as user name.
+    # Default: name
+    # userNameKey: nickname
 ```
 
 [oidc-doc]: openid-connect.md

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -47,14 +47,18 @@ func TestHandleCallback(t *testing.T) {
 	tests := []struct {
 		name                      string
 		userIDKey                 string
+		userNameKey               string
 		insecureSkipEmailVerified bool
 		expectUserID              string
+		expectUserName            string
 		token                     map[string]interface{}
 	}{
 		{
-			name:         "simpleCase",
-			userIDKey:    "", // not configured
-			expectUserID: "subvalue",
+			name:           "simpleCase",
+			userIDKey:      "", // not configured
+			userNameKey:    "", // not configured
+			expectUserID:   "subvalue",
+			expectUserName: "namevalue",
 			token: map[string]interface{}{
 				"sub":            "subvalue",
 				"name":           "namevalue",
@@ -66,6 +70,7 @@ func TestHandleCallback(t *testing.T) {
 			name:                      "email_verified not in claims, configured to be skipped",
 			insecureSkipEmailVerified: true,
 			expectUserID:              "subvalue",
+			expectUserName:            "namevalue",
 			token: map[string]interface{}{
 				"sub":   "subvalue",
 				"name":  "namevalue",
@@ -73,12 +78,25 @@ func TestHandleCallback(t *testing.T) {
 			},
 		},
 		{
-			name:         "withUserIDKey",
-			userIDKey:    "name",
-			expectUserID: "namevalue",
+			name:           "withUserIDKey",
+			userIDKey:      "name",
+			expectUserID:   "namevalue",
+			expectUserName: "namevalue",
 			token: map[string]interface{}{
 				"sub":            "subvalue",
 				"name":           "namevalue",
+				"email":          "emailvalue",
+				"email_verified": true,
+			},
+		},
+		{
+			name:           "withUserNameKey",
+			userNameKey:    "user_name",
+			expectUserID:   "subvalue",
+			expectUserName: "username",
+			token: map[string]interface{}{
+				"sub":            "subvalue",
+				"user_name":      "username",
 				"email":          "emailvalue",
 				"email_verified": true,
 			},
@@ -100,6 +118,7 @@ func TestHandleCallback(t *testing.T) {
 				Scopes:                    []string{"groups"},
 				RedirectURI:               fmt.Sprintf("%s/callback", serverURL),
 				UserIDKey:                 tc.userIDKey,
+				UserNameKey:               tc.userNameKey,
 				InsecureSkipEmailVerified: tc.insecureSkipEmailVerified,
 			}
 
@@ -119,7 +138,7 @@ func TestHandleCallback(t *testing.T) {
 			}
 
 			expectEquals(t, identity.UserID, tc.expectUserID)
-			expectEquals(t, identity.Username, "namevalue")
+			expectEquals(t, identity.Username, tc.expectUserName)
 			expectEquals(t, identity.Email, "emailvalue")
 			expectEquals(t, identity.EmailVerified, true)
 		})


### PR DESCRIPTION
this PR is needed to support OpenID providers that don't have a "name" claim