### PR TITLE
Fix templates which asset path points to external URL

### DIFF
--- a/server/templates.go
+++ b/server/templates.go
@@ -176,6 +176,11 @@ func loadTemplates(c webConfig, templatesDir string) (*templates, error) {
 //assetPath is static/main.css
 //relativeURL("/dex", "/dex/auth", "static/main.css") = "../static/main.css"
 func relativeURL(serverPath, reqPath, assetPath string) string {
+	if u, err := url.ParseRequestURI(assetPath); err == nil && u.Scheme != "" {
+		// assetPath points to the external URL, no changes needed
+		return assetPath
+	}
+
 	splitPath := func(p string) []string {
 		res := []string{}
 		parts := strings.Split(path.Clean(p), "/")

--- a/server/templates_test.go
+++ b/server/templates_test.go
@@ -31,6 +31,13 @@ func TestRelativeURL(t *testing.T) {
 			assetPath:  "assets/css/main.css",
 			expected:   "../assets/css/main.css",
 		},
+		{
+			name:       "external-url",
+			serverPath: "/dex",
+			reqPath:    "/dex/auth/connector",
+			assetPath:  "https://kubernetes.io/images/favicon.png",
+			expected:   "https://kubernetes.io/images/favicon.png",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description:
#1554 breaks the ability to specify an icon for header using external URL like [this one](https://kubernetes.io/images/favicon.png).

I added check, that if assetURL points to external URL, no transformations required.