### PR TITLE
connector/gitlab: implement useLoginAsID as in GitHub connector

### DIFF
--- a/Documentation/connectors/gitlab.md
+++ b/Documentation/connectors/gitlab.md
@@ -33,4 +33,7 @@ connectors:
       # If `groups` is provided, this acts as a whitelist - only the user's GitLab groups that are in the configured `groups` below will go into the groups claim.  Conversely, if the user is not in any of the configured `groups`, the user will not be authenticated.
       groups:
       - my-group
+      # flag which will switch from using the internal GitLab id to the users handle (@mention) as the user id.
+      # It is possible for a user to change their own user name but it is very rare for them to do so
+      useLoginAsID: false
 ```

--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -150,7 +150,7 @@ type githubConnector struct {
 	teamNameField string
 	// if set to true and no orgs are configured then connector loads all user claims (all orgs and team)
 	loadAllGroups bool
-	// if set to true will use the users handle rather than their numeric id as the ID
+	// if set to true will use the user's handle rather than their numeric id as the ID
 	useLoginAsID bool
 }
 

--- a/connector/gitlab/gitlab.go
+++ b/connector/gitlab/gitlab.go
@@ -32,6 +32,7 @@ type Config struct {
 	ClientSecret string   `json:"clientSecret"`
 	RedirectURI  string   `json:"redirectURI"`
 	Groups       []string `json:"groups"`
+	UseLoginAsID bool     `json:"useLoginAsID"`
 }
 
 type gitlabUser struct {
@@ -55,6 +56,7 @@ func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error)
 		clientSecret: c.ClientSecret,
 		logger:       logger,
 		groups:       c.Groups,
+		useLoginAsID: c.UseLoginAsID,
 	}, nil
 }
 
@@ -76,6 +78,8 @@ type gitlabConnector struct {
 	clientSecret string
 	logger       log.Logger
 	httpClient   *http.Client
+	// if set to true will use the user's handle rather than their numeric id as the ID
+	useLoginAsID bool
 }
 
 func (c *gitlabConnector) oauth2Config(scopes connector.Scopes) *oauth2.Config {
@@ -147,6 +151,9 @@ func (c *gitlabConnector) HandleCallback(s connector.Scopes, r *http.Request) (i
 		Username:      username,
 		Email:         user.Email,
 		EmailVerified: true,
+	}
+	if c.useLoginAsID {
+		identity.UserID = user.Username
 	}
 
 	if s.Groups {

--- a/connector/gitlab/gitlab_test.go
+++ b/connector/gitlab/gitlab_test.go
@@ -104,7 +104,7 @@ func TestUsernameIncludedInFederatedIdentity(t *testing.T) {
 func TestLoginUsedAsIDWhenConfigured(t *testing.T) {
 
 	s := newTestServer(map[string]interface{}{
-		"/api/v4/user": gitlabUser{Email: "some@email.com", ID: 12345678, Name: "Joe Bloggs"},
+		"/api/v4/user": gitlabUser{Email: "some@email.com", ID: 12345678, Name: "Joe Bloggs", Username: "joebloggs"},
 		"/oauth/token": map[string]interface{}{
 			"access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9",
 			"expires_in":   "30",
@@ -121,11 +121,11 @@ func TestLoginUsedAsIDWhenConfigured(t *testing.T) {
 	req, err := http.NewRequest("GET", hostURL.String(), nil)
 	expectNil(t, err)
 
-	c := gitlabConnector{baseURL: s.URL, httpClient: newClient()}
+	c := gitlabConnector{baseURL: s.URL, httpClient: newClient(), useLoginAsID: true}
 	identity, err := c.HandleCallback(connector.Scopes{Groups: true}, req)
 
 	expectNil(t, err)
-	expectEquals(t, identity.UserID, "12345678")
+	expectEquals(t, identity.UserID, "joebloggs")
 	expectEquals(t, identity.Username, "Joe Bloggs")
 }
 


### PR DESCRIPTION
I'm not user if we can use the same name `useLoginAsID` as in GitHub since in GitLab it is called Username in the API (vs Login). But in this case, the config is the same.

We have a test for it as well (which I have added, but now it is valid :)