### PR TITLE
Adjusting Makefile so that `golint` will compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PROJ=dex
 ORG_PATH=github.com/dexidp
 REPO_PATH=$(ORG_PATH)/$(PROJ)
 export PATH := $(PWD)/bin:$(PATH)
+THIS_DIRECTORY:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 VERSION ?= $(shell ./scripts/git-version)
 
@@ -73,7 +74,7 @@ bin/protoc-gen-go:
 	@go install -v $(REPO_PATH)/vendor/github.com/golang/protobuf/protoc-gen-go
 
 bin/golint:
-	@go install -v $(REPO_PATH)/vendor/golang.org/x/lint/golint
+	@go install -v $(THIS_DIRECTORY)/vendor/golang.org/x/lint/golint
 
 clean:
 	@rm -rf bin/


### PR DESCRIPTION
When doing `make bin/golint` one will get an error about go modules and lint.  By asking `go install -v ...` on the absolute file path, the error goes away.

I'm unsure about this nuance of `go install` where the absolute path will work just fine but the current `REPO_PATH` does not.  Regardless, this _does_ fix it and it does allow dex to use the latest and greatest grpc and lint libraries, unlike my previous PR.

Fixes #1506 