### PR TITLE
Enable local build of example app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,13 @@ LD_FLAGS="-w -X $(REPO_PATH)/version.Version=$(VERSION)"
 # Dependency versions
 GOLANGCI_VERSION = 1.21.0
 
-build: bin/dex bin/grpc-client
+build: bin/dex bin/example-app bin/grpc-client
 
 bin/dex:
 	@go install -v -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/dex
+
+bin/example-app:
+	@go install -v -ldflags $(LD_FLAGS) $(REPO_PATH)/examples/example-app
 
 bin/grpc-client:
 	@go install -v -ldflags $(LD_FLAGS) $(REPO_PATH)/examples/grpc-client

--- a/go.mod
+++ b/go.mod
@@ -48,3 +48,4 @@ require (
 )
 
 replace github.com/dexidp/dex/api/v2 => ./api/v2
+replace github.com/dexidp/dex/examples => ./examples


### PR DESCRIPTION
Without these changes, it doesn't seem possible to build the example app from the **local** checkout.
(I'm not a Go expert, so there might be other ways to achieve this.)