### PR TITLE
Only use metadata.Name to store and retrieve the connector ID

### DIFF
--- a/storage/kubernetes/types.go
+++ b/storage/kubernetes/types.go
@@ -663,7 +663,6 @@ type Connector struct {
 	k8sapi.TypeMeta   `json:",inline"`
 	k8sapi.ObjectMeta `json:"metadata,omitempty"`
 
-	ID              string `json:"id,omitempty"`
 	Type            string `json:"type,omitempty"`
 	Name            string `json:"name,omitempty"`
 	ResourceVersion string `json:"resourceVersion,omitempty"`
@@ -681,7 +680,6 @@ func (cli *client) fromStorageConnector(c storage.Connector) Connector {
 			Name:      c.ID,
 			Namespace: cli.namespace,
 		},
-		ID:              c.ID,
 		Type:            c.Type,
 		Name:            c.Name,
 		ResourceVersion: c.ResourceVersion,
@@ -691,7 +689,7 @@ func (cli *client) fromStorageConnector(c storage.Connector) Connector {
 
 func toStorageConnector(c Connector) storage.Connector {
 	return storage.Connector{
-		ID:              c.ID,
+		ID:              c.ObjectMeta.Name,
 		Type:            c.Type,
 		Name:            c.Name,
 		ResourceVersion: c.ResourceVersion,


### PR DESCRIPTION
Currently, in the k8s storage backend, DEX stores the connector ID in two places: (1) as the resource name of the Connector resource, and (2) in a separate ID field. The implementation as it is right now also saves the exact same connector ID to both places. 

This PR removes the ID field, and relies solely on the metadata.Name. The change is backwards compatible; the ID field will simply be ignored if set.