### PR TITLE
Add the option to configure the bind password using an environment variable for the LDAP connector.

### DIFF
--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -191,7 +191,7 @@ func (c *ldapConnector) userMatchers() []UserMatcher {
 	if len(c.GroupSearch.UserMatchers) > 0 && c.GroupSearch.UserMatchers[0].UserAttr != "" {
 		return c.GroupSearch.UserMatchers[:]
 	}
-	
+
 	return []UserMatcher{
 		{
 			UserAttr:  c.GroupSearch.UserAttr,
@@ -247,7 +247,11 @@ func (c *Config) openConnector(logger log.Logger) (*ldapConnector, error) {
 		if c.BindPW != "" {
 			return nil, fmt.Errorf("ldap: bindPW and bindPWFromEnv are exclusive for the LDAP connector")
 		}
-		bindPW = os.Getenv(c.BindPWFromEnv)
+		var ok bool
+		bindPW, ok = os.LookupEnv(c.BindPWFromEnv)
+		if !ok || bindPW == "" {
+			return nil, fmt.Errorf("ldap: environment variable for the bind password was not set to a valid")
+		}
 	}
 	c.BindPW = bindPW
 

--- a/connector/ldap/ldap_test.go
+++ b/connector/ldap/ldap_test.go
@@ -61,27 +61,38 @@ func TestOpenForBindPW(t *testing.T) {
 	tests := []struct {
 		bindPW        string
 		bindPWFromEnv string
+		bindPWFromEnvVal string
 		expectedError error
 	}{
 		{
-			bindPW:        "",
-			bindPWFromEnv: "",
-			expectedError: fmt.Errorf("ldap: bindPW or bindPWFromEnv are required for the LDAP connector"),
+			bindPW:           "",
+			bindPWFromEnv:    "",
+			bindPWFromEnvVal: "",
+			expectedError:    fmt.Errorf("ldap: bindPW or bindPWFromEnv are required for the LDAP connector"),
 		},
 		{
-			bindPW:        "admin",
-			bindPWFromEnv: "admin",
-			expectedError: fmt.Errorf("ldap: bindPW and bindPWFromEnv are exclusive for the LDAP connector"),
+			bindPW:           "admin",
+			bindPWFromEnv:    "LDAP_BIND_PW",
+			bindPWFromEnvVal: "admin",
+			expectedError:    fmt.Errorf("ldap: bindPW and bindPWFromEnv are exclusive for the LDAP connector"),
 		},
 		{
-			bindPW:        "",
-			bindPWFromEnv: "LDAP_BIND_PW",
-			expectedError: nil,
+			bindPW:           "",
+			bindPWFromEnv:    "LDAP_BIND_PW",
+			bindPWFromEnvVal: "admin",
+			expectedError:    nil,
 		},
 		{
-			bindPW:        "admin",
-			bindPWFromEnv: "",
-			expectedError: nil,
+			bindPW:           "",
+			bindPWFromEnv:    "LDAP_BIND_PW",
+			bindPWFromEnvVal: "",
+			expectedError:    fmt.Errorf("ldap: environment variable for the bind password was not set to a valid"),
+		},
+		{
+			bindPW:           "admin",
+			bindPWFromEnv:    "",
+			bindPWFromEnvVal: "",
+			expectedError:    nil,
 		},
 	}
 
@@ -89,7 +100,7 @@ func TestOpenForBindPW(t *testing.T) {
 
 	for _, tc := range tests {
 		if tc.bindPWFromEnv != "" {
-			os.Setenv(tc.bindPWFromEnv, "admin")
+			os.Setenv(tc.bindPWFromEnv, tc.bindPWFromEnvVal)
 		}
 		c.BindPW = tc.bindPW
 		c.BindPWFromEnv = tc.bindPWFromEnv


### PR DESCRIPTION
In a k8s deployment that uses Dex, this will allow us to define an environment variable using a k8s secret that contains the bind password instead of showing it in plaintext in a configmap. 

This partially meets requirements in #1099.

Related  issue - https://github.com/dexidp/dex/issues/1158 

cc: @sagikazarmark @bonifaido @danilina-wsib 