### PR TITLE
Add option to always display connector selection even if there's only one

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -127,6 +127,8 @@ type OAuth2 struct {
 	// If specified, do not prompt the user to approve client authorization. The
 	// act of logging in implies authorization.
 	SkipApprovalScreen bool `json:"skipApprovalScreen"`
+	// If specified, show the connector selection screen even if there's only one
+	AlwaysShowLoginScreen bool `json:"alwaysShowLoginScreen"`
 }
 
 // Web is the config format for the HTTP server.

--- a/cmd/dex/config_test.go
+++ b/cmd/dex/config_test.go
@@ -76,6 +76,9 @@ staticClients:
   name: 'Example App'
   secret: ZXhhbXBsZS1hcHAtc2VjcmV0
 
+oauth2:
+  alwaysShowLoginScreen: true
+
 connectors:
 - type: mockCallback
   id: mock
@@ -139,6 +142,9 @@ logger:
 					"http://127.0.0.1:5555/callback",
 				},
 			},
+		},
+		OAuth2: OAuth2{
+			AlwaysShowLoginScreen: true,
 		},
 		StaticConnectors: []Connector{
 			{

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -199,6 +199,7 @@ func serve(cmd *cobra.Command, args []string) error {
 	serverConfig := server.Config{
 		SupportedResponseTypes: c.OAuth2.ResponseTypes,
 		SkipApprovalScreen:     c.OAuth2.SkipApprovalScreen,
+		AlwaysShowLoginScreen:  c.OAuth2.AlwaysShowLoginScreen,
 		AllowedOrigins:         c.Web.AllowedOrigins,
 		Issuer:                 c.Issuer,
 		Storage:                s,

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -249,7 +249,7 @@ func (s *Server) handleAuthorization(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(connectors) == 1 {
+	if len(connectors) == 1 && !s.alwaysShowLogin {
 		for _, c := range connectors {
 			// TODO(ericchiang): Make this pass on r.URL.RawQuery and let something latter
 			// on create the auth request.

--- a/server/server.go
+++ b/server/server.go
@@ -68,6 +68,9 @@ type Config struct {
 	// Logging in implies approval.
 	SkipApprovalScreen bool
 
+	// If enabled, the connectors selection page will always be shown even if there's only one
+	AlwaysShowLoginScreen bool
+
 	RotateKeysAfter      time.Duration // Defaults to 6 hours.
 	IDTokensValidFor     time.Duration // Defaults to 24 hours
 	AuthRequestsValidFor time.Duration // Defaults to 24 hours
@@ -133,6 +136,9 @@ type Server struct {
 
 	// If enabled, don't prompt user for approval after logging in through connector.
 	skipApproval bool
+
+	// If enabled, show the connector selection screen even if there's only one
+	alwaysShowLogin bool
 
 	supportedResponseTypes map[string]bool
 
@@ -201,6 +207,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 		idTokensValidFor:       value(c.IDTokensValidFor, 24*time.Hour),
 		authRequestsValidFor:   value(c.AuthRequestsValidFor, 24*time.Hour),
 		skipApproval:           c.SkipApprovalScreen,
+		alwaysShowLogin:        c.AlwaysShowLoginScreen,
 		now:                    now,
 		templates:              tmpls,
 		logger:                 c.Logger,


### PR DESCRIPTION
We are currently building an auth proxy system that will be used to authenticate users before being redirected to their destination. The fact that Dex automatically forwards to the connector if there's only one has been confusing for our users. They type `my-service.com` in their browsers and end up on Google login, not a great UX.

This PR allows to specify an option to always show the connector selection screen even if there's only one. That way our users will land on a themed login page, and select "Login with Google" before ending up on Google login.

Let me know what you think!