### PR TITLE
Allow the "google" connector to work without a service account

### DIFF
--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -70,7 +70,7 @@ connectors:
 - type: mockCallback
   id: mock
   name: Example
-# - type: oidc
+# - type: google
 #   id: google
 #   name: Google
 #   config:


### PR DESCRIPTION
Fixes #1718

--------

The code *did* originally have a check for empty adminEmail and empty serviceAccountFilePath, but didn't check this when loading the config - so tried to open an empty filename.

With this fix, token refresh works when using the "google" connector instead of the "oidc" connector to talk to Google, even without a hosted domain.