### PR TITLE
Add examples for recent additions to oauth2 configuration options

### DIFF
--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -42,11 +42,17 @@ telemetry:
 #   level: "debug"
 #   format: "text" # can also be "json"
 
-# Uncomment this block to control which response types dex supports. For example
-# the following response types enable the implicit flow for web-only clients.
-# Defaults to ["code"], the code flow.
+# Default values shown below
 # oauth2:
-#   responseTypes: ["code", "token", "id_token"]
+    # use ["code", "token", "id_token"] to enable implicit flow for web-only clients
+#   responseTypes: [ "code" ] # also allowed are "token" and "id_token"
+    # By default, Dex will ask for approval to share data with application
+    # (approval for sharing data from connected IdP to Dex is separate process on IdP)
+#   skipApprovalScreen: false
+    # If only one authentication method is enabled, the default behavior is to
+    # go directly to it. For connected IdPs, this redirects the browser away
+    # from application to upstream provider such as the Google login page
+#   alwaysShowLoginScreen: false
 
 # Instead of reading from an external storage, use this list of clients.
 #


### PR DESCRIPTION
Improve example "documentation" for oauth2 configuration feature introduced in #1505 and other previously-added feature.