### PR TITLE
Replace x/net/context with stdlib context

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -1,14 +1,11 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"golang.org/x/crypto/bcrypt"
-
-	// go-grpc doesn't use the standard library's context.
-	// https://github.com/grpc/grpc-go/issues/711
-	"golang.org/x/net/context"
 
 	"github.com/dexidp/dex/api"
 	"github.com/dexidp/dex/pkg/log"


### PR DESCRIPTION
I was not able to build the project due to missing the "golang.org/x/net/context" (with `go version go1.12.9 darwin/amd64`). It looks like there are two options here to fix this: (1) add a dependency to golang.org/x/net/context, or (2) use the context from the standard library.

Since the comment in the code does no longer apply (it is two years old) and the linked issue seems to be resolved, I think we can safely move to use "context".