### PR TITLE
allow no secret for static public clients

### DIFF
--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -166,7 +166,7 @@ func serve(cmd *cobra.Command, args []string) error {
 				}
 				c.StaticClients[i].ID = os.Getenv(client.IDEnv)
 			}
-			if client.Secret == "" && client.SecretEnv == "" {
+			if client.Secret == "" && client.SecretEnv == "" && !client.Public {
 				return fmt.Errorf("invalid config: Secret or SecretEnv field is required for client %q", client.ID)
 			}
 			if client.SecretEnv != "" {


### PR DESCRIPTION
For statically-configured public clients it should be allowed for both
Secret and SecretEnv fields to be empty.