### PR TITLE
Client Credentials Grant

### DIFF
--- a/connector/authproxy/authproxy.go
+++ b/connector/authproxy/authproxy.go
@@ -83,20 +83,20 @@ type callback struct {
 }
 
 // LoginURL returns the URL to redirect the user to login with.
-func (m *callback) LoginURL(s connector.Scopes, callbackURL, state string) (string, error) {
+func (m *callback) LoginURL(s connector.Scopes, callbackURL, state string) (string, []byte, error) {
 	u, err := url.Parse(callbackURL)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse callbackURL %q: %v", callbackURL, err)
+		return "", nil, fmt.Errorf("failed to parse callbackURL %q: %v", callbackURL, err)
 	}
 	u.Path += m.pathSuffix
 	v := u.Query()
 	v.Set("state", state)
 	u.RawQuery = v.Encode()
-	return u.String(), nil
+	return u.String(), nil, nil
 }
 
 // HandleCallback parses the request and returns the user's identity
-func (m *callback) HandleCallback(s connector.Scopes, r *http.Request) (connector.Identity, error) {
+func (m *callback) HandleCallback(s connector.Scopes, _ []byte, r *http.Request) (connector.Identity, error) {
 	remoteUser := r.Header.Get(m.userHeader)
 	if remoteUser == "" {
 		return connector.Identity{}, fmt.Errorf("required HTTP header %s is not set", m.userHeader)

--- a/connector/authproxy/authproxy_test.go
+++ b/connector/authproxy/authproxy_test.go
@@ -36,7 +36,7 @@ func TestUser(t *testing.T) {
 		"X-Remote-User": {testUsername},
 	}
 
-	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, nil, req)
 	expectNil(t, err)
 
 	// If not specified, the userID and email should fall back to the remote user
@@ -62,7 +62,7 @@ func TestExtraHeaders(t *testing.T) {
 		"X-Remote-User-Email": {testEmail},
 	}
 
-	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, nil, req)
 	expectNil(t, err)
 
 	expectEquals(t, ident.UserID, testUserID)
@@ -85,7 +85,7 @@ func TestSingleGroup(t *testing.T) {
 		"X-Remote-Group": {testGroup1},
 	}
 
-	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, nil, req)
 	expectNil(t, err)
 
 	expectEquals(t, ident.UserID, testEmail)
@@ -106,7 +106,7 @@ func TestMultipleGroup(t *testing.T) {
 		"X-Remote-Group": {testGroup1 + ", " + testGroup2 + ", " + testGroup3 + ", " + testGroup4},
 	}
 
-	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, nil, req)
 	expectNil(t, err)
 
 	expectEquals(t, ident.UserID, testEmail)
@@ -132,7 +132,7 @@ func TestMultipleGroupWithCustomSeparator(t *testing.T) {
 		"X-Remote-Group": {testGroup1 + ";" + testGroup2 + ";" + testGroup3 + ";" + testGroup4},
 	}
 
-	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, nil, req)
 	expectNil(t, err)
 
 	expectEquals(t, ident.UserID, testEmail)
@@ -158,7 +158,7 @@ func TestStaticGroup(t *testing.T) {
 		"X-Remote-Group": {testGroup1 + ", " + testGroup2 + ", " + testGroup3 + ", " + testGroup4},
 	}
 
-	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, nil, req)
 	expectNil(t, err)
 
 	expectEquals(t, ident.UserID, testEmail)

--- a/connector/oauth/oauth.go
+++ b/connector/oauth/oauth.go
@@ -116,9 +116,9 @@ func (c *Config) Open(id string, logger *slog.Logger) (connector.Connector, erro
 	return oauthConn, err
 }
 
-func (c *oauthConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
+func (c *oauthConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, []byte, error) {
 	if c.redirectURI != callbackURL {
-		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
+		return "", nil, fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}
 
 	oauth2Config := &oauth2.Config{
@@ -129,10 +129,10 @@ func (c *oauthConnector) LoginURL(scopes connector.Scopes, callbackURL, state st
 		Scopes:       c.scopes,
 	}
 
-	return oauth2Config.AuthCodeURL(state), nil
+	return oauth2Config.AuthCodeURL(state), nil, nil
 }
 
-func (c *oauthConnector) HandleCallback(s connector.Scopes, r *http.Request) (identity connector.Identity, err error) {
+func (c *oauthConnector) HandleCallback(s connector.Scopes, _ []byte, r *http.Request) (identity connector.Identity, err error) {
 	q := r.URL.Query()
 	if errType := q.Get("error"); errType != "" {
 		return identity, errors.New(q.Get("error_description"))

--- a/connector/oauth/oauth_test.go
+++ b/connector/oauth/oauth_test.go
@@ -50,7 +50,7 @@ func TestLoginURL(t *testing.T) {
 
 	conn := newConnector(t, testServer.URL)
 
-	loginURL, err := conn.LoginURL(connector.Scopes{}, conn.redirectURI, "some-state")
+	loginURL, _, err := conn.LoginURL(connector.Scopes{}, conn.redirectURI, "some-state")
 	assert.Equal(t, err, nil)
 
 	expectedURL, err := url.Parse(testServer.URL + "/authorize")
@@ -86,7 +86,7 @@ func TestHandleCallBackForGroupsInUserInfo(t *testing.T) {
 	conn := newConnector(t, testServer.URL)
 	req := newRequestWithAuthCode(t, testServer.URL, "TestHandleCallBackForGroupsInUserInfo")
 
-	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 	assert.Equal(t, err, nil)
 
 	sort.Strings(identity.Groups)
@@ -122,7 +122,7 @@ func TestHandleCallBackForGroupMapsInUserInfo(t *testing.T) {
 	conn := newConnector(t, testServer.URL)
 	req := newRequestWithAuthCode(t, testServer.URL, "TestHandleCallBackForGroupMapsInUserInfo")
 
-	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 	assert.Equal(t, err, nil)
 
 	sort.Strings(identity.Groups)
@@ -156,7 +156,7 @@ func TestHandleCallBackForGroupsInToken(t *testing.T) {
 	conn := newConnector(t, testServer.URL)
 	req := newRequestWithAuthCode(t, testServer.URL, "TestHandleCallBackForGroupsInToken")
 
-	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 	assert.Equal(t, err, nil)
 
 	assert.Equal(t, len(identity.Groups), 1)
@@ -186,7 +186,7 @@ func TestHandleCallbackForNumericUserID(t *testing.T) {
 	conn := newConnector(t, testServer.URL)
 	req := newRequestWithAuthCode(t, testServer.URL, "TestHandleCallbackForNumericUserID")
 
-	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 	assert.Equal(t, err, nil)
 
 	assert.Equal(t, identity.UserID, "1000")

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -889,6 +889,8 @@ func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
 		s.withClientFromStorage(w, r, s.handlePasswordGrant)
 	case grantTypeTokenExchange:
 		s.withClientFromStorage(w, r, s.handleTokenExchange)
+	case grantTypeClientCredentials:
+		s.withClientFromStorage(w, r, s.handleClientCredentialsGrant)
 	default:
 		s.tokenErrHelper(w, errUnsupportedGrantType, "", http.StatusBadRequest)
 	}
@@ -1141,6 +1143,29 @@ func (s *Server) handleUserInfo(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(claims)
+}
+
+func (s *Server) handleClientCredentialsGrant(w http.ResponseWriter, r *http.Request, client storage.Client) {
+	if err := r.ParseForm(); err != nil {
+		s.tokenErrHelper(w, errInvalidRequest, "Couldn't parse data", http.StatusBadRequest)
+		return
+	}
+	q := r.Form
+
+	nonce := q.Get("nonce")
+	scopes := strings.Fields(q.Get("scope"))
+
+	claims := storage.Claims{UserID: client.ID}
+
+	accessToken := storage.NewID()
+	idToken, expiry, err := s.newIDToken(r.Context(), client.ID, claims, scopes, nonce, accessToken, "", "client")
+	if err != nil {
+		s.tokenErrHelper(w, errServerError, fmt.Sprintf("failed to create ID token: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	resp := s.toAccessTokenResponse(idToken, accessToken, "", expiry)
+	s.writeAccessToken(w, resp)
 }
 
 func (s *Server) handlePasswordGrant(w http.ResponseWriter, r *http.Request, client storage.Client) {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1157,7 +1157,13 @@ func (s *Server) handleClientCredentialsGrant(w http.ResponseWriter, r *http.Req
 
 	claims := storage.Claims{UserID: client.ID}
 
-	accessToken := storage.NewID()
+	accessToken, _, err := s.newAccessToken(r.Context(), client.ID, claims, scopes, nonce, "client")
+	if err != nil {
+		s.logger.ErrorContext(r.Context(), "failed to create new access token", "err", err)
+		s.tokenErrHelper(w, errServerError, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	idToken, expiry, err := s.newIDToken(r.Context(), client.ID, claims, scopes, nonce, accessToken, "", "client")
 	if err != nil {
 		s.tokenErrHelper(w, errServerError, fmt.Sprintf("failed to create ID token: %v", err), http.StatusInternalServerError)

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -62,6 +62,7 @@ func TestHandleDiscovery(t *testing.T) {
 		Introspect:     fmt.Sprintf("%s/token/introspect", httpServer.URL),
 		GrantTypes: []string{
 			"authorization_code",
+			"client_credentials",
 			"refresh_token",
 			"urn:ietf:params:oauth:grant-type:device_code",
 			"urn:ietf:params:oauth:grant-type:token-exchange",

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -143,6 +143,7 @@ const (
 	grantTypePassword          = "password"
 	grantTypeDeviceCode        = "urn:ietf:params:oauth:grant-type:device_code"
 	grantTypeTokenExchange     = "urn:ietf:params:oauth:grant-type:token-exchange"
+	grantTypeClientCredentials = "client_credentials"
 )
 
 const (

--- a/server/server.go
+++ b/server/server.go
@@ -233,6 +233,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		grantTypeRefreshToken:      true,
 		grantTypeDeviceCode:        true,
 		grantTypeTokenExchange:     true,
+		grantTypeClientCredentials: true,
 	}
 	supportedRes := make(map[string]bool)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -107,6 +107,7 @@ func newTestServer(t *testing.T, updateConfig func(c *Config)) (*httptest.Server
 			grantTypeTokenExchange,
 			grantTypeImplicit,
 			grantTypePassword,
+			grantTypeClientCredentials,
 		},
 		Signer: sig,
 	}
@@ -1774,7 +1775,7 @@ func TestServerSupportedGrants(t *testing.T) {
 		{
 			name:      "Simple",
 			config:    func(c *Config) {},
-			resGrants: []string{grantTypeAuthorizationCode, grantTypeRefreshToken, grantTypeDeviceCode, grantTypeTokenExchange},
+			resGrants: []string{grantTypeAuthorizationCode, grantTypeClientCredentials, grantTypeRefreshToken, grantTypeDeviceCode, grantTypeTokenExchange},
 		},
 		{
 			name:      "Minimal",
@@ -1784,12 +1785,12 @@ func TestServerSupportedGrants(t *testing.T) {
 		{
 			name:      "With password connector",
 			config:    func(c *Config) { c.PasswordConnector = "local" },
-			resGrants: []string{grantTypeAuthorizationCode, grantTypePassword, grantTypeRefreshToken, grantTypeDeviceCode, grantTypeTokenExchange},
+			resGrants: []string{grantTypeAuthorizationCode, grantTypeClientCredentials, grantTypePassword, grantTypeRefreshToken, grantTypeDeviceCode, grantTypeTokenExchange},
 		},
 		{
 			name:      "With token response",
 			config:    func(c *Config) { c.SupportedResponseTypes = append(c.SupportedResponseTypes, responseTypeToken) },
-			resGrants: []string{grantTypeAuthorizationCode, grantTypeImplicit, grantTypeRefreshToken, grantTypeDeviceCode, grantTypeTokenExchange},
+			resGrants: []string{grantTypeAuthorizationCode, grantTypeClientCredentials, grantTypeImplicit, grantTypeRefreshToken, grantTypeDeviceCode, grantTypeTokenExchange},
 		},
 		{
 			name: "All",
@@ -1797,7 +1798,7 @@ func TestServerSupportedGrants(t *testing.T) {
 				c.PasswordConnector = "local"
 				c.SupportedResponseTypes = append(c.SupportedResponseTypes, responseTypeToken)
 			},
-			resGrants: []string{grantTypeAuthorizationCode, grantTypeImplicit, grantTypePassword, grantTypeRefreshToken, grantTypeDeviceCode, grantTypeTokenExchange},
+			resGrants: []string{grantTypeAuthorizationCode, grantTypeClientCredentials, grantTypeImplicit, grantTypePassword, grantTypeRefreshToken, grantTypeDeviceCode, grantTypeTokenExchange},
 		},
 	}
 

--- a/storage/sql/sql.go
+++ b/storage/sql/sql.go
@@ -95,7 +95,7 @@ var (
 			// For compound indexes (with two keys) even less.
 			{matchLiteral("text"), "varchar(384)"},
 			// Quote keywords and reserved words used as identifiers.
-			{regexp.MustCompile(`\b(keys)\b`), "`$1`"},
+			{regexp.MustCompile(`\b(keys|groups)\b`), "`$1`"},
 			// Change default timestamp to fit datetime.
 			{regexp.MustCompile(`0001-01-01 00:00:00 UTC`), "1000-01-01 00:00:00"},
 		},


### PR DESCRIPTION
so client can get access to Dex resources e.g. forwarding auth request and performing token exchange while handling callback from Dex.