### PR TITLE
Groups whitelist for SAML connector

### DIFF
--- a/Documentation/connectors/saml.md
+++ b/Documentation/connectors/saml.md
@@ -43,6 +43,13 @@ connectors:
     usernameAttr: name
     emailAttr: email
     groupsAttr: groups # optional
+    
+    # Optional groups whitelist.
+    # If `groups` is omitted, all of the user's groups are returned when the groups scope is present.
+    # If `groups` is provided, this acts as a whitelist - only the user's groups that are in the configured `groups` below will go into the groups claim.  Conversely, if the user is not in any of the configured `groups`, the user will not be authenticated.
+    # groups:
+    # - Admins
+    # - Everyone
 
     # CA's can also be provided inline as a base64'd blob.
     #

--- a/connector/saml/saml_test.go
+++ b/connector/saml/saml_test.go
@@ -52,6 +52,7 @@ type responseTest struct {
 	usernameAttr string
 	emailAttr    string
 	groupsAttr   string
+	groups       []string
 
 	// Expected outcome of the test.
 	wantErr   bool
@@ -85,6 +86,7 @@ func TestGroups(t *testing.T) {
 		usernameAttr: "Name",
 		emailAttr:    "email",
 		groupsAttr:   "groups",
+		groups:       []string{"Admins"},
 		inResponseTo: "6zmm5mguyebwvajyf2sdwwcw6m",
 		redirectURI:  "http://127.0.0.1:5556/dex/callback",
 		wantIdent: connector.Identity{
@@ -92,7 +94,7 @@ func TestGroups(t *testing.T) {
 			Username:      "Eric",
 			Email:         "eric.chiang+okta@coreos.com",
 			EmailVerified: true,
-			Groups:        []string{"Admins", "Everyone"},
+			Groups:        []string{"Admins"},
 		},
 	}
 	test.run(t)
@@ -294,6 +296,7 @@ func (r responseTest) run(t *testing.T) {
 		UsernameAttr: r.usernameAttr,
 		EmailAttr:    r.emailAttr,
 		GroupsAttr:   r.groupsAttr,
+		Groups:       r.groups,
 		RedirectURI:  r.redirectURI,
 		EntityIssuer: r.entityIssuer,
 		// Never logging in, don't need this.


### PR DESCRIPTION
The PR adds possibility to specify allowed groups.
It helps to keep group list modest and send only meaningful groups to application.

Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>