### PR TITLE
Adding architecture support for arm/arm64/amd64 docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Get Version
+        id: info
+        run: |
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
       - name: Determine Docker Tag
         uses: haya14busa/action-cond@v1
         id: imagetag
@@ -109,6 +114,7 @@ jobs:
         with:
           install: true
           version: latest
+          # TODO: Remove driver-opts once fix is released docker/buildx#386
           driver-opts: image=moby/buildkit:master
 
       - name: Login to DockerHub
@@ -125,3 +131,12 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: dexidp/dex:${{ steps.imagetag.outputs.value }}
+        labels: |
+          org.opencontainers.image.title=${{ github.event.repository.name }}
+          org.opencontainers.image.description=${{ github.event.repository.description }}
+          org.opencontainers.image.url=${{ github.event.repository.html_url }}
+          org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+          org.opencontainers.image.version=${{ steps.imagetag.outputs.value }}
+          org.opencontainers.image.created=${{ steps.info.outputs.created }}
+          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,20 +90,38 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Determine tag
+      - name: Determine Docker Tag
         uses: haya14busa/action-cond@v1
         id: imagetag
         with:
           cond: ${{ github.event_name == 'pull_request' }}
           if_true: ${{ github.sha }}
-          if_false: "master"
+          if_false: 'master'
 
-      - name: Build
-        uses: docker/build-push-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: dexidp/dex
-          tags: ${{ steps.imagetag.outputs.value }}
-          add_git_labels: true
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+          version: latest
+          driver-opts: image=moby/buildkit:master
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: ${{ github.event_name == 'push' }}
+          tags: dexidp/dex:${{ steps.imagetag.outputs.value }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,12 +131,12 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: dexidp/dex:${{ steps.imagetag.outputs.value }}
-        labels: |
-          org.opencontainers.image.title=${{ github.event.repository.name }}
-          org.opencontainers.image.description=${{ github.event.repository.description }}
-          org.opencontainers.image.url=${{ github.event.repository.html_url }}
-          org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-          org.opencontainers.image.version=${{ steps.imagetag.outputs.value }}
-          org.opencontainers.image.created=${{ steps.info.outputs.created }}
-          org.opencontainers.image.revision=${{ github.sha }}
-          org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.version=${{ steps.imagetag.outputs.value }}
+            org.opencontainers.image.created=${{ steps.info.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   docker:
@@ -13,12 +13,39 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Build and push image
-        uses: docker/build-push-action@v1
+      - name: Get Version
+        id: info
+        run: |
+          VERSION=$(shell ./scripts/git-version)
+          echo ::set-output name=version::${VERSION}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: dexidp/dex
-          tags: latest
-          tag_with_ref: true
-          add_git_labels: true
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+          version: latest
+          driver-opts: image=moby/buildkit:master
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: true
+          tags: |
+            dexidp/dex:latest
+            dexidp/dex:${{ steps.info.outputs.version }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           VERSION=$(shell ./scripts/git-version)
           echo ::set-output name=version::${VERSION}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -30,6 +31,7 @@ jobs:
         with:
           install: true
           version: latest
+          # TODO: Remove driver-opts once fix is released docker/buildx#386
           driver-opts: image=moby/buildkit:master
 
       - name: Login to DockerHub
@@ -48,4 +50,12 @@ jobs:
           tags: |
             dexidp/dex:latest
             dexidp/dex:${{ steps.info.outputs.version }}
-
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.version=${{ steps.info.outputs.version }}
+            org.opencontainers.image.created=${{ steps.info.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}


### PR DESCRIPTION
Adding architecture support for arm/arm64/amd64 docker images using docker `buildx` functionality.

Tested arm64 running on a local Kubernetes cluster to confirm it was working without issues.

Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>