### PR TITLE
Let Github actions always pull the base images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+          always_pull: true
           repository: dexidp/dex
           tags: ${{ steps.imagetag.outputs.value }}
           add_git_labels: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+          always_pull: true
           repository: dexidp/dex
           tags: latest
           tag_with_ref: true

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ fix: bin/golangci-lint ## Fix lint violations
 
 .PHONY: docker-image
 docker-image:
-	@sudo docker build -t $(DOCKER_IMAGE) .
+	@docker build -t $(DOCKER_IMAGE) .
 
 .PHONY: proto
 proto: bin/protoc bin/protoc-gen-go

--- a/Makefile
+++ b/Makefile
@@ -74,11 +74,7 @@ fix: bin/golangci-lint ## Fix lint violations
 	bin/golangci-lint run --fix
 
 .PHONY: docker-image
-docker-image: ## Pull base images, then build the image.
-	@sudo docker build --pull -t $(DOCKER_IMAGE) .
-
-.PHONY: docker-image-no-pull
-docker-image-no-pull: ## Skip pulling the base images for development.
+docker-image:
 	@sudo docker build -t $(DOCKER_IMAGE) .
 
 .PHONY: proto

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,11 @@ fix: bin/golangci-lint ## Fix lint violations
 	bin/golangci-lint run --fix
 
 .PHONY: docker-image
-docker-image:
+docker-image: ## Pull base images, then build the image.
+	@sudo docker build --pull -t $(DOCKER_IMAGE) .
+
+.PHONY: docker-image-no-pull
+docker-image-no-pull: ## Skip pulling the base images for development.
 	@sudo docker build -t $(DOCKER_IMAGE) .
 
 .PHONY: proto


### PR DESCRIPTION
Let Github actions always pull the base images, to avoid CVEs.