### PR TITLE
fix: copy the "web" directory.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY --from=0 /go/bin/dex /usr/local/bin/dex
 
 # Import frontend assets and set the correct CWD directory so the assets
 # are in the default path.
-COPY web .
+COPY web web
 
 ENTRYPOINT ["dex"]
 


### PR DESCRIPTION
The Dockerfile was changed to do

    COPY web .

which is unfortunate because that means copy the *contents* of the directory
"web", rather than copying the directory itself which is what the author
intended.

Issues: #1820
Signed-off-by: Alastair Houghton <alastair@alastairs-place.net>