### PR TITLE
Deprecated oauth2.RegisterBrokenAuthHeaderProvider

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/coreos/go-oidc"
@@ -85,18 +84,6 @@ func knownBrokenAuthHeaderProvider(issuerURL string) bool {
 	return false
 }
 
-// golang.org/x/oauth2 doesn't do internal locking. Need to do it in this
-// package ourselves and hope that other packages aren't calling it at the
-// same time.
-var registerMu = new(sync.Mutex)
-
-func registerBrokenAuthHeaderProvider(url string) {
-	registerMu.Lock()
-	defer registerMu.Unlock()
-
-	oauth2.RegisterBrokenAuthHeaderProvider(url)
-}
-
 // Open returns a connector which can be used to login users through an upstream
 // OpenID Connect provider.
 func (c *Config) Open(id string, logger log.Logger) (conn connector.Connector, err error) {
@@ -108,13 +95,15 @@ func (c *Config) Open(id string, logger log.Logger) (conn connector.Connector, e
 		return nil, fmt.Errorf("failed to get provider: %v", err)
 	}
 
+	endpoint := provider.Endpoint()
+
 	if c.BasicAuthUnsupported != nil {
 		// Setting "basicAuthUnsupported" always overrides our detection.
 		if *c.BasicAuthUnsupported {
-			registerBrokenAuthHeaderProvider(provider.Endpoint().TokenURL)
+			endpoint.AuthStyle = oauth2.AuthStyleInParams
 		}
 	} else if knownBrokenAuthHeaderProvider(c.Issuer) {
-		registerBrokenAuthHeaderProvider(provider.Endpoint().TokenURL)
+		endpoint.AuthStyle = oauth2.AuthStyleInParams
 	}
 
 	scopes := []string{oidc.ScopeOpenID}
@@ -131,7 +120,7 @@ func (c *Config) Open(id string, logger log.Logger) (conn connector.Connector, e
 		oauth2Config: &oauth2.Config{
 			ClientID:     clientID,
 			ClientSecret: c.ClientSecret,
-			Endpoint:     provider.Endpoint(),
+			Endpoint:     endpoint,
 			Scopes:       scopes,
 			RedirectURL:  c.RedirectURI,
 		},

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -111,6 +111,7 @@ func TestHandleCallback(t *testing.T) {
 			}
 			defer testServer.Close()
 			serverURL := testServer.URL
+			basicAuth := true
 			config := Config{
 				Issuer:                    serverURL,
 				ClientID:                  "clientID",
@@ -120,6 +121,7 @@ func TestHandleCallback(t *testing.T) {
 				UserIDKey:                 tc.userIDKey,
 				UserNameKey:               tc.userNameKey,
 				InsecureSkipEmailVerified: tc.insecureSkipEmailVerified,
+				BasicAuthUnsupported:      &basicAuth,
 			}
 
 			conn, err := newConnector(config)


### PR DESCRIPTION
`ouath2.RegisterBrokenAuthHeaderProvider()` is deprecated and now behaves as a noop.

This modifies `connector/oidc` to set `oauth2.Endpoint.AuthStyle` in its place. 

The `sync.Mutex` that guarded `oauth2.RegisterBrokenAuthHeaderProvider` became vestigal, so it was removed.