### PR TITLE
Fail on missing scheme in the configured Issuer URL

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -173,6 +173,8 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	issuerURL, err := url.Parse(c.Issuer)
 	if err != nil {
 		return nil, fmt.Errorf("server: can't parse issuer URL")
+	} else if issuerURL.Scheme == "" {
+		return nil, fmt.Errorf("server: configured issuer URL doesn't include http(s):// scheme")
 	}
 
 	if c.Storage == nil {


### PR DESCRIPTION
Fail early on bad issuer URL (related to #1240)