### PR TITLE
Documentation: Fix typo and add specification in openshift connector doc

### DIFF
--- a/Documentation/connectors/openshift.md
+++ b/Documentation/connectors/openshift.md
@@ -21,10 +21,10 @@ OpenShift Service Accounts can be used as a constrained form of OAuth client. Ma
 Patch the Service Account to add an annotation for location of the Redirect URI
 
 ```
-oc patch serviceaccount <name> --type='json' -p='[{"op": "add", "path": "/metadata/annotations/serviceaccounts.openshift.io~1oauth-redirecturi.dex", "value":"https:///<dex_url>/callback"}]'
+oc patch serviceaccount <name> --type='json' -p='[{"op": "add", "path": "/metadata/annotations/serviceaccounts.openshift.io/oauth-redirecturi.dex", "value":"https:///<dex_url>/callback"}]'
 ```
 
-The Client ID for a Service Account representing an OAuth Client takes the form `
+The Client ID for a Service Account representing an OAuth Client takes the form `system:serviceaccount:<namespace>:<service_account_name>`
 
 The Client Secret for a Service Account representing an OAuth Client is the long lived OAuth Token that is configued for the Service Account. Execute the following command to retrieve the OAuth Token.
 


### PR DESCRIPTION
Serviceaccount annotation in oc patch instruction was malformed. Format
specification of Client ID for a Service Account was missing.