### PR TITLE
Make prompt configurable for oidc offline_access

### DIFF
--- a/Documentation/connectors/oidc.md
+++ b/Documentation/connectors/oidc.md
@@ -83,6 +83,11 @@ connectors:
     # The set claim is used as user name.
     # Default: name
     # userNameKey: nickname
+
+    # For offline_access, the prompt parameter is set by default to "prompt=consent". 
+    # However this is not supported by all OIDC providers, some of them support different
+    # value for prompt, like "prompt=login" or "prompt=none"
+    # promptType: consent
 ```
 
 [oidc-doc]: openid-connect.md

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -54,6 +54,9 @@ type Config struct {
 
 	// Configurable key which contains the user name claim
 	UserNameKey string `json:"userNameKey"`
+
+	// PromptType will be used fot the prompt parameter (when offline_access, by default prompt=consent)
+	PromptType string `json:"promptType"`
 }
 
 // Domains that don't support basic auth. golang.org/x/oauth2 has an internal
@@ -113,6 +116,11 @@ func (c *Config) Open(id string, logger log.Logger) (conn connector.Connector, e
 		scopes = append(scopes, "profile", "email")
 	}
 
+	// PromptType should be "consent" by default, if not set
+	if c.PromptType == "" {
+		c.PromptType = "consent"
+	}
+
 	clientID := c.ClientID
 	return &oidcConnector{
 		provider:    provider,
@@ -135,6 +143,7 @@ func (c *Config) Open(id string, logger log.Logger) (conn connector.Connector, e
 		getUserInfo:               c.GetUserInfo,
 		userIDKey:                 c.UserIDKey,
 		userNameKey:               c.UserNameKey,
+		promptType:                c.PromptType,
 	}, nil
 }
 
@@ -156,6 +165,7 @@ type oidcConnector struct {
 	getUserInfo               bool
 	userIDKey                 string
 	userNameKey               string
+	promptType                string
 }
 
 func (c *oidcConnector) Close() error {
@@ -178,7 +188,7 @@ func (c *oidcConnector) LoginURL(s connector.Scopes, callbackURL, state string) 
 	}
 
 	if s.OfflineAccess {
-		opts = append(opts, oauth2.AccessTypeOffline, oauth2.SetAuthURLParam("prompt", "consent"))
+		opts = append(opts, oauth2.AccessTypeOffline, oauth2.SetAuthURLParam("prompt", c.promptType))
 	}
 	return c.oauth2Config.AuthCodeURL(state, opts...), nil
 }


### PR DESCRIPTION
For OIDC offline_access, the `prompt` used to be hardcoded to `consent`:
```
opts = append(opts, oauth2.AccessTypeOffline, oauth2.SetAuthURLParam("prompt", "consent"))
```

However, in some OIDC provides this value is not supported (e.g. OneLogin: https://developers.onelogin.com/openid-connect/api/id-token) where it states:

> Optional. If used must be set to one of the following:
> - login - The user will be prompted with a login dialog.
> - none - The user will not be prompted with a login dialog. If they do not have a current session a login_required error will be returned.
> 

This adds the `promptType` param, set by default to `consent` but with the ability to explicitly set it in the config and override it.
