### PR TITLE
Fixed mysql EOF issue

### DIFF
--- a/storage/sql/config.go
+++ b/storage/sql/config.go
@@ -308,6 +308,13 @@ func (s *MySQL) open(logger log.Logger) (*conn, error) {
 		return nil, err
 	}
 
+	if s.MaxIdleConns == 0 {
+		/*Override default behaviour to fix https://github.com/dexidp/dex/issues/1608*/
+		db.SetMaxIdleConns(0)
+	} else {
+		db.SetMaxIdleConns(s.MaxIdleConns)
+	}
+
 	err = db.Ping()
 	if err != nil {
 		if mysqlErr, ok := err.(*mysql.MySQLError); ok && mysqlErr.Number == mysqlErrUnknownSysVar {


### PR DESCRIPTION
The upstream package that Dex uses for MySQL storage support has the following bug https://github.com/go-sql-driver/mysql/issues/674.

This addition to the config.go file removes the dex based default of 5 idle DB connections when using the go-SQL-driver for MySQL.

fixes issue https://github.com/dexidp/dex/issues/1608