### PR TITLE
Allowed connectors for clients

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -223,11 +223,25 @@ func (s *Server) handleAuthorization(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	connectors, e := s.storage.ListConnectors()
+	connectorsAll, e := s.storage.ListConnectors()
 	if e != nil {
 		s.logger.Errorf("Failed to get list of connectors: %v", e)
 		s.renderError(w, http.StatusInternalServerError, "Failed to retrieve connector list.")
 		return
+	}
+
+	connectors := []storage.Connector{}
+	if len(authReq.AllowedConnectors) == 0 {
+		connectors = connectorsAll
+	} else {
+		for _, connector := range connectorsAll {
+			for _, allowed := range authReq.AllowedConnectors {
+				if connector.ID == allowed {
+					connectors = append(connectors, connector)
+					break
+				}
+			}
+		}
 	}
 
 	if len(connectors) == 1 {

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -497,6 +497,7 @@ func (s *Server) parseAuthorizationRequest(r *http.Request) (req storage.AuthReq
 	return storage.AuthRequest{
 		ID:                  storage.NewID(),
 		ClientID:            client.ID,
+		AllowedConnectors:   client.Connectors,
 		State:               state,
 		Nonce:               nonce,
 		ForceApprovalPrompt: q.Get("approval_prompt") == "force",

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -133,6 +133,9 @@ type Client struct {
 	// Name and LogoURL used when displaying this client to the end user.
 	Name    string `json:"name" yaml:"name"`
 	LogoURL string `json:"logoURL" yaml:"logoURL"`
+
+	// Allowed connectors, if not specified all is allowed
+	Connectors []string `json:"connectors" yaml:"connectors"`
 }
 
 // Claims represents the ID Token claims supported by the server.
@@ -152,7 +155,8 @@ type AuthRequest struct {
 	ID string
 
 	// ID of the client requesting authorization from a user.
-	ClientID string
+	ClientID          string
+	AllowedConnectors []string
 
 	// Values parsed from the initial request. These describe the resources the client is
 	// requesting as well as values describing the form of the response.


### PR DESCRIPTION
We have currently use-case that we have multiple connectors (and multiple clients) configured to dex. However, we want limit which connectors are active in each client. The default behaviour is not changed in this PR, if connectors are not defined all connectors are listed.