### PR TITLE
Add configurable callback

### DIFF
--- a/Documentation/connectors/oidc.md
+++ b/Documentation/connectors/oidc.md
@@ -30,7 +30,8 @@ connectors:
     clientID: $GOOGLE_CLIENT_ID
     clientSecret: $GOOGLE_CLIENT_SECRET
 
-    # Dex's issuer URL + "/callback" or if a custom callback field is declared, Dex's callback URL + "/callback"
+    # Dex's issuer URL + "/callback" or if a custom callback field is declared in 
+    # the config of the main application, Dex's callback URL + "/callback". 
     redirectURI: http://127.0.0.1:5556/callback
 
 

--- a/Documentation/connectors/oidc.md
+++ b/Documentation/connectors/oidc.md
@@ -30,7 +30,7 @@ connectors:
     clientID: $GOOGLE_CLIENT_ID
     clientSecret: $GOOGLE_CLIENT_SECRET
 
-    # Dex's issuer URL + "/callback"
+    # Dex's issuer URL + "/callback" or if a custom callback field is declared, Dex's callback URL + "/callback"
     redirectURI: http://127.0.0.1:5556/callback
 
 

--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -20,6 +20,7 @@ import (
 // Config is the config format for the main application.
 type Config struct {
 	Issuer    string    `json:"issuer"`
+	Callback  string    `json:"callback"`
 	Storage   Storage   `json:"storage"`
 	Web       Web       `json:"web"`
 	Telemetry Telemetry `json:"telemetry"`

--- a/cmd/dex/config_test.go
+++ b/cmd/dex/config_test.go
@@ -151,3 +151,139 @@ logger:
 	}
 
 }
+
+func TestUnmarshalConfigWithCallback(t *testing.T) {
+
+	rawConfigWithCallback := []byte(`
+issuer: http://127.0.0.1:5556/dex
+callback: http://127.0.0.1:5556/custom
+storage:
+  type: postgres
+  config:
+    host: 10.0.0.1
+    port: 65432
+    maxOpenConns: 5
+    maxIdleConns: 3
+    connMaxLifetime: 30
+    connectionTimeout: 3
+web:
+  http: 127.0.0.1:5556
+staticClients:
+- id: example-app
+  redirectURIs:
+  - 'http://127.0.0.1:5555/callback'
+  name: 'Example App'
+  secret: ZXhhbXBsZS1hcHAtc2VjcmV0
+connectors:
+- type: mockCallback
+  id: mock
+  name: Example
+- type: oidc
+  id: google
+  name: Google
+  config:
+    issuer: https://accounts.google.com
+    clientID: foo
+    clientSecret: bar
+    redirectURI: http://127.0.0.1:5556/custom/callback/google
+enablePasswordDB: true
+staticPasswords:
+- email: "admin@example.com"
+  # bcrypt hash of the string "password"
+  hash: "$2a$10$33EMT0cVYVlPy6WAMCLsceLYjWhuHpbz5yuZxu/GAFj03J9Lytjuy"
+  username: "admin"
+  userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+- email: "foo@example.com"
+  # base64'd value of the same bcrypt hash above. We want to be able to parse both of these
+  hash: "JDJhJDEwJDMzRU1UMGNWWVZsUHk2V0FNQ0xzY2VMWWpXaHVIcGJ6NXl1Wnh1L0dBRmowM0o5THl0anV5"
+  username: "foo"
+  userID: "41331323-6f44-45e6-b3b9-2c4b60c02be5"
+expiry:
+  signingKeys: "7h"
+  idTokens: "25h"
+  authRequests: "25h"
+logger:
+  level: "debug"
+  format: "json"
+`)
+
+	wantWithCallback := Config{
+		Issuer: "http://127.0.0.1:5556/dex",
+		Callback: "http://127.0.0.1:5556/custom",
+		Storage: Storage{
+			Type: "postgres",
+			Config: &sql.Postgres{
+				Host:              "10.0.0.1",
+				Port:              65432,
+				MaxOpenConns:      5,
+				MaxIdleConns:      3,
+				ConnMaxLifetime:   30,
+				ConnectionTimeout: 3,
+			},
+		},
+		Web: Web{
+			HTTP: "127.0.0.1:5556",
+		},
+		StaticClients: []storage.Client{
+			{
+				ID:     "example-app",
+				Secret: "ZXhhbXBsZS1hcHAtc2VjcmV0",
+				Name:   "Example App",
+				RedirectURIs: []string{
+					"http://127.0.0.1:5555/callback",
+				},
+			},
+		},
+		StaticConnectors: []Connector{
+			{
+				Type:   "mockCallback",
+				ID:     "mock",
+				Name:   "Example",
+				Config: &mock.CallbackConfig{},
+			},
+			{
+				Type: "oidc",
+				ID:   "google",
+				Name: "Google",
+				Config: &oidc.Config{
+					Issuer:       "https://accounts.google.com",
+					ClientID:     "foo",
+					ClientSecret: "bar",
+					RedirectURI:  "http://127.0.0.1:5556/custom/callback/google",
+				},
+			},
+		},
+		EnablePasswordDB: true,
+		StaticPasswords: []password{
+			{
+				Email:    "admin@example.com",
+				Hash:     []byte("$2a$10$33EMT0cVYVlPy6WAMCLsceLYjWhuHpbz5yuZxu/GAFj03J9Lytjuy"),
+				Username: "admin",
+				UserID:   "08a8684b-db88-4b73-90a9-3cd1661f5466",
+			},
+			{
+				Email:    "foo@example.com",
+				Hash:     []byte("$2a$10$33EMT0cVYVlPy6WAMCLsceLYjWhuHpbz5yuZxu/GAFj03J9Lytjuy"),
+				Username: "foo",
+				UserID:   "41331323-6f44-45e6-b3b9-2c4b60c02be5",
+			},
+		},
+		Expiry: Expiry{
+			SigningKeys:  "7h",
+			IDTokens:     "25h",
+			AuthRequests: "25h",
+		},
+		Logger: Logger{
+			Level:  "debug",
+			Format: "json",
+		},
+	}
+
+  var c Config
+	if err := yaml.Unmarshal(rawConfigWithCallback, &c); err !=nil {
+	  t.Fatalf("failed to decode config: %v", err)
+	}
+	if diff := pretty.Compare(c, wantWithCallback); diff != "" {
+		t.Errorf("got!=want: %s", diff)
+	}
+}

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -96,6 +96,12 @@ func serve(cmd *cobra.Command, args []string) error {
 	}
 
 	logger.Infof("config issuer: %s", c.Issuer)
+	
+	if c.Callback == "" {
+		logger.Infof("No callback url specified, using default %s/callback", c.Issuer)
+	} else {
+	        logger.Infof("config callback url: %s", c.Callback)
+	}
 
 	prometheusRegistry := prometheus.NewRegistry()
 	err = prometheusRegistry.Register(prometheus.NewGoCollector())
@@ -221,6 +227,7 @@ func serve(cmd *cobra.Command, args []string) error {
 		SkipApprovalScreen:     c.OAuth2.SkipApprovalScreen,
 		AllowedOrigins:         c.Web.AllowedOrigins,
 		Issuer:                 c.Issuer,
+	  Callback:               c.Callback,
 		Storage:                s,
 		Web:                    c.Frontend,
 		Logger:                 logger,

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -307,7 +307,7 @@ func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 			// Use the auth request ID as the "state" token.
 			//
 			// TODO(ericchiang): Is this appropriate or should we also be using a nonce?
-			callbackURL, err := conn.LoginURL(scopes, s.absURL("/callback"), authReqID)
+			callbackURL, err := conn.LoginURL(scopes, s.useCallback("/callback"), authReqID)
 			if err != nil {
 				s.logger.Errorf("Connector %q returned error when creating callback: %v", connID, err)
 				s.renderError(w, http.StatusInternalServerError, "Login error.")
@@ -490,7 +490,7 @@ func (s *Server) finalizeLogin(identity connector.Identity, authReq storage.Auth
 	s.logger.Infof("login successful: connector %q, username=%q, email=%q, groups=%q",
 		authReq.ConnectorID, claims.Username, email, claims.Groups)
 
-	return path.Join(s.issuerURL.Path, "/approval") + "?req=" + authReq.ID, nil
+	return path.Join(s.useCallbackURL(), "/approval") + "?req=" + authReq.ID, nil
 }
 
 func (s *Server) handleApproval(w http.ResponseWriter, r *http.Request) {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -149,6 +149,7 @@ func (s *Server) handlePublicKeys(w http.ResponseWriter, r *http.Request) {
 
 type discovery struct {
 	Issuer        string   `json:"issuer"`
+	Callback      string   `json:"callback"`
 	Auth          string   `json:"authorization_endpoint"`
 	Token         string   `json:"token_endpoint"`
 	Keys          string   `json:"jwks_uri"`
@@ -164,6 +165,7 @@ type discovery struct {
 func (s *Server) discoveryHandler() (http.HandlerFunc, error) {
 	d := discovery{
 		Issuer:      s.issuerURL.String(),
+		Callback:    s.callbackConfig.String(),
 		Auth:        s.absURL("/auth"),
 		Token:       s.absURL("/token"),
 		Keys:        s.absURL("/keys"),

--- a/server/server.go
+++ b/server/server.go
@@ -344,7 +344,7 @@ func (s *Server) useCallback(pathItems ...string) string {
 	}
 }
 
-func (s *Server) useCallback() string {
+func (s *Server) useCallbackURL() string {
         u := s.callbackConfig
         if u.String() == "" {
 		return s.issuerURL.Path


### PR DESCRIPTION
Allows the user to set a custom callback URL (different than that of the issuer) for an OIDC connector. An organization that implements OIDC may have a domain limit (eg. Google), which would limit the number of applications that can authenticate against it. This feature uses redirect URIs, rather than domains to redirect to the correct application after authentication. 


Setup: Add a "callback" field in the config.yaml file (eg. https://auth.company.com/app1). The redirect URI for the connectors would then be the callback URL + /callback (eg. https://auth.company.com/app1/callback). Ensure that your OIDC connector has the callback URL for each application configured. Create a proxy that directs traffic back to the application and does a URI match and re-write for callback and approval back to dex (eg. URI match on /app1/callback and re-write it to /callback and a URI match on /app1/approval and rewrite it to /approval). 


You can now have a number of applications that use the same OIDC connector for authentication. 