### PR TITLE
Convert k8s connector config to encode in a string 

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -31,6 +30,7 @@ import (
 	"github.com/dexidp/dex/pkg/log"
 	"github.com/dexidp/dex/storage"
 	"github.com/felixge/httpsnoop"
+	"github.com/ghodss/yaml"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
@@ -475,7 +475,7 @@ func openConnector(logger log.Logger, conn storage.Connector) (connector.Connect
 	connConfig := f()
 	if len(conn.Config) != 0 {
 		data := []byte(string(conn.Config))
-		if err := json.Unmarshal(data, connConfig); err != nil {
+		if err := yaml.Unmarshal(data, connConfig); err != nil {
 			return c, fmt.Errorf("parse connector config: %v", err)
 		}
 	}

--- a/storage/kubernetes/types.go
+++ b/storage/kubernetes/types.go
@@ -667,8 +667,10 @@ type Connector struct {
 	Type            string `json:"type,omitempty"`
 	Name            string `json:"name,omitempty"`
 	ResourceVersion string `json:"resourceVersion,omitempty"`
-	// Config holds connector specific configuration information
-	Config []byte `json:"config,omitempty"`
+	// Config holds connector specific configuration information in a YAML or JSON struct
+	// The config here is a string rather than a byte-array to improve
+	// readability/editing in the k8s Connector CRD.
+	Config string `json:"config,omitempty"`
 }
 
 func (cli *client) fromStorageConnector(c storage.Connector) Connector {
@@ -685,7 +687,7 @@ func (cli *client) fromStorageConnector(c storage.Connector) Connector {
 		Type:            c.Type,
 		Name:            c.Name,
 		ResourceVersion: c.ResourceVersion,
-		Config:          c.Config,
+		Config:          string(c.Config),
 	}
 }
 
@@ -695,7 +697,7 @@ func toStorageConnector(c Connector) storage.Connector {
 		Type:            c.Type,
 		Name:            c.Name,
 		ResourceVersion: c.ResourceVersion,
-		Config:          c.Config,
+		Config:          []byte(c.Config),
 	}
 }
 


### PR DESCRIPTION
Currently, in the Kubernetes storage, the connector config is stored as a JSON object in a byte array. This reduces readability, and prevents creating or editing the config in the Kubernetes resource.

This PR changes this by introducing the `configString` field to the Kubernetes storage struct of the connector. DEX stores the configuration as a JSON object (to avoid impacting the whole system) into this field, and is able to read both a YAML or JSON-encoded config from it (ff9fc64).

By keeping the original config (for now), this change is backward-compatible. DEX will prefer `configString`, but fallback to reading from `config` to be able to support configuration using the old structure.

Old config structure:
```yaml
apiVersion: dex.coreos.com/v1
kind: Connector
metadata:
  name: github
type: github
id: github
config: e30K
```

New config structure:
```yaml
apiVersion: dex.coreos.com/v1
kind: Connector
metadata:
  name: github
id: github
type: github
configString: |
  clientID: $GITHUB_CLIENT_ID
  clientSecret: $GITHUB_CLIENT_SECRET
  loadAllGroups: true
```
