### PR TITLE
connector/authproxy: supports groups claim

### DIFF
--- a/Documentation/connectors/authproxy.md
+++ b/Documentation/connectors/authproxy.md
@@ -85,6 +85,8 @@ configuration will work for Apache 2.4.10+:
 
     # Requires Apache 2.4.10+
     RequestHeader set X-Remote-User expr=%{REMOTE_USER}@debian.org
+    RequestHeader set X-Remote-Group first-group
+    RequestHeader set X-Remote-Group second-group
 
     ProxyPass "http://localhost:5556/dex/callback/myBasicAuth"
     ProxyPassReverse "http://localhost:5556/dex/callback/myBasicAuth"
@@ -128,6 +130,8 @@ virtual host configuration in e.g. `/etc/apache2/sites-available/sso.conf`:
 
         # Requires Apache 2.4.10+
         RequestHeader set X-Remote-User expr=%{REMOTE_USER}@debian.org
+        RequestHeader set X-Remote-Group first-group
+        RequestHeader set X-Remote-Group second-group
 
         ProxyPass "http://localhost:5556/dex/callback/myBasicAuth"
         ProxyPassReverse "http://localhost:5556/dex/callback/myBasicAuth"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Dex implements the following connectors:
 | [Google](Documentation/connectors/google.md) | yes | yes | yes | alpha | |
 | [LinkedIn](Documentation/connectors/linkedin.md) | yes | no | no | beta | |
 | [Microsoft](Documentation/connectors/microsoft.md) | yes | yes | no | beta | |
-| [AuthProxy](Documentation/connectors/authproxy.md) | no | no | no | alpha | Authentication proxies such as Apache2 mod_auth, etc. |
+| [AuthProxy](Documentation/connectors/authproxy.md) | no | yes | no | alpha | Authentication proxies such as Apache2 mod_auth, etc. |
 | [Bitbucket Cloud](Documentation/connectors/bitbucketcloud.md) | yes | yes | no | alpha | |
 | [OpenShift](Documentation/connectors/openshift.md) | no | yes | no | stable | |
 


### PR DESCRIPTION
The groups are collected from the X-Remote-Group headers as it is
proposed at https://kubernetes.io/docs/admin/authentication/#authenticating-proxy.

The X-Remote-User header is handled as email address only if it contains
"@" character, and the Username is derived before the "@" sign.

The UserID of the Identity is not set because we do not have any
knowledge of the proxied authentication how should that be handled.