### PR TITLE
Add groupsClaimMapping to the OIDC connector

### DIFF
--- a/Documentation/connectors/oidc.md
+++ b/Documentation/connectors/oidc.md
@@ -68,6 +68,10 @@ connectors:
     # This can be overridden with the below option
     # insecureEnableGroups: true
 
+    # If an OIDC provider uses a different claim name than the standard "groups" claim to provide group information
+    # the claim to use can be specified
+    # groupsClaimMapping: "cognito:groups"
+
     # When enabled, the OpenID Connector will query the UserInfo endpoint for additional claims. UserInfo claims
     # take priority over claims returned by the IDToken. This option should be used when the IDToken doesn't contain
     # all the claims requested.


### PR DESCRIPTION
The `groupsClaimMapping` setting allows one to specify which claim to pull group information from the OIDC provider.  Previously it assumed group information was always in the "groups" claim, but that isn't the case for many OIDC providers (such as AWS Cognito using the "cognito:groups" claim instead)