### PR TITLE
Allow preferred_username claim to be set for Crowd connector

### DIFF
--- a/Documentation/connectors/atlassian-crowd.md
+++ b/Documentation/connectors/atlassian-crowd.md
@@ -36,4 +36,9 @@ connectors:
     - my-group
     # Prompt for username field.
     usernamePrompt: Login
+    # Optionally set preferred_username claim.
+    # If `preferredUsernameField` is omitted or contains an invalid option, the `preferred_username` claim will be empty.
+    # If `preferredUsernameField` is set, the `preferred_username` claim will be set to the chosen Crowd user attribute value.
+    # Possible choices are: "key", "name", "email"
+    preferredUsernameField: name
 ```

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Dex implements the following connectors:
 | [AuthProxy](Documentation/connectors/authproxy.md) | no | no | no | alpha | Authentication proxies such as Apache2 mod_auth, etc. |
 | [Bitbucket Cloud](Documentation/connectors/bitbucketcloud.md) | yes | yes | no | alpha | |
 | [OpenShift](Documentation/connectors/openshift.md) | no | yes | no | stable | |
+| [Atlassian Crowd](Documentation/connectors/atlassiancrowd.md) | yes | yes | yes *) | beta | preferred_username claim must be configured through config |
 
 Stable, beta, and alpha are defined as:
 

--- a/connector/atlassiancrowd/atlassiancrowd.go
+++ b/connector/atlassiancrowd/atlassiancrowd.go
@@ -35,12 +35,18 @@ import (
 //       - admin
 //       # Prompt for username field
 //       usernamePrompt: Login
+//		 preferredUsernameField: name
 //
 type Config struct {
 	BaseURL      string   `json:"baseURL"`
 	ClientID     string   `json:"clientID"`
 	ClientSecret string   `json:"clientSecret"`
 	Groups       []string `json:"groups"`
+
+	// PreferredUsernameField allows users to set the field to any of the
+	// following values: "key", "name" or "email".
+	// If unset, the preferred_username field will remain empty.
+	PreferredUsernameField string `json:"preferredUsernameField"`
 
 	// UsernamePrompt allows users to override the username attribute (displayed
 	// in the username/password prompt). If unset, the handler will use.
@@ -366,6 +372,15 @@ func (c *crowdConnector) identityFromCrowdUser(user crowdUser) (connector.Identi
 		UserID:        user.Key,
 		Email:         user.Email,
 		EmailVerified: true,
+	}
+
+	switch c.PreferredUsernameField {
+	case "key":
+		identity.PreferredUsername = user.Key
+	case "name":
+		identity.PreferredUsername = user.Name
+	case "email":
+		identity.PreferredUsername = user.Email
 	}
 
 	return identity, nil

--- a/connector/atlassiancrowd/atlassiancrowd.go
+++ b/connector/atlassiancrowd/atlassiancrowd.go
@@ -381,6 +381,10 @@ func (c *crowdConnector) identityFromCrowdUser(user crowdUser) (connector.Identi
 		identity.PreferredUsername = user.Name
 	case "email":
 		identity.PreferredUsername = user.Email
+	default:
+		if c.PreferredUsernameField != "" {
+			c.logger.Warnf("preferred_username left empty. Invalid crowd field mapped to preferred_username: %s", c.PreferredUsernameField)
+		}
 	}
 
 	return identity, nil


### PR DESCRIPTION
**What this is**
In the current implementation, the `preferred_username` claim remains empty. Some clients might require that claim and Dex supports it, if set from the connector's side.

This PR allows the connector to **optionally** support the `preferred_username` claim. It achieves this by allowing a user to choose to fill the `preferred_username` claim by one of the available Crowd fields. Specifically: `key`, `name` or `email`. Invalid options cause the claim to remain empty.

**Breaking change:** No. Existing configuration should not notice this change.
**Optional:** Yes.

**Notes:**
- Added test for `identityFromCrowdUser` function which was not extensively tested before
- Added entry for the Crowd connector in the readme
- Updated documentation for the connector
- I'm fairly new to Go, so I welcome constructive feedback