### PR TITLE
Configurable cors support

### DIFF
--- a/Documentation/cors.md
+++ b/Documentation/cors.md
@@ -1,0 +1,91 @@
+# CORS
+
+CORS (cross-origin-resource-sharing) allows servers to specify not only who can access protected resources but also how those resources are accessed. For a more indepth explanation for CORS please refer to https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+
+To successfully make a request to one of Dex's protected endpoints a CORS configuration will have to be set up.
+
+Dex is built on top of Gorilla's router and is able to access the standard CORS package provided by Gorilla. This is accessed via the `handlers` package.
+See `"github.com/gorilla/handlers"` for mor information on included functionality.
+
+## Protected endpoints
+
+Any requests to the following endpoints provided by Dex during runtime is subject to CORS policies
+
+* /token
+* /keys
+* /userinfo
+* /.well-known/openid-configuration
+
+
+## Dex defaults
+
+By default a Dex installation will turn off CORS if the `allowedOrigins` option is not set.
+
+If CORS is turned on by setting the `allowedOrigins`. The following are the default values which will be set.
+* allowedHeaders: "Accept", "Accept-Language", "Content-Language", "Origin"
+* allowedMethods: "GET", "HEAD", "POST"
+* exposedHeaders: {empty}
+* ignoreOptions: false
+* allowCredentials: false
+* maxAge: default 0 seconds, max 600 seconds (10 minutes)
+* optionsStatuscode: 200
+
+
+## CORS configuration
+
+CORS functionality can be setup via the addition of the following items in the yml configuration file under the object `web`
+
+Note: You can choose to omit several of these configurations as they have defaults already. However if you require CORS, you must at least have `allowedOrigins` set. 
+
+```
+# Configuration for the HTTP endpoints.
+web:
+  http: 0.0.0.0:5556
+  # Allow all origins, or use a comma seperated list, If not present CORS is turned off.
+  allowedOrigins: ["*"]
+  # Allow the following specific headers, comma seperated list Note that this is an APPEND operation, you will always get "Accept", "Accept-Language", "Content-Language", "Origin"
+  allowedHeaders: ["custom-header-1", "custom-header-2"]
+  # Allow the following specific methods, comma seperated list. Note that this is a REPLACE operation, you will need to explicitly list all the methods you need to allow.
+  allowedMethods: ["PATCH", "DELETE"]
+  # Exposed headers, these are the headers the server will not strip out. 
+  exposedHeaders: ["custom-header-1", "custom-header-2"]
+  # Ignores request for OPTIONS (default: false)
+  ignoreOptions: true
+  # Allows Credentals to be passed with the request (default: false)
+  allowCredentials: true
+  # Sets the maximum age in seconds between pre-flight requests for OPTIONS (default: 0 seconds, max: 600 seconds)
+  maxAge: 10
+  # Sets a custom status code for the OPTIONS response, default is 200
+  optionsStatuscode: 204
+  
+  # Uncomment for HTTPS options.
+  # https: 127.0.0.1:5554
+  # tlsCert: /etc/dex/tls.crt
+  # tlsKey: /etc/dex/tls.key
+```
+## Swaggerui support with CORS
+Should you wish to test out Dex against a Swaggerui such as https://petstore.swagger.io then you must configure CORS on Dex to support the following:
+ 
+ * allowedHeaders: ["api_key", "Authorization"]
+
+Additionally your swaggerui defintion file must contain the following:
+
+```json
+"securityDefinitions": {
+    "OAuth2": {
+      "type": "oauth2",
+      "flow": "accessCode",
+      "authorizationUrl": "http://localhost:5556/dex/auth",
+      "tokenUrl": "http://localhost:5556/dex/token",
+      "scopes": {
+        "openid": "OpenID Connect scope",
+        "admin": "Grants read and write access to administrative information",
+        "read": "Grants read access",
+        "write": "Grants write access"
+      }
+    }
+  }
+```
+
+
+For more information please refer: https://swagger.io/docs/open-source-tools/swagger-ui/usage/cors/ 

--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -141,6 +141,7 @@ type Web struct {
 	AllowedHeaders []string `json:"allowedHeaders"`
 	AllowedMethods []string `json:"allowedMethods"`
 	IgnoreOptions  bool     `json:"ignoreOptions"`
+	MaxAge         int      `json:"maxAge"`
 }
 
 // Telemetry is the config format for telemetry including the HTTP server config.

--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -139,6 +139,7 @@ type Web struct {
 	TLSKey         string   `json:"tlsKey"`
 	AllowedOrigins []string `json:"allowedOrigins"`
 	AllowedHeaders []string `json:"allowedHeaders"`
+	IgnoreOptions  bool     `json:"ignoreOptions"`
 }
 
 // Telemetry is the config format for telemetry including the HTTP server config.

--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -138,6 +138,7 @@ type Web struct {
 	TLSCert        string   `json:"tlsCert"`
 	TLSKey         string   `json:"tlsKey"`
 	AllowedOrigins []string `json:"allowedOrigins"`
+	AllowedHeaders []string `json:"allowedHeaders"`
 }
 
 // Telemetry is the config format for telemetry including the HTTP server config.

--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -143,6 +143,7 @@ type Web struct {
 	IgnoreOptions     bool     `json:"ignoreOptions"`
 	MaxAge            int      `json:"maxAge"`
 	OptionsStatusCode int      `json:"optionsStatusCode"`
+	ExposedHeaders    []string `json:"exposedHeaders"`
 }
 
 // Telemetry is the config format for telemetry including the HTTP server config.

--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -141,6 +141,7 @@ type Web struct {
 	AllowedHeaders    []string `json:"allowedHeaders"`
 	AllowedMethods    []string `json:"allowedMethods"`
 	IgnoreOptions     bool     `json:"ignoreOptions"`
+	AllowCredentials  bool     `json:"allowCredentials"`
 	MaxAge            int      `json:"maxAge"`
 	OptionsStatusCode int      `json:"optionsStatusCode"`
 	ExposedHeaders    []string `json:"exposedHeaders"`

--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -133,15 +133,16 @@ type OAuth2 struct {
 
 // Web is the config format for the HTTP server.
 type Web struct {
-	HTTP           string   `json:"http"`
-	HTTPS          string   `json:"https"`
-	TLSCert        string   `json:"tlsCert"`
-	TLSKey         string   `json:"tlsKey"`
-	AllowedOrigins []string `json:"allowedOrigins"`
-	AllowedHeaders []string `json:"allowedHeaders"`
-	AllowedMethods []string `json:"allowedMethods"`
-	IgnoreOptions  bool     `json:"ignoreOptions"`
-	MaxAge         int      `json:"maxAge"`
+	HTTP              string   `json:"http"`
+	HTTPS             string   `json:"https"`
+	TLSCert           string   `json:"tlsCert"`
+	TLSKey            string   `json:"tlsKey"`
+	AllowedOrigins    []string `json:"allowedOrigins"`
+	AllowedHeaders    []string `json:"allowedHeaders"`
+	AllowedMethods    []string `json:"allowedMethods"`
+	IgnoreOptions     bool     `json:"ignoreOptions"`
+	MaxAge            int      `json:"maxAge"`
+	OptionsStatusCode int      `json:"optionsStatusCode"`
 }
 
 // Telemetry is the config format for telemetry including the HTTP server config.

--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -139,6 +139,7 @@ type Web struct {
 	TLSKey         string   `json:"tlsKey"`
 	AllowedOrigins []string `json:"allowedOrigins"`
 	AllowedHeaders []string `json:"allowedHeaders"`
+	AllowedMethods []string `json:"allowedMethods"`
 	IgnoreOptions  bool     `json:"ignoreOptions"`
 }
 

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -205,6 +205,9 @@ func serve(cmd *cobra.Command, args []string) error {
 	if len(c.Web.AllowedOrigins) > 0 {
 		logger.Infof("config allowed origins: %s", c.Web.AllowedOrigins)
 	}
+	if len(c.Web.AllowedHeaders) > 0 {
+		logger.Infof("config allowed headers: %s", c.Web.AllowedHeaders)
+	}
 
 	// explicitly convert to UTC.
 	now := func() time.Time { return time.Now().UTC() }

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -214,6 +214,9 @@ func serve(cmd *cobra.Command, args []string) error {
 	if c.Web.IgnoreOptions {
 		logger.Infof("config ignoring OPTIONS requests")
 	}
+	if c.Web.AllowCredentials {
+		logger.Infof("config allow credentials in CORS requests")
+	}
 	if c.Web.MaxAge > 0 {
 		logger.Infof("config CORS max age for preflights set to %d seconds", c.Web.MaxAge)
 	}
@@ -235,6 +238,7 @@ func serve(cmd *cobra.Command, args []string) error {
 		AllowedHeaders:         c.Web.AllowedHeaders,
 		AllowedMethods:         c.Web.AllowedMethods,
 		IgnoreOptions:          c.Web.IgnoreOptions,
+		AllowCredentials:       c.Web.AllowCredentials,
 		MaxAge:                 c.Web.MaxAge,
 		OptionsStatusCode:      c.Web.OptionsStatusCode,
 		ExposedHeaders:         c.Web.ExposedHeaders,

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -208,6 +208,9 @@ func serve(cmd *cobra.Command, args []string) error {
 	if len(c.Web.AllowedHeaders) > 0 {
 		logger.Infof("config allowed headers: %s", c.Web.AllowedHeaders)
 	}
+	if c.Web.IgnoreOptions {
+		logger.Infof("config ignoring OPTIONS requests")
+	}
 
 	// explicitly convert to UTC.
 	now := func() time.Time { return time.Now().UTC() }

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -221,6 +221,7 @@ func serve(cmd *cobra.Command, args []string) error {
 		AlwaysShowLoginScreen:  c.OAuth2.AlwaysShowLoginScreen,
 		AllowedOrigins:         c.Web.AllowedOrigins,
 		AllowedHeaders:         c.Web.AllowedHeaders,
+		IgnoreOptions:          c.Web.IgnoreOptions,
 		Issuer:                 c.Issuer,
 		Storage:                s,
 		Web:                    c.Frontend,

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -218,6 +218,9 @@ func serve(cmd *cobra.Command, args []string) error {
 		logger.Infof("config CORS max age for preflights set to %d seconds", c.Web.MaxAge)
 
 	}
+	if c.Web.OptionsStatusCode > 0 {
+		logger.Infof("config CORS setting custom status code %d", c.Web.OptionsStatusCode)
+	}
 
 	// explicitly convert to UTC.
 	now := func() time.Time { return time.Now().UTC() }
@@ -231,6 +234,7 @@ func serve(cmd *cobra.Command, args []string) error {
 		AllowedMethods:         c.Web.AllowedMethods,
 		IgnoreOptions:          c.Web.IgnoreOptions,
 		MaxAge:                 c.Web.MaxAge,
+		OptionsStatusCode:      c.Web.OptionsStatusCode,
 		Issuer:                 c.Issuer,
 		Storage:                s,
 		Web:                    c.Frontend,

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -214,6 +214,7 @@ func serve(cmd *cobra.Command, args []string) error {
 		SkipApprovalScreen:     c.OAuth2.SkipApprovalScreen,
 		AlwaysShowLoginScreen:  c.OAuth2.AlwaysShowLoginScreen,
 		AllowedOrigins:         c.Web.AllowedOrigins,
+		AllowedHeaders:         c.Web.AllowedHeaders,
 		Issuer:                 c.Issuer,
 		Storage:                s,
 		Web:                    c.Frontend,

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -208,6 +208,9 @@ func serve(cmd *cobra.Command, args []string) error {
 	if len(c.Web.AllowedHeaders) > 0 {
 		logger.Infof("config allowed headers: %s", c.Web.AllowedHeaders)
 	}
+	if len(c.Web.AllowedMethods) > 0 {
+		logger.Infof("config allowed methods: %s", c.Web.AllowedMethods)
+	}
 	if c.Web.IgnoreOptions {
 		logger.Infof("config ignoring OPTIONS requests")
 	}
@@ -221,6 +224,7 @@ func serve(cmd *cobra.Command, args []string) error {
 		AlwaysShowLoginScreen:  c.OAuth2.AlwaysShowLoginScreen,
 		AllowedOrigins:         c.Web.AllowedOrigins,
 		AllowedHeaders:         c.Web.AllowedHeaders,
+		AllowedMethods:         c.Web.AllowedMethods,
 		IgnoreOptions:          c.Web.IgnoreOptions,
 		Issuer:                 c.Issuer,
 		Storage:                s,

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -214,6 +214,10 @@ func serve(cmd *cobra.Command, args []string) error {
 	if c.Web.IgnoreOptions {
 		logger.Infof("config ignoring OPTIONS requests")
 	}
+	if c.Web.MaxAge > 0 {
+		logger.Infof("config CORS max age for preflights set to %d seconds", c.Web.MaxAge)
+
+	}
 
 	// explicitly convert to UTC.
 	now := func() time.Time { return time.Now().UTC() }
@@ -226,6 +230,7 @@ func serve(cmd *cobra.Command, args []string) error {
 		AllowedHeaders:         c.Web.AllowedHeaders,
 		AllowedMethods:         c.Web.AllowedMethods,
 		IgnoreOptions:          c.Web.IgnoreOptions,
+		MaxAge:                 c.Web.MaxAge,
 		Issuer:                 c.Issuer,
 		Storage:                s,
 		Web:                    c.Frontend,

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -216,10 +216,12 @@ func serve(cmd *cobra.Command, args []string) error {
 	}
 	if c.Web.MaxAge > 0 {
 		logger.Infof("config CORS max age for preflights set to %d seconds", c.Web.MaxAge)
-
 	}
 	if c.Web.OptionsStatusCode > 0 {
 		logger.Infof("config CORS setting custom status code %d", c.Web.OptionsStatusCode)
+	}
+	if len(c.Web.ExposedHeaders) > 0 {
+		logger.Infof("config exposed headers: %s", c.Web.ExposedHeaders)
 	}
 
 	// explicitly convert to UTC.
@@ -235,6 +237,7 @@ func serve(cmd *cobra.Command, args []string) error {
 		IgnoreOptions:          c.Web.IgnoreOptions,
 		MaxAge:                 c.Web.MaxAge,
 		OptionsStatusCode:      c.Web.OptionsStatusCode,
+		ExposedHeaders:         c.Web.ExposedHeaders,
 		Issuer:                 c.Issuer,
 		Storage:                s,
 		Web:                    c.Frontend,

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -15,6 +15,15 @@ storage:
 # Configuration for the HTTP endpoints.
 web:
   http: 0.0.0.0:5556
+  # Uncomment for CORS see the CORS document at Documentation/cors.md for further information.
+  # allowedOrigins: ["*"]
+  # allowedHeaders: ["api_key", "Authorization", "x-requested-with"]
+  # allowedMethods: ["GET","PATCH", "POST"]
+  # exposedHeaders: ["header-1", "header-2"]
+  # allowCredentials: false
+  # ignoreOptions: false
+  # maxAge: 10
+  # optionsStatusCode: 204
   # Uncomment for HTTPS options.
   # https: 127.0.0.1:5554
   # tlsCert: /etc/dex/tls.crt

--- a/server/server.go
+++ b/server/server.go
@@ -79,6 +79,9 @@ type Config struct {
 	// The maximum age in seconds between preflight requests.
 	MaxAge int
 
+	// List of headers which the server will not strip out when requests are made
+	ExposedHeaders []string
+
 	// Sets a custom OPTIONS status code by default it is set to 200
 	OptionsStatusCode int
 
@@ -306,6 +309,11 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 
 			if c.OptionsStatusCode > 0 {
 				opts = append(opts, handlers.OptionStatusCode(c.OptionsStatusCode))
+			}
+
+			if len(c.ExposedHeaders) > 0 {
+				// Sets CORS header: Access-Control-Expose-Headers
+				opts = append(opts, handlers.ExposedHeaders(c.ExposedHeaders))
 			}
 
 			handler = handlers.CORS(opts...)(handler)

--- a/server/server.go
+++ b/server/server.go
@@ -79,6 +79,9 @@ type Config struct {
 	// The maximum age in seconds between preflight requests.
 	MaxAge int
 
+	// Sets a custom OPTIONS status code by default it is set to 200
+	OptionsStatusCode int
+
 	// If enabled, the server won't prompt the user to approve authorization requests.
 	// Logging in implies approval.
 	SkipApprovalScreen bool
@@ -299,6 +302,10 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 
 			if c.MaxAge > 0 {
 				opts = append(opts, handlers.MaxAge(c.MaxAge))
+			}
+
+			if c.OptionsStatusCode > 0 {
+				opts = append(opts, handlers.OptionStatusCode(c.OptionsStatusCode))
 			}
 
 			handler = handlers.CORS(opts...)(handler)

--- a/server/server.go
+++ b/server/server.go
@@ -65,16 +65,19 @@ type Config struct {
 	AllowedOrigins []string
 
 	// List of allowed headers for CORS requests on discovery, token and keys endpoint.
-	// If none are indicated, CORS may not work properly.
+	// If none are indicated, CORS will be setup with the default ("Accept", "Accept-Language", "Content-Language", "Origin")
 	AllowedHeaders []string
 
 	// List of allowed methods for CORS requests on discpver, token and keys endpoints.
-	// If none are indicated, CORS requests have the following allowed methods by default ()
+	// If none are indicated, CORS requests have the following allowed methods by default ("GET", "HEAD", "POST")
 	AllowedMethods []string
 
 	// If enabled, the server will not handle requests for OPTIONS from CORS handler.
 	// Instead passing them through to the next handler. This is useful when Dex can handle OPTIONS on its own.
 	IgnoreOptions bool
+
+	// The maximum age in seconds between preflight requests.
+	MaxAge int
 
 	// If enabled, the server won't prompt the user to approve authorization requests.
 	// Logging in implies approval.
@@ -292,6 +295,10 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 
 			if len(c.AllowedMethods) > 0 {
 				opts = append(opts, handlers.AllowedMethods(c.AllowedMethods))
+			}
+
+			if c.MaxAge > 0 {
+				opts = append(opts, handlers.MaxAge(c.MaxAge))
 			}
 
 			handler = handlers.CORS(opts...)(handler)

--- a/server/server.go
+++ b/server/server.go
@@ -64,6 +64,10 @@ type Config struct {
 	// domain.
 	AllowedOrigins []string
 
+	// List of allowed headers for CORS requests on discovery, token and keys endpoint.
+	// If none are indicated, CORS may not work properly.
+	AllowedHeaders []string
+
 	// If enabled, the server won't prompt the user to approve authorization requests.
 	// Logging in implies approval.
 	SkipApprovalScreen bool
@@ -264,9 +268,17 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	}
 	handleWithCORS := func(p string, h http.HandlerFunc) {
 		var handler http.Handler = h
+
 		if len(c.AllowedOrigins) > 0 {
-			corsOption := handlers.AllowedOrigins(c.AllowedOrigins)
-			handler = handlers.CORS(corsOption)(handler)
+			var opts []handlers.CORSOption
+
+			opts = append(opts, handlers.AllowedOrigins(c.AllowedOrigins))
+
+			if len(c.AllowedHeaders) > 0 {
+				opts = append(opts, handlers.AllowedHeaders(c.AllowedHeaders))
+			}
+
+			handler = handlers.CORS(opts...)(handler)
 		}
 		r.Handle(path.Join(issuerURL.Path, p), instrumentHandlerCounter(p, handler))
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -297,14 +297,19 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 				opts = append(opts, handlers.AllowedHeaders(c.AllowedHeaders))
 			}
 
-			if c.IgnoreOptions {
-				// Ignores the CORS request: OPTIONS
-				opts = append(opts, handlers.IgnoreOptions())
-			}
-
 			if len(c.AllowedMethods) > 0 {
 				// Sets CORS header: Access-Control-Allow-Methods
 				opts = append(opts, handlers.AllowedMethods(c.AllowedMethods))
+			}
+
+			if len(c.ExposedHeaders) > 0 {
+				// Sets CORS header: Access-Control-Expose-Headers
+				opts = append(opts, handlers.ExposedHeaders(c.ExposedHeaders))
+			}
+
+			if c.IgnoreOptions {
+				// Ignores the CORS request: OPTIONS
+				opts = append(opts, handlers.IgnoreOptions())
 			}
 
 			if c.MaxAge > 0 {
@@ -315,11 +320,6 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 			if c.OptionsStatusCode > 0 {
 				// Sets a custom OPTIONS status response code. Default 200
 				opts = append(opts, handlers.OptionStatusCode(c.OptionsStatusCode))
-			}
-
-			if len(c.ExposedHeaders) > 0 {
-				// Sets CORS header: Access-Control-Expose-Headers
-				opts = append(opts, handlers.ExposedHeaders(c.ExposedHeaders))
 			}
 
 			handler = handlers.CORS(opts...)(handler)

--- a/server/server.go
+++ b/server/server.go
@@ -68,6 +68,10 @@ type Config struct {
 	// If none are indicated, CORS may not work properly.
 	AllowedHeaders []string
 
+	// List of allowed methods for CORS requests on discpver, token and keys endpoints.
+	// If none are indicated, CORS requests have the following allowed methods by default ()
+	AllowedMethods []string
+
 	// If enabled, the server will not handle requests for OPTIONS from CORS handler.
 	// Instead passing them through to the next handler. This is useful when Dex can handle OPTIONS on its own.
 	IgnoreOptions bool
@@ -284,6 +288,10 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 
 			if c.IgnoreOptions {
 				opts = append(opts, handlers.IgnoreOptions())
+			}
+
+			if len(c.AllowedMethods) > 0 {
+				opts = append(opts, handlers.AllowedMethods(c.AllowedMethods))
 			}
 
 			handler = handlers.CORS(opts...)(handler)

--- a/server/server.go
+++ b/server/server.go
@@ -68,6 +68,10 @@ type Config struct {
 	// If none are indicated, CORS may not work properly.
 	AllowedHeaders []string
 
+	// If enabled, the server will not handle requests for OPTIONS from CORS handler.
+	// Instead passing them through to the next handler. This is useful when Dex can handle OPTIONS on its own.
+	IgnoreOptions bool
+
 	// If enabled, the server won't prompt the user to approve authorization requests.
 	// Logging in implies approval.
 	SkipApprovalScreen bool
@@ -276,6 +280,10 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 
 			if len(c.AllowedHeaders) > 0 {
 				opts = append(opts, handlers.AllowedHeaders(c.AllowedHeaders))
+			}
+
+			if c.IgnoreOptions {
+				opts = append(opts, handlers.IgnoreOptions())
 			}
 
 			handler = handlers.CORS(opts...)(handler)

--- a/server/server.go
+++ b/server/server.go
@@ -76,6 +76,9 @@ type Config struct {
 	// Instead passing them through to the next handler. This is useful when Dex can handle OPTIONS on its own.
 	IgnoreOptions bool
 
+	// if enabled, the server will allow credentials to be passed along with the request.
+	AllowCredentials bool
+
 	// The maximum age in seconds between preflight requests.
 	MaxAge int
 
@@ -310,6 +313,11 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 			if c.IgnoreOptions {
 				// Ignores the CORS request: OPTIONS
 				opts = append(opts, handlers.IgnoreOptions())
+			}
+
+			if c.AllowCredentials {
+				// Sets CORS header: Access-Control-Allow-Credentials
+				opts = append(opts, handlers.AllowCredentials())
 			}
 
 			if c.MaxAge > 0 {

--- a/server/server.go
+++ b/server/server.go
@@ -289,25 +289,31 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 		if len(c.AllowedOrigins) > 0 {
 			var opts []handlers.CORSOption
 
+			// Sets CORS header: Access-Control-Allow-Origin
 			opts = append(opts, handlers.AllowedOrigins(c.AllowedOrigins))
 
 			if len(c.AllowedHeaders) > 0 {
+				// Sets CORS header: Access-Control-Allow-Headers
 				opts = append(opts, handlers.AllowedHeaders(c.AllowedHeaders))
 			}
 
 			if c.IgnoreOptions {
+				// Ignores the CORS request: OPTIONS
 				opts = append(opts, handlers.IgnoreOptions())
 			}
 
 			if len(c.AllowedMethods) > 0 {
+				// Sets CORS header: Access-Control-Allow-Methods
 				opts = append(opts, handlers.AllowedMethods(c.AllowedMethods))
 			}
 
 			if c.MaxAge > 0 {
+				// Sets the CORS header: Access-Control-Max-Age. This is the maximum age in seconds between preflight (OPTIONS) requests, default 0, max 600 seconds (10 minutes)
 				opts = append(opts, handlers.MaxAge(c.MaxAge))
 			}
 
 			if c.OptionsStatusCode > 0 {
+				// Sets a custom OPTIONS status response code. Default 200
 				opts = append(opts, handlers.OptionStatusCode(c.OptionsStatusCode))
 			}
 


### PR DESCRIPTION
Adds support for configuring all options present in Gorilla's CORS handler. All options configurable via an entry under the `Web` object in the configuration yml file.

// Access-Control-Allow-Origin
* allowedOrigins: ["*"]
// Access-Control-Allow-Headers
* allowedHeaders: ["custom-header-1", "custom-header-2"]
// Access-Control-Allow-Methods
* allowedMethods: ["PATCH", "DELETE"]
// Access-Control-Expose-Headers
* exposedHeaders: ["custom-header-1", "custom-header-2"] 
* ignoreOptions: true
// Access-Control-Allow-Credentials
* allowCredentials: true
// Access-Control-Max-Age
* maxAge: 10
* optionsStatuscode: 204

See Documentation/cors.md for more details