### PR TITLE
Rule-restricted wildcard match of single subdomain #488

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-sql-driver/mysql v1.5.0
-	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
+	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6
 	github.com/golang/protobuf v1.3.2
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/gorilla/handlers v1.4.2

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kylelemons/godebug v1.1.0
 	github.com/lib/pq v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-sql-driver/mysql v1.5.0
-	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6
+	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/gorilla/handlers v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -21,9 +21,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/groupcache/lru"
-
 	jose "gopkg.in/square/go-jose.v2"
+
+	lru "github.com/hashicorp/golang-lru"
 
 	"github.com/dexidp/dex/connector"
 	"github.com/dexidp/dex/server/internal"
@@ -590,7 +590,7 @@ func (s *Server) validateCrossClientTrust(clientID, peerID string) (trusted bool
 	return false, nil
 }
 
-func validateRedirectURI(client storage.Client, wildcardCache *lru.Cache, redirectURI string) bool {
+func validateRedirectURI(client storage.Client, wildcardCache *lru.ARCCache, redirectURI string) bool {
 	if !client.Public {
 		for _, uri := range client.RedirectURIs {
 			if redirectURI == uri {
@@ -625,7 +625,7 @@ func validateRedirectURI(client storage.Client, wildcardCache *lru.Cache, redire
 	return err == nil && host == "localhost"
 }
 
-func wildcardMatch(knownRedirectUri string, requestedRedirectUri string, wildcardCache *lru.Cache) bool {
+func wildcardMatch(knownRedirectUri string, requestedRedirectUri string, wildcardCache *lru.ARCCache) bool {
 	if wildcardCache == nil {
 		return false
 	}

--- a/server/oauth2_test.go
+++ b/server/oauth2_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/square/go-jose.v2"
 
@@ -325,9 +325,9 @@ func TestAccessTokenHash(t *testing.T) {
 }
 
 func TestSplitHttpRedirectUrl(t *testing.T) {
-	//if strings.Index(clientRedirectUrlSpec, "*") == -1 {
-	//	// no wildcard characters to consider
-	//	return nil
+	//  if strings.Index(clientRedirectUrlSpec, "*") == -1 {
+	//  no wildcard characters to consider
+	//  return nil
 	//}
 
 	tests := []struct {
@@ -371,10 +371,10 @@ func TestSplitHttpRedirectUrl(t *testing.T) {
 
 	tAssert := assert.New(t)
 	for _, test := range tests {
-		testRedirectUrl, err := url.Parse(test.redirectURI)
+		testRedirectURL, err := url.Parse(test.redirectURI)
 		tAssert.Nilf(err, "Invalid test url %v", test.redirectURI)
-		tAssert.NotNilf(testRedirectUrl, "Invalid test url %v", test.redirectURI)
-		result := splitClobberHttpRedirectUrl(testRedirectUrl)
+		tAssert.NotNilf(testRedirectURL, "Invalid test url %v", test.redirectURI)
+		result := splitClobberHTTPRedirectURL(testRedirectURL)
 		tAssert.Equal(test.expectValid, result != nil, "Valid result expected for %v", test.redirectURI)
 		if test.expectHostSplit != nil {
 			tAssert.Equal(result, test.expectHostSplit, "Host split validation failed for %v", test.redirectURI)
@@ -382,7 +382,7 @@ func TestSplitHttpRedirectUrl(t *testing.T) {
 		if result != nil {
 			fullResult := createClientRedirectClobberMatcher(test.redirectURI)
 			tAssert.True(fullResult.HostMatcher != nil)
-			tAssert.Equal(fullResult.ClientRedirectURL, testRedirectUrl)
+			tAssert.Equal(fullResult.ClientRedirectURL, testRedirectURL)
 		}
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -232,7 +232,6 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 		c.Logger.Infof("ARC LRU case failed to load, wildcard redirect URIs disabled: %v", err)
 	}
 
-
 	s := &Server{
 		issuerURL:              *issuerURL,
 		connectors:             make(map[string]Connector),

--- a/server/server.go
+++ b/server/server.go
@@ -559,15 +559,15 @@ func (s *Server) OpenConnector(conn storage.Connector) (Connector, error) {
 		}
 	}
 
-	connector := Connector{
+	connectorInstance := Connector{
 		ResourceVersion: conn.ResourceVersion,
 		Connector:       c,
 	}
 	s.mu.Lock()
-	s.connectors[conn.ID] = connector
+	s.connectors[conn.ID] = connectorInstance
 	s.mu.Unlock()
 
-	return connector, nil
+	return connectorInstance, nil
 }
 
 // getConnector retrieves the connector object with the given id from the storage

--- a/server/server.go
+++ b/server/server.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/felixge/httpsnoop"
+	"github.com/golang/groupcache/lru"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
@@ -163,6 +164,9 @@ type Server struct {
 	deviceRequestsValidFor time.Duration
 
 	logger log.Logger
+
+	// LRU cache of regex matchers for a given permitted redirect URI defined in Client
+	wildcardMatcherCache *lru.Cache
 }
 
 // NewServer constructs a server from the provided config.
@@ -236,6 +240,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 		templates:              tmpls,
 		passwordConnector:      c.PasswordConnector,
 		logger:                 c.Logger,
+		wildcardMatcherCache:   lru.New(500),
 	}
 
 	// Retrieves connector objects in backend storage. This list includes the static connectors


### PR DESCRIPTION
Add support for rule-restricted wildcard match of lowest-level subdomain via LRU cache.

This PR:
- builds on [PR 1220](https://github.com/dexidp/dex/pull/1220), applying to any client created via API for example - rather than static clients only, see discussion at [issue 448](https://github.com/dexidp/dex/issues/448)
- far tigher security as per comments by fbsb on PR #1220
- in-memory LRU cache of max 500 redirect URI values -> empty string (no valid wildcard) or to regex string to match if all conditions met
