### PR TITLE
[WIP] Add basic session management for certain connectors

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -37,6 +37,12 @@ type Identity struct {
 	ConnectorData []byte
 }
 
+type Session struct {
+	ConnectorID string
+	Username    string
+	ValidUntil  string
+}
+
 // PasswordConnector is an interface implemented by connectors which take a
 // username and password.
 // Prompt() is used to inform the handler what to display in the password
@@ -96,4 +102,12 @@ type RefreshConnector interface {
 	// connector should attempt to update the identity object to reflect any
 	// changes since the token was last refreshed.
 	Refresh(ctx context.Context, s Scopes, identity Identity) (Identity, error)
+}
+
+// SessionConnector is an interface implemented by connectors which allow session
+// management.
+// SessionValid() is used to check whether an existing session is still valid.
+// It returns current identity information when called.
+type SessionConnector interface {
+	SessionValid(ctx context.Context, s Scopes, session Session) (identity Identity, validSession bool, err error)
 }

--- a/connector/mock/connectortest.go
+++ b/connector/mock/connectortest.go
@@ -33,6 +33,7 @@ var (
 
 	_ connector.PasswordConnector = passwordConnector{}
 	_ connector.RefreshConnector  = passwordConnector{}
+	_ connector.SessionConnector  = passwordConnector{}
 )
 
 // Callback is a connector that requires no user interaction and always returns the same identity.
@@ -116,4 +117,16 @@ func (p passwordConnector) Prompt() string { return "" }
 
 func (p passwordConnector) Refresh(_ context.Context, _ connector.Scopes, identity connector.Identity) (connector.Identity, error) {
 	return identity, nil
+}
+
+func (p passwordConnector) SessionValid(_ context.Context, _ connector.Scopes, session connector.Session) (connector.Identity, validSession bool, error) {
+	if session.Username == p.username {
+		return connector.Identity{
+			UserID:        "0-385-28089-0",
+			Username:      "Kilgore Trout",
+			Email:         "kilgore@kilgore.trout",
+			EmailVerified: true,
+		}, true, nil
+	}
+	return identity, false, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -539,3 +539,12 @@ func (s *Server) getConnector(id string) (Connector, error) {
 
 	return conn, nil
 }
+
+func (s *Server) getActiveSession(r *http.Request) (session connector.Session, validSession bool) {
+	// TODO: implement
+	return connector.Session{}, false
+}
+
+func (s *Server) storeSession(w http.ResponseWriter, connectorID string, username string, identity connector.Identity) {
+	// TODO: implement
+}


### PR DESCRIPTION
After reading #32 (and wanting such a feature, but for LDAP) I decided to try to add some basic session management. I've created a skeleton -- the cookie handling and configuration is missing -- to get some feedback, whether this is the right direction and approach.

The idea is as follows: when you authenticate with a connector which supports the `SessionConnector` interface (and when this is configured), a cookie is set which contains information on the used connector, the username, and when it expires (should be a JWT or something like that, so that the user can't just modify or fake it). If this cookie is found when the user wants to autenticate and it is still valid, the connector will be asked whether this user is still valid, and if it is, the user will be authenticated directly.

This mostly makes sense for password-based connectors. I've implemented it for the mock connector and the LDAP connector.