### PR TITLE
Pick icons on login screen by connector type instead of ID

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -259,16 +259,15 @@ func (s *Server) handleAuthorization(w http.ResponseWriter, r *http.Request) {
 	}
 
 	connectorInfos := make([]connectorInfo, len(connectors))
-	i := 0
-	for _, conn := range connectors {
-		connectorInfos[i] = connectorInfo{
+	for index, conn := range connectors {
+		connectorInfos[index] = connectorInfo{
 			ID:   conn.ID,
 			Name: conn.Name,
+			Type: conn.Type,
 			// TODO(ericchiang): Make this pass on r.URL.RawQuery and let something latter
 			// on create the auth request.
 			URL: s.absPath("/auth", conn.ID) + "?req=" + authReq.ID,
 		}
-		i++
 	}
 
 	if err := s.templates.login(r, w, connectorInfos, r.URL.Path); err != nil {

--- a/server/templates.go
+++ b/server/templates.go
@@ -246,6 +246,7 @@ type connectorInfo struct {
 	ID   string
 	Name string
 	URL  string
+	Type string
 }
 
 type byName []connectorInfo

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -68,12 +68,12 @@ body {
   background-size: contain;
 }
 
-.dex-btn-icon--bitbucket {
+.dex-btn-icon--bitbucket-cloud {
   background-color: #205081;
   background-image: url(../static/img/bitbucket-icon.svg);
 }
 
-.dex-btn-icon--ldap, .dex-btn-icon--tectonic-ldap {
+.dex-btn-icon--ldap {
   background-color: #84B6EF;
   background-image: url(../static/img/ldap-icon.svg);
 }

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -7,7 +7,7 @@
       <div class="theme-form-row">
         <a href="{{ $c.URL }}" target="_self">
           <button class="dex-btn theme-btn-provider">
-            <span class="dex-btn-icon dex-btn-icon--{{ $c.ID }}"></span>
+            <span class="dex-btn-icon dex-btn-icon--{{ $c.Type }}"></span>
             <span class="dex-btn-text">Log in with {{ $c.Name }}</span>
           </button>
         </a>


### PR DESCRIPTION
We are picking icons by provider ID. For example:
1. User can type anything into ID field.
2. ID field don't match any css class name with icon
3. User have no icon even if he picked provider with predefined icon (github, gitlab, etc.)

Using type field will make user always have icons for all providers on login screen.
Because we know all possible provider types and can prepare icons for them.

Only icons that don't fit into the logic now is google-icon.svg and coreos-icon.svg.


Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>