### PR TITLE
server: templates: use relative URLs to refer to assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 dist
 _output
+.idea

--- a/server/templates_test.go
+++ b/server/templates_test.go
@@ -1,1 +1,44 @@
 package server
+
+import "testing"
+
+func TestRelativeURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		serverPath string
+		reqPath    string
+		assetPath  string
+		expected   string
+	}{
+		{
+			name:       "server-root-req-one-level-asset-two-level",
+			serverPath: "/",
+			reqPath:    "/auth",
+			assetPath:  "/theme/main.css",
+			expected:   "theme/main.css",
+		},
+		{
+			name:       "server-one-level-req-one-level-asset-two-level",
+			serverPath: "/dex",
+			reqPath:    "/dex/auth",
+			assetPath:  "/theme/main.css",
+			expected:   "theme/main.css",
+		},
+		{
+			name:       "server-root-req-two-level-asset-three-level",
+			serverPath: "/dex",
+			reqPath:    "/dex/auth/connector",
+			assetPath:  "assets/css/main.css",
+			expected:   "../assets/css/main.css",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := relativeURL(test.serverPath, test.reqPath, test.assetPath)
+			if actual != test.expected {
+				t.Fatalf("Got '%s'. Expected '%s'", actual, test.expected)
+			}
+		})
+	}
+}

--- a/web/templates/header.html
+++ b/web/templates/header.html
@@ -5,15 +5,15 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>{{ issuer }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="{{ url "static/main.css" }}" rel="stylesheet">
-    <link href="{{ url "theme/styles.css" }}" rel="stylesheet">
-    <link rel="icon" href="{{ url "theme/favicon.png" }}">
+    <link href="{{ url .ReqPath "static/main.css" }}" rel="stylesheet">
+    <link href="{{ url .ReqPath "theme/styles.css" }}" rel="stylesheet">
+    <link rel="icon" href="{{ url .ReqPath "theme/favicon.png" }}">
   </head>
 
   <body class="theme-body">
     <div class="theme-navbar">
       <div class="theme-navbar__logo-wrap">
-        <img class="theme-navbar__logo" src="{{ logo }}">
+        <img class="theme-navbar__logo" src="{{ url .ReqPath logo }}">
       </div>
     </div>
 


### PR DESCRIPTION
Fixes #1553 

This PR makes sure every template refers to its local assets using a URL relative to the request's URL.

For example:
server listens at localhost/dex so serverPath is dex
reqPath is /dex/auth
assetPath is static/main.css
relativeURL("/dex", "/dex/auth", "static/main.css") = "../static/main.css"

I had to propagate the request's path from each handler down to the templates' data.
I chose to pass the whole http request as a parameter to the template render functions, as it may contain other useful information in the future (eg values from context).
I can change it to only pass down the request's path if it's preferable.


Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>