### PR TITLE
Preserve client ID when using Kubernetes storage

### DIFF
--- a/storage/kubernetes/client.go
+++ b/storage/kubernetes/client.go
@@ -161,6 +161,7 @@ func (c *client) get(resource, name string, v interface{}) error {
 }
 
 func (c *client) getResource(apiVersion, namespace, resource, name string, v interface{}) error {
+	c.logger.Debugf("Retrieving resource: %s/%s %s/%s", apiVersion, namespace, resource, name)
 	url := c.urlFor(apiVersion, namespace, resource, name)
 	resp, err := c.client.Get(url)
 	if err != nil {

--- a/storage/kubernetes/storage.go
+++ b/storage/kubernetes/storage.go
@@ -281,8 +281,7 @@ func (cli *client) GetClient(id string) (storage.Client, error) {
 
 func (cli *client) getClient(id string) (Client, error) {
 	var c Client
-	name := cli.idToName(id)
-	if err := cli.get(resourceClient, name, &c); err != nil {
+	if err := cli.get(resourceClient, id, &c); err != nil {
 		return Client{}, err
 	}
 	if c.ID != id {

--- a/storage/kubernetes/types.go
+++ b/storage/kubernetes/types.go
@@ -257,7 +257,7 @@ func (cli *client) fromStorageClient(c storage.Client) Client {
 			APIVersion: cli.apiVersion,
 		},
 		ObjectMeta: k8sapi.ObjectMeta{
-			Name:      cli.idToName(c.ID),
+			Name:      c.ID,
 			Namespace: cli.namespace,
 		},
 		ID:           c.ID,


### PR DESCRIPTION
This is more of a proposal. 

Currently, when using the Kubernetes CRD storage, all clients IDs are encoded. Although this allows for a more extensive charset, it basically makes the client identifier unguessable/unconstructable without the DEX client. This is cumbersome to overcome if you are managing DEX through the CRDs rather through the DEX API.

So, I propose to not encode the client ID, since it doesn't seem like a necessity for the client IDs. 

An alternative implementation would be to add an option to the Kubernetes storage config "PreserveClientID", which will only preserve the client ID if enabled. 