### PR TITLE
fix: allow Authorization header when doing CORS

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -294,8 +294,14 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	handleWithCORS := func(p string, h http.HandlerFunc) {
 		var handler http.Handler = h
 		if len(c.AllowedOrigins) > 0 {
-			corsOption := handlers.AllowedOrigins(c.AllowedOrigins)
-			handler = handlers.CORS(corsOption)(handler)
+			allowedHeaders := []string{
+				"Authorization",
+			}
+			cors := handlers.CORS(
+				handlers.AllowedOrigins(c.AllowedOrigins),
+				handlers.AllowedHeaders(allowedHeaders),
+			)
+			handler = cors(handler)
 		}
 		r.Handle(path.Join(issuerURL.Path, p), instrumentHandlerCounter(p, handler))
 	}


### PR DESCRIPTION
The Authorization header needs to be allowed when doing CORS because
otherwise /userinfo can't work.  It isn't one of the headers
explicitly allowed by default by Gorilla, so we have to call
handlers.AllowedHeaders() to specify it.

Fixes #1532