### PR TITLE
ci: add mysql service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,15 @@ jobs:
           - 5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: dex
+        ports:
+          - 3306:3306
+        options: --health-cmd "mysql -proot -e \"show databases;\"" --health-interval 10s --health-timeout 5s --health-retries 5
+
       etcd:
         image: gcr.io/etcd-development/etcd:v3.2.9
         ports:
@@ -44,9 +53,6 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v2
-
-      - name: Setup MySQL database
-        run: mysql -u root -proot -e 'CREATE DATABASE dex;'
 
       - name: Run tests
         run: make testall


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

Somehow MySQL started to fail in recent CI runs, see: https://github.com/dexidp/dex/pull/1673/checks?check_run_id=516025437

Also the MySQL service is scheduled for removal from the default image: https://github.community/t5/GitHub-Actions/github-actions-cannot-connect-to-mysql-service/m-p/31578/highlight/true#M831