### PR TITLE
Allow env expansion of issuer URL

### DIFF
--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -75,6 +75,7 @@ func serve(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	c.Issuer = os.ExpandEnv(c.Issuer)
 	logger.Infof("config issuer: %s", c.Issuer)
 
 	prometheusRegistry := prometheus.NewRegistry()


### PR DESCRIPTION
- This allows us to have config file that can be reused across different environment `dev/qa/prod`