### PR TITLE
add docker-compose.yaml for local testing

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,39 @@
+# This docker-compose file provides quick setups for testing different storage backend options.
+version: "3.8"
+services:
+  mysql:
+    # For using percona-xtradb you need to make strict mode permissive with:
+    # docker-compose exec mysql mysql -uroot -proot -e "SET GLOBAL pxc_strict_mode=PERMISSIVE;"
+    # See: https://www.percona.com/doc/percona-xtradb-cluster/5.7/features/pxc-strict-mode.html
+    # image: percona/percona-xtradb-cluster:5.7
+    # image: mariadb:10.5
+    # image: mysql:5.6
+    # image: mysql:8.0
+    image: mysql:5.7
+    environment:
+      MYSQL_DATABASE: dex
+      MYSQL_USER: mysql
+      MYSQL_PASSWORD: mysql
+      MYSQL_ROOT_PASSWORD: root
+    ports:
+      - "127.0.0.1:3306:3306"
+
+  postgres:
+    image: postgres:10.8
+    environment:
+      POSTGRES_DB: dex
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "127.0.0.1:5432:5432"
+
+  etcd:
+    image: gcr.io/etcd-development/etcd:v3.2.9
+    environment:
+      ETCD_LISTEN_CLIENT_URLS: http://0.0.0.0:2379
+      ETCD_ADVERTISE_CLIENT_URLS: http://0.0.0.0:2379
+    ports:
+      - "127.0.0.1:2379:2379"
+
+  # For testing the Kubernetes storage backend we suggest https://kind.sigs.k8s.io/:
+  # kind create cluster

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -12,6 +12,36 @@ storage:
   config:
     file: examples/dex.db
 
+  # type: mysql
+  # config:
+  #   host: localhost
+  #   port: 3306
+  #   database: dex
+  #   user: mysql
+  #   password: mysql
+  #   ssl:
+  #     mode: "false"
+
+  # type: postgres
+  # config:
+  #   host: localhost
+  #   port: 5432
+  #   database: dex
+  #   user: postgres
+  #   password: postgres
+  #   ssl:
+  #     mode: disable
+
+  # type: etcd
+  # config:
+  #   endpoints:
+  #     - http://localhost:2379
+  #   namespace: dex/
+
+  # type: kubernetes
+  # config:
+  #   kubeConfigFile: $HOME/.kube/config
+
 # Configuration for the HTTP endpoints.
 web:
   http: 0.0.0.0:5556

--- a/storage/sql/config_test.go
+++ b/storage/sql/config_test.go
@@ -270,7 +270,7 @@ func TestMySQL(t *testing.T) {
 		NetworkDB: NetworkDB{
 			Database:          getenv("DEX_MYSQL_DATABASE", "mysql"),
 			User:              getenv("DEX_MYSQL_USER", "mysql"),
-			Password:          getenv("DEX_MYSQL_PASSWORD", ""),
+			Password:          getenv("DEX_MYSQL_PASSWORD", "mysql"),
 			Host:              host,
 			Port:              uint16(port),
 			ConnectionTimeout: 5,


### PR DESCRIPTION
This PR tries to resolve the pain of testing different storage options quickly. I have added different almost all storage options/versions (except Kubernetes CRDs) and included the corresponding Dex config counterparts as well.