### PR TITLE
OIDC: Add parameter configuration to override email claim key

### DIFF
--- a/Documentation/connectors/oidc.md
+++ b/Documentation/connectors/oidc.md
@@ -56,6 +56,11 @@ connectors:
     #  - email
     #  - groups
 
+    # Some providers return no standard email claim key (ex: 'mail')
+    # Override email claim key
+    # Default is "email"
+    # emailClaim: email
+
     # Some providers return claims without "email_verified", when they had no usage of emails verification in enrollment process
     # or if they are acting as a proxy for another IDP etc AWS Cognito with an upstream SAML IDP
     # This can be overridden with the below option

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -51,6 +51,7 @@ func TestHandleCallback(t *testing.T) {
 		userNameKey               string
 		insecureSkipEmailVerified bool
 		scopes                    []string
+		emailClaim                string
 		expectUserID              string
 		expectUserName            string
 		expectedEmailField        string
@@ -67,6 +68,21 @@ func TestHandleCallback(t *testing.T) {
 				"sub":            "subvalue",
 				"name":           "namevalue",
 				"email":          "emailvalue",
+				"email_verified": true,
+			},
+		},
+		{
+			name:               "customEmailClaim",
+			userIDKey:          "", // not configured
+			userNameKey:        "", // not configured
+			emailClaim:         "mail",
+			expectUserID:       "subvalue",
+			expectUserName:     "namevalue",
+			expectedEmailField: "emailvalue",
+			token: map[string]interface{}{
+				"sub":            "subvalue",
+				"name":           "namevalue",
+				"mail":           "emailvalue",
 				"email_verified": true,
 			},
 		},
@@ -161,6 +177,7 @@ func TestHandleCallback(t *testing.T) {
 				RedirectURI:               fmt.Sprintf("%s/callback", serverURL),
 				UserIDKey:                 tc.userIDKey,
 				UserNameKey:               tc.userNameKey,
+				EmailClaim:                tc.emailClaim,
 				InsecureSkipEmailVerified: tc.insecureSkipEmailVerified,
 				BasicAuthUnsupported:      &basicAuth,
 			}


### PR DESCRIPTION
Some OIDC providers don't return standard email claim key (ex: 'mail'), add configuration to override email claim name.