### PR TITLE
Automatic consistency fixing in case of missing refresh token in db

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1344,10 +1344,14 @@ func (s *Server) handlePasswordGrant(w http.ResponseWriter, r *http.Request, cli
 			if oldTokenRef, ok := session.Refresh[tokenRef.ClientID]; ok {
 				// Delete old refresh token from storage.
 				if err := s.storage.DeleteRefresh(oldTokenRef.ID); err != nil {
-					s.logger.Errorf("failed to delete refresh token: %v", err)
-					s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
-					deleteToken = true
-					return
+					if err == storage.ErrNotFound {
+						s.logger.Warnf("database inconsistent, refresh token missing: %v", oldTokenRef.ID)
+					} else {
+						s.logger.Errorf("failed to delete refresh token: %v", err)
+						s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
+						deleteToken = true
+						return
+					}
 				}
 			}
 


### PR DESCRIPTION
In case of missing refresh token in db application will return 500 when user tries to issue new refresh token.

This PR adds automatic consistency fixing in case of missing refresh token in db by ignoring missing one. This could happen in case of interrupted write.