### PR TITLE
add connector_id to example app

### DIFF
--- a/cmd/example-app/main.go
+++ b/cmd/example-app/main.go
@@ -237,6 +237,10 @@ func (a *app) handleLogin(w http.ResponseWriter, r *http.Request) {
 	for _, client := range clients {
 		scopes = append(scopes, "audience:server:client_id:"+client)
 	}
+	connectorID := ""
+	if id := r.FormValue("connector_id"); id != "" {
+		connectorID = id
+	}
 
 	authCodeURL := ""
 	scopes = append(scopes, "openid", "profile", "email")
@@ -247,6 +251,9 @@ func (a *app) handleLogin(w http.ResponseWriter, r *http.Request) {
 		authCodeURL = a.oauth2Config(scopes).AuthCodeURL(exampleAppState)
 	} else {
 		authCodeURL = a.oauth2Config(scopes).AuthCodeURL(exampleAppState, oauth2.AccessTypeOffline)
+	}
+	if connectorID != "" {
+		authCodeURL = authCodeURL + "&connector_id=" + connectorID
 	}
 
 	http.Redirect(w, r, authCodeURL, http.StatusSeeOther)

--- a/cmd/example-app/templates.go
+++ b/cmd/example-app/templates.go
@@ -15,8 +15,11 @@ var indexTmpl = template.Must(template.New("index.html").Parse(`<html>
        <p>
          Extra scopes:<input type="text" name="extra_scopes" placeholder="list of scopes">
        </p>
-	   <p>
-	     Request offline access:<input type="checkbox" name="offline_access" value="yes" checked>
+       <p>
+         Connector ID:<input type="text" name="connector_id" placeholder="connector id">
+       </p>
+       <p>
+         Request offline access:<input type="checkbox" name="offline_access" value="yes" checked>
        </p>
        <input type="submit" value="Login">
     </form>

--- a/cmd/example-app/templates.go
+++ b/cmd/example-app/templates.go
@@ -66,13 +66,13 @@ pre {
 </html>
 `))
 
-func renderToken(w http.ResponseWriter, redirectURL, idToken, accessToken, refreshToken string, claims []byte) {
+func renderToken(w http.ResponseWriter, redirectURL, idToken, accessToken, refreshToken, claims string) {
 	renderTemplate(w, tokenTmpl, tokenTmplData{
 		IDToken:      idToken,
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
 		RedirectURL:  redirectURL,
-		Claims:       string(claims),
+		Claims:       claims,
 	})
 }
 


### PR DESCRIPTION
This makes it easy to play with the new parameter.

However, it also shows a problem: when trying to login to dex (run via `dex serve examples/config-dev.yaml`), and providing `local` as `connector_id`, the "back link" will be shown, and go back in browser history one step -- this will _not_ lead you to the connector selection, but to example-app. To be fixed in a follow-up PR (_help wanted!_ :wink:)

Added two small cleanups, nothing too significant.