### PR TITLE
Wrap Kubernetes host address in square brackets

### DIFF
--- a/storage/kubernetes/client.go
+++ b/storage/kubernetes/client.go
@@ -415,6 +415,9 @@ func inClusterConfig() (cluster k8sapi.Cluster, user k8sapi.AuthInfo, namespace 
 		err = fmt.Errorf("unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined")
 		return
 	}
+	// we need to wrap IPv6 addresses in square brackets
+	// IPv4 also works with square brackets
+	host = "[" + host + "]"
 	cluster = k8sapi.Cluster{
 		Server:               "https://" + host + ":" + port,
 		CertificateAuthority: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",


### PR DESCRIPTION
When constructing the host address string, the address is
not wrapped in square brackets. This does not work in IPv6
Kubernetes deployments. This commit adds square brackets
around the address. IPv4 was also tested to ensure it works
with wrapped address.

fixes #1643

Signed-off-by: Jerry Sun <jerry.sun@windriver.com>