### PR TITLE
Setting email for OpenShift connector

### DIFF
--- a/connector/openshift/openshift.go
+++ b/connector/openshift/openshift.go
@@ -177,6 +177,7 @@ func (c *openshiftConnector) HandleCallback(s connector.Scopes, r *http.Request)
 		UserID:            user.UID,
 		Username:          user.Name,
 		PreferredUsername: user.Name,
+		Email:             user.Name,
 		Groups:            user.Groups,
 	}
 

--- a/connector/openshift/openshift_test.go
+++ b/connector/openshift/openshift_test.go
@@ -180,6 +180,7 @@ func TestCallbackIdentity(t *testing.T) {
 	expectEquals(t, identity.UserID, "12345")
 	expectEquals(t, identity.Username, "jdoe")
 	expectEquals(t, identity.PreferredUsername, "jdoe")
+	expectEquals(t, identity.Email, "jdoe")
 	expectEquals(t, len(identity.Groups), 1)
 	expectEquals(t, identity.Groups[0], "users")
 }


### PR DESCRIPTION
Automatically sets the email field to be based on the username for the OpenShift connector