### PR TITLE
Use a more conservative set of CipherSuites

### DIFF
--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -97,6 +97,17 @@ func serve(cmd *cobra.Command, args []string) error {
 
 	var grpcOptions []grpc.ServerOption
 
+	allowedTLSCiphers := []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	}
+
 	if c.GRPC.TLSCert != "" {
 		// Parse certificates from certificate file and key file for server.
 		cert, err := tls.LoadX509KeyPair(c.GRPC.TLSCert, c.GRPC.TLSKey)
@@ -107,6 +118,7 @@ func serve(cmd *cobra.Command, args []string) error {
 		tlsConfig := tls.Config{
 			Certificates:             []tls.Certificate{cert},
 			MinVersion:               tls.VersionTLS12,
+			CipherSuites:             allowedTLSCiphers,
 			PreferServerCipherSuites: true,
 		}
 
@@ -262,6 +274,7 @@ func serve(cmd *cobra.Command, args []string) error {
 			Addr:    c.Web.HTTPS,
 			Handler: serv,
 			TLSConfig: &tls.Config{
+				CipherSuites:             allowedTLSCiphers,
 				PreferServerCipherSuites: true,
 				MinVersion:               tls.VersionTLS12,
 			},


### PR DESCRIPTION
The default cipher suites used by Go include a number of ciphers that
have known weaknesses. In addition to leaving users open to these
weaknesses, the inclusion of these weaker ciphers causes problems with
various automated scanning tools.

This PR disables the CBC-mode, RC4, and 3DES ciphers included in the
Go standard library by passing an explicit cipher suite list.

The ciphers included here are more line with those recommended by
Mozilla for "Intermediate" compatibility. [0]

*Performance Implications*

The Go standard library does capability-based cipher ordering,
preferring AES ciphers if the underlying hardware has AES specific
instructions. [1] Since all of the relevant code is internal modules,
to do the same thing ourselves would require duplicating that
code. Here, I've placed AES based ciphers first.

*Compatibility Implications*

This does reduce the number of clients who will be able to communicate
with dex.

[0] https://ssl-config.mozilla.org/#server=nginx&server-version=1.17.0&config=intermediate&hsts=false&ocsp=false
[1] https://github.com/golang/go/blob/a8c2e5c6adc0d8f9b976a55bf4e22fcf5770ea55/src/crypto/tls/common.go#L1091

Signed-off-by: Steven Danna <steve@chef.io>