### PR TITLE
WIP: Gracefully shutdown server

### DIFF
--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -293,8 +293,16 @@ func serve(cmd *cobra.Command, args []string) error {
 			}()
 		}()
 	}
-
-	return <-errc
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+	select {
+	case err = <-errc:
+		return err //there is error in stating service, return immediately
+	case <-stop:
+		//TODO: stop http/gRPC server in grachful style as well.
+		s.Close()
+	}
+	return nil
 }
 
 var (


### PR DESCRIPTION
A simple fix to allow graceful shutdown on the server. 
Try to resolve issue https://github.com/dexidp/dex/issues/1523
but only storage close is implemented at the moment. More should be done on http servers and gRPC server.