### PR TITLE
Allow public clients (e.g. SPAs using implicit flow or PKCE) to have redirect URLs other than localhost

### DIFF
--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -588,12 +588,15 @@ func (s *Server) validateCrossClientTrust(clientID, peerID string) (trusted bool
 }
 
 func validateRedirectURI(client storage.Client, redirectURI string) bool {
-	if !client.Public {
-		for _, uri := range client.RedirectURIs {
-			if redirectURI == uri {
-				return true
-			}
+	// Allow named RedirectURIs for both public and non-public clients.
+	// This is required make PKCE-enabled web apps work, when configured as public clients.
+	for _, uri := range client.RedirectURIs {
+		if redirectURI == uri {
+			return true
 		}
+	}
+	// For non-public clients, only named RedirectURIs are allowed.
+	if !client.Public {
 		return false
 	}
 

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -595,8 +595,9 @@ func validateRedirectURI(client storage.Client, redirectURI string) bool {
 			return true
 		}
 	}
-	// For non-public clients, only named RedirectURIs are allowed.
-	if !client.Public {
+	// For non-public clients or when RedirectURIs is set, we allow only explicitly named RedirectURIs.
+	// Otherwise, we check below for special URIs used for desktop or mobile apps.
+	if !client.Public || len(client.RedirectURIs) > 0 {
 		return false
 	}
 

--- a/server/oauth2_test.go
+++ b/server/oauth2_test.go
@@ -340,6 +340,7 @@ func TestValidRedirectURI(t *testing.T) {
 				RedirectURIs: []string{"http://foo.com/bar"},
 			},
 			redirectURI: "http://foo.com/bar/baz",
+			wantValid:   false,
 		},
 		{
 			client: storage.Client{
@@ -368,6 +369,30 @@ func TestValidRedirectURI(t *testing.T) {
 			},
 			redirectURI: "http://localhost",
 			wantValid:   true,
+		},
+		// Both Public + RedirectURIs configured: Could e.g. be a PKCE-enabled web app.
+		{
+			client: storage.Client{
+				Public: true,
+				RedirectURIs: []string{"http://foo.com/bar"},
+			},
+			redirectURI: "http://foo.com/bar",
+			wantValid:   true,
+		},
+		{
+			client: storage.Client{
+				Public: true,
+				RedirectURIs: []string{"http://foo.com/bar"},
+			},
+			redirectURI: "http://foo.com/bar/baz",
+			wantValid:   false,
+		},
+		{
+			client: storage.Client{
+				Public: true,
+			},
+			redirectURI: "http://foo.com/bar",
+			wantValid:   false,
 		},
 		{
 			client: storage.Client{

--- a/server/oauth2_test.go
+++ b/server/oauth2_test.go
@@ -395,14 +395,14 @@ func TestValidRedirectURI(t *testing.T) {
 			redirectURI: "http://foo.com/bar/baz",
 			wantValid:   false,
 		},
-		// These special desktop + device + localhost URIs are allowed even when RedirectURIs is non-empty.
+		// These special desktop + device + localhost URIs are not allowed implicitly when RedirectURIs is non-empty.
 		{
 			client: storage.Client{
 				Public:       true,
 				RedirectURIs: []string{"http://foo.com/bar"},
 			},
 			redirectURI: "urn:ietf:wg:oauth:2.0:oob",
-			wantValid:   true,
+			wantValid:   false,
 		},
 		{
 			client: storage.Client{
@@ -410,7 +410,7 @@ func TestValidRedirectURI(t *testing.T) {
 				RedirectURIs: []string{"http://foo.com/bar"},
 			},
 			redirectURI: "/device/callback",
-			wantValid:   true,
+			wantValid:   false,
 		},
 		{
 			client: storage.Client{
@@ -418,7 +418,7 @@ func TestValidRedirectURI(t *testing.T) {
 				RedirectURIs: []string{"http://foo.com/bar"},
 			},
 			redirectURI: "http://localhost:8080/",
-			wantValid:   true,
+			wantValid:   false,
 		},
 		{
 			client: storage.Client{
@@ -426,12 +426,53 @@ func TestValidRedirectURI(t *testing.T) {
 				RedirectURIs: []string{"http://foo.com/bar"},
 			},
 			redirectURI: "http://localhost:991/bar",
-			wantValid:   true,
+			wantValid:   false,
 		},
 		{
 			client: storage.Client{
 				Public:       true,
 				RedirectURIs: []string{"http://foo.com/bar"},
+			},
+			redirectURI: "http://localhost",
+			wantValid:   false,
+		},
+		// These special desktop + device + localhost URIs can still be specified explicitly.
+		{
+			client: storage.Client{
+				Public:       true,
+				RedirectURIs: []string{"http://foo.com/bar", "urn:ietf:wg:oauth:2.0:oob"},
+			},
+			redirectURI: "urn:ietf:wg:oauth:2.0:oob",
+			wantValid:   true,
+		},
+		{
+			client: storage.Client{
+				Public:       true,
+				RedirectURIs: []string{"http://foo.com/bar", "/device/callback"},
+			},
+			redirectURI: "/device/callback",
+			wantValid:   true,
+		},
+		{
+			client: storage.Client{
+				Public:       true,
+				RedirectURIs: []string{"http://foo.com/bar", "http://localhost:8080/"},
+			},
+			redirectURI: "http://localhost:8080/",
+			wantValid:   true,
+		},
+		{
+			client: storage.Client{
+				Public:       true,
+				RedirectURIs: []string{"http://foo.com/bar", "http://localhost:991/bar"},
+			},
+			redirectURI: "http://localhost:991/bar",
+			wantValid:   true,
+		},
+		{
+			client: storage.Client{
+				Public:       true,
+				RedirectURIs: []string{"http://foo.com/bar", "http://localhost"},
 			},
 			redirectURI: "http://localhost",
 			wantValid:   true,

--- a/server/oauth2_test.go
+++ b/server/oauth2_test.go
@@ -373,7 +373,7 @@ func TestValidRedirectURI(t *testing.T) {
 		// Both Public + RedirectURIs configured: Could e.g. be a PKCE-enabled web app.
 		{
 			client: storage.Client{
-				Public: true,
+				Public:       true,
 				RedirectURIs: []string{"http://foo.com/bar"},
 			},
 			redirectURI: "http://foo.com/bar",
@@ -381,7 +381,7 @@ func TestValidRedirectURI(t *testing.T) {
 		},
 		{
 			client: storage.Client{
-				Public: true,
+				Public:       true,
 				RedirectURIs: []string{"http://foo.com/bar"},
 			},
 			redirectURI: "http://foo.com/bar/baz",

--- a/server/oauth2_test.go
+++ b/server/oauth2_test.go
@@ -342,11 +342,19 @@ func TestValidRedirectURI(t *testing.T) {
 			redirectURI: "http://foo.com/bar/baz",
 			wantValid:   false,
 		},
+		// These special desktop + device + localhost URIs are allowed by default.
 		{
 			client: storage.Client{
 				Public: true,
 			},
 			redirectURI: "urn:ietf:wg:oauth:2.0:oob",
+			wantValid:   true,
+		},
+		{
+			client: storage.Client{
+				Public: true,
+			},
+			redirectURI: "/device/callback",
 			wantValid:   true,
 		},
 		{
@@ -387,6 +395,48 @@ func TestValidRedirectURI(t *testing.T) {
 			redirectURI: "http://foo.com/bar/baz",
 			wantValid:   false,
 		},
+		// These special desktop + device + localhost URIs are allowed even when RedirectURIs is non-empty.
+		{
+			client: storage.Client{
+				Public:       true,
+				RedirectURIs: []string{"http://foo.com/bar"},
+			},
+			redirectURI: "urn:ietf:wg:oauth:2.0:oob",
+			wantValid:   true,
+		},
+		{
+			client: storage.Client{
+				Public:       true,
+				RedirectURIs: []string{"http://foo.com/bar"},
+			},
+			redirectURI: "/device/callback",
+			wantValid:   true,
+		},
+		{
+			client: storage.Client{
+				Public:       true,
+				RedirectURIs: []string{"http://foo.com/bar"},
+			},
+			redirectURI: "http://localhost:8080/",
+			wantValid:   true,
+		},
+		{
+			client: storage.Client{
+				Public:       true,
+				RedirectURIs: []string{"http://foo.com/bar"},
+			},
+			redirectURI: "http://localhost:991/bar",
+			wantValid:   true,
+		},
+		{
+			client: storage.Client{
+				Public:       true,
+				RedirectURIs: []string{"http://foo.com/bar"},
+			},
+			redirectURI: "http://localhost",
+			wantValid:   true,
+		},
+		// Non-localhost URIs are not allowed implicitly.
 		{
 			client: storage.Client{
 				Public: true,


### PR DESCRIPTION
Relates to:
* https://github.com/dexidp/dex/pull/1722 (also allow usual IP addresses)
* https://github.com/dexidp/dex/pull/1784 (PKCE)