### PR TITLE
Add support for auth endpoint on separate URL

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -28,6 +28,10 @@ type Config struct {
 	Expiry    Expiry    `json:"expiry"`
 	Logger    Logger    `json:"logger"`
 
+	// Allow to announce and expose auth and callback endpoints on different URL
+	// than token and issuer URLs.
+	PublicURL string `json:"publicURL"`
+
 	Frontend server.WebConfig `json:"frontend"`
 
 	// StaticConnectors are user defined connectors specified in the ConfigMap

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -95,6 +95,10 @@ func serve(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if len(c.PublicURL) == 0 {
+		c.PublicURL = c.Issuer
+	}
+
 	logger.Infof("config issuer: %s", c.Issuer)
 
 	prometheusRegistry := prometheus.NewRegistry()
@@ -221,6 +225,7 @@ func serve(cmd *cobra.Command, args []string) error {
 		SkipApprovalScreen:     c.OAuth2.SkipApprovalScreen,
 		AllowedOrigins:         c.Web.AllowedOrigins,
 		Issuer:                 c.Issuer,
+		PublicURL:              c.PublicURL,
 		Storage:                s,
 		Web:                    c.Frontend,
 		Logger:                 logger,

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -3,6 +3,14 @@
 # path is provided, dex's HTTP service will listen at a non-root URL.
 issuer: http://127.0.0.1:5556/dex
 
+# The publicURL allows to complete user authorization over different HTTP server
+# than token retrieval. This may be useful in scenarios where token endpoint
+# can be accesssible over the internal networks to internal authorization clients
+# while users still need to complete login flow over public web browser accessible
+# URL.
+# If not provided the value of `issuer` is used.
+# publicURL: https://example.com/dex
+
 # The storage configuration determines where dex stores its state. Supported
 # options include SQL flavors and Kubernetes third party resources.
 #

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -164,7 +164,7 @@ type discovery struct {
 func (s *Server) discoveryHandler() (http.HandlerFunc, error) {
 	d := discovery{
 		Issuer:      s.issuerURL.String(),
-		Auth:        s.absURL("/auth"),
+		Auth:        s.absPublicURL("/auth"),
 		Token:       s.absURL("/token"),
 		Keys:        s.absURL("/keys"),
 		UserInfo:    s.absURL("/userinfo"),
@@ -237,7 +237,7 @@ func (s *Server) handleAuthorization(w http.ResponseWriter, r *http.Request) {
 		for _, c := range connectors {
 			// TODO(ericchiang): Make this pass on r.URL.RawQuery and let something latter
 			// on create the auth request.
-			http.Redirect(w, r, s.absPath("/auth", c.ID)+"?req="+authReq.ID, http.StatusFound)
+			http.Redirect(w, r, s.absPublicURL("/auth", c.ID)+"?req="+authReq.ID, http.StatusFound)
 			return
 		}
 	}
@@ -250,7 +250,7 @@ func (s *Server) handleAuthorization(w http.ResponseWriter, r *http.Request) {
 			Name: conn.Name,
 			// TODO(ericchiang): Make this pass on r.URL.RawQuery and let something latter
 			// on create the auth request.
-			URL: s.absPath("/auth", conn.ID) + "?req=" + authReq.ID,
+			URL: s.absPublicURL("/auth", conn.ID) + "?req=" + authReq.ID,
 		}
 		i++
 	}
@@ -305,7 +305,7 @@ func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 			// Use the auth request ID as the "state" token.
 			//
 			// TODO(ericchiang): Is this appropriate or should we also be using a nonce?
-			callbackURL, err := conn.LoginURL(scopes, s.absURL("/callback"), authReqID)
+			callbackURL, err := conn.LoginURL(scopes, s.absPublicURL("/callback"), authReqID)
 			if err != nil {
 				s.logger.Errorf("Connector %q returned error when creating callback: %v", connID, err)
 				s.renderError(w, http.StatusInternalServerError, "Login error.")

--- a/server/server.go
+++ b/server/server.go
@@ -50,7 +50,8 @@ type Connector struct {
 //
 // Multiple servers using the same storage are expected to be configured identically.
 type Config struct {
-	Issuer string
+	Issuer    string
+	PublicURL string
 
 	// The backing persistence layer.
 	Storage storage.Storage
@@ -119,6 +120,7 @@ func value(val, defaultValue time.Duration) time.Duration {
 // Server is the top level object.
 type Server struct {
 	issuerURL url.URL
+	publicURL url.URL
 
 	// mutex for the connectors map.
 	mu sync.Mutex
@@ -158,6 +160,15 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 		return nil, fmt.Errorf("server: can't parse issuer URL")
 	}
 
+	if len(c.PublicURL) == 0 {
+		c.PublicURL = c.Issuer
+	}
+
+	publicURL, err := url.Parse(c.PublicURL)
+	if err != nil {
+		return nil, fmt.Errorf("server: can't parse auth URL")
+	}
+
 	if c.Storage == nil {
 		return nil, errors.New("server: storage cannot be nil")
 	}
@@ -178,7 +189,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	web := webConfig{
 		dir:       c.Web.Dir,
 		logoURL:   c.Web.LogoURL,
-		issuerURL: c.Issuer,
+		issuerURL: c.PublicURL,
 		issuer:    c.Web.Issuer,
 		theme:     c.Web.Theme,
 	}
@@ -195,6 +206,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 
 	s := &Server{
 		issuerURL:              *issuerURL,
+		publicURL:              *publicURL,
 		connectors:             make(map[string]Connector),
 		storage:                newKeyCacher(c.Storage, now),
 		supportedResponseTypes: supported,
@@ -247,6 +259,9 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	handleFunc := func(p string, h http.HandlerFunc) {
 		handle(p, h)
 	}
+	handlePublicFunc := func(p string, h http.HandlerFunc) {
+		r.Handle(path.Join(publicURL.Path, p), instrumentHandlerCounter(p, h))
+	}
 	handlePrefix := func(p string, h http.Handler) {
 		prefix := path.Join(issuerURL.Path, p)
 		r.PathPrefix(prefix).Handler(http.StripPrefix(prefix, h))
@@ -271,9 +286,9 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	handleWithCORS("/token", s.handleToken)
 	handleWithCORS("/keys", s.handlePublicKeys)
 	handleWithCORS("/userinfo", s.handleUserInfo)
-	handleFunc("/auth", s.handleAuthorization)
-	handleFunc("/auth/{connector}", s.handleConnectorLogin)
-	r.HandleFunc(path.Join(issuerURL.Path, "/callback"), func(w http.ResponseWriter, r *http.Request) {
+	handlePublicFunc("/auth", s.handleAuthorization)
+	handlePublicFunc("/auth/{connector}", s.handleConnectorLogin)
+	r.HandleFunc(path.Join(publicURL.Path, "/callback"), func(w http.ResponseWriter, r *http.Request) {
 		// Strip the X-Remote-* headers to prevent security issues on
 		// misconfigured authproxy connector setups.
 		for key := range r.Header {
@@ -312,6 +327,19 @@ func (s *Server) absPath(pathItems ...string) string {
 func (s *Server) absURL(pathItems ...string) string {
 	u := s.issuerURL
 	u.Path = s.absPath(pathItems...)
+	return u.String()
+}
+
+func (s *Server) absPublicPath(pathItems ...string) string {
+	paths := make([]string, len(pathItems)+1)
+	paths[0] = s.publicURL.Path
+	copy(paths[1:], pathItems)
+	return path.Join(paths...)
+}
+
+func (s *Server) absPublicURL(pathItems ...string) string {
+	u := s.publicURL
+	u.Path = s.absPublicPath(pathItems...)
 	return u.String()
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -156,6 +156,36 @@ func TestDiscovery(t *testing.T) {
 	}
 }
 
+func TestPublicURL(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	publicServer := httptest.NewServer(nil)
+	defer publicServer.Close()
+
+	httpServer, s := newTestServer(ctx, t, func(c *Config) {
+		c.PublicURL = publicServer.URL
+	})
+	defer httpServer.Close()
+
+	// Connect auth url to same Dex server and let it handle request
+	publicServer.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.ServeHTTP(w, r)
+	})
+
+	p, err := oidc.NewProvider(ctx, httpServer.URL)
+	if err != nil {
+		t.Fatalf("failed to get provider: %v", err)
+	}
+
+	if !strings.HasPrefix(p.Endpoint().AuthURL, publicServer.URL) {
+		t.Errorf("server discovery auth URL should be announced on public URL")
+	}
+	if strings.HasPrefix(p.Endpoint().TokenURL, publicServer.URL) {
+		t.Errorf("server discovery token URL should be announced on main server URL")
+	}
+}
+
 // TestOAuth2CodeFlow runs integration tests against a test server. The tests stand up a server
 // which requires no interaction to login, logs in through a test client, then passes the client
 // and returned token to the test.
@@ -1114,6 +1144,112 @@ func TestRefreshTokenFlow(t *testing.T) {
 		c.Now = now
 	})
 	defer httpServer.Close()
+
+	p, err := oidc.NewProvider(ctx, httpServer.URL)
+	if err != nil {
+		t.Fatalf("failed to get provider: %v", err)
+	}
+
+	var oauth2Client oauth2Client
+
+	oauth2Client.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/callback" {
+			// User is visiting app first time. Redirect to dex.
+			http.Redirect(w, r, oauth2Client.config.AuthCodeURL(state), http.StatusSeeOther)
+			return
+		}
+
+		// User is at '/callback' so they were just redirected _from_ dex.
+		q := r.URL.Query()
+
+		if errType := q.Get("error"); errType != "" {
+			if desc := q.Get("error_description"); desc != "" {
+				t.Errorf("got error from server %s: %s", errType, desc)
+			} else {
+				t.Errorf("got error from server %s", errType)
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// Grab code, exchange for token.
+		if code := q.Get("code"); code != "" {
+			token, err := oauth2Client.config.Exchange(ctx, code)
+			if err != nil {
+				t.Errorf("failed to exchange code for token: %v", err)
+				return
+			}
+			oauth2Client.token = token
+		}
+
+		// Ensure state matches.
+		if gotState := q.Get("state"); gotState != state {
+			t.Errorf("state did not match, want=%q got=%q", state, gotState)
+		}
+		w.WriteHeader(http.StatusOK)
+		return
+	}))
+	defer oauth2Client.server.Close()
+
+	// Register the client above with dex.
+	redirectURL := oauth2Client.server.URL + "/callback"
+	client := storage.Client{
+		ID:           "testclient",
+		Secret:       "testclientsecret",
+		RedirectURIs: []string{redirectURL},
+	}
+	if err := s.storage.CreateClient(client); err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	oauth2Client.config = &oauth2.Config{
+		ClientID:     client.ID,
+		ClientSecret: client.Secret,
+		Endpoint:     p.Endpoint(),
+		Scopes:       []string{oidc.ScopeOpenID, "email", "offline_access"},
+		RedirectURL:  redirectURL,
+	}
+
+	if _, err = http.Get(oauth2Client.server.URL + "/login"); err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+
+	tok := &oauth2.Token{
+		RefreshToken: oauth2Client.token.RefreshToken,
+		Expiry:       time.Now().Add(-time.Hour),
+	}
+
+	// Login in again to receive a new token.
+	if _, err = http.Get(oauth2Client.server.URL + "/login"); err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+
+	// try to refresh expired token with old refresh token.
+	newToken, err := oauth2Client.config.TokenSource(ctx, tok).Token()
+	if newToken != nil {
+		t.Errorf("Token refreshed with invalid refresh token.")
+	}
+}
+
+func TestAuthEndpointDifferentFromIssuerURL(t *testing.T) {
+	state := "state"
+	now := func() time.Time { return time.Now() }
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	publicServer := httptest.NewServer(nil)
+	defer publicServer.Close()
+
+	httpServer, s := newTestServer(ctx, t, func(c *Config) {
+		c.PublicURL = publicServer.URL
+		c.Now = now
+	})
+	defer httpServer.Close()
+
+	// Connect auth url to same Dex server and let it handle request
+	publicServer.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.ServeHTTP(w, r)
+	})
 
 	p, err := oidc.NewProvider(ctx, httpServer.URL)
 	if err != nil {


### PR DESCRIPTION
This PR introduces a new optional configuration parameter `publicURL`. If not provided, default is the existing `issuer` value. The new option allows announcing Dex `authentication_endpoint` value on different URL than `issuer` and `token_endpoint` in the `discovery` endpoint. This can be useful in a setup where Dex runs on an internal network that is not publicly accessible.

We would like to configure Dex as an OpenID Connect provider (OP) in an internal network. The OpenID Connect relying parties (RPs) are also in the internal network. However, the user agents (UAs) are exclusively in the external network. The DNS names used in the internal network do not work in the external network and vice versa.

In our example, when the UAs want to reach the OP then they use the base URL `https://my-aws-01-elb.aws.amazon.com/` whereas when the RPs want to reach the OP they use the base URL `https://dex-kubeaddons.kubeaddons.svc.cluster.local:8080/`.

The RPs redirect the UAs to the OP via the `authorization_endpoint` URL exposed in the OP's `.well-known/openid-configuration` JSON doc. Therefore, there should be a way in Dex to set a custom `authorization_endpoint` URL which is what this patch tries to achieve.

Using two different base URLs in `issuer` and `authorization_endpoint` does not seem to be common but we believe that it is a valid configuration and that it does not impose a security risk. What do you think?

Example of discovery endpoint output with the following configuration:

```yaml
issuer: https://dex-kubeaddons.kubeaddons.svc.cluster.local:8080/dex
publicURL: https://my-aws-01-elb.aws.amazon.com/dex
```

```json
{
  "issuer": "https://dex-kubeaddons.kubeaddons.svc.cluster.local:8080/dex",
  "authorization_endpoint": "https://my-aws-01-elb.aws.amazon.com/dex/auth",
  "token_endpoint": "https://dex-kubeaddons.kubeaddons.svc.cluster.local:8080/dex/token",
  "jwks_uri": "https://dex-kubeaddons.kubeaddons.svc.cluster.local:8080/dex/keys",
  ...
}
```

This can be useful in scenarios when `kube-apiserver` needs to be configured to use OIDC authentication against the Dex instance that will eventually run on same kubernetes cluster. In such setup, the `publicURL` will point to public ingress that exposes Dex service.