### PR TITLE
Support multiple refresh tokens per user.

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -47,6 +47,8 @@ type Config struct {
 	// querying the storage. Cannot be specified without enabling a passwords
 	// database.
 	StaticPasswords []password `json:"staticPasswords"`
+
+	EnableMultiRefreshTokens bool `json:"enableMultiRefreshTokens"`
 }
 
 //Validate the configuration

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -233,17 +233,18 @@ func serve(cmd *cobra.Command, args []string) error {
 	now := func() time.Time { return time.Now().UTC() }
 
 	serverConfig := server.Config{
-		SupportedResponseTypes: c.OAuth2.ResponseTypes,
-		SkipApprovalScreen:     c.OAuth2.SkipApprovalScreen,
-		AlwaysShowLoginScreen:  c.OAuth2.AlwaysShowLoginScreen,
-		PasswordConnector:      c.OAuth2.PasswordConnector,
-		AllowedOrigins:         c.Web.AllowedOrigins,
-		Issuer:                 c.Issuer,
-		Storage:                s,
-		Web:                    c.Frontend,
-		Logger:                 logger,
-		Now:                    now,
-		PrometheusRegistry:     prometheusRegistry,
+		SupportedResponseTypes:   c.OAuth2.ResponseTypes,
+		SkipApprovalScreen:       c.OAuth2.SkipApprovalScreen,
+		AlwaysShowLoginScreen:    c.OAuth2.AlwaysShowLoginScreen,
+		PasswordConnector:        c.OAuth2.PasswordConnector,
+		AllowedOrigins:           c.Web.AllowedOrigins,
+		Issuer:                   c.Issuer,
+		Storage:                  s,
+		Web:                      c.Frontend,
+		Logger:                   logger,
+		Now:                      now,
+		PrometheusRegistry:       prometheusRegistry,
+		EnableMultiRefreshTokens: c.EnableMultiRefreshTokens,
 	}
 	if c.Expiry.SigningKeys != "" {
 		signingKeys, err := time.ParseDuration(c.Expiry.SigningKeys)
@@ -326,7 +327,7 @@ func serve(cmd *cobra.Command, args []string) error {
 					return fmt.Errorf("listening on %s failed: %v", c.GRPC.Addr, err)
 				}
 				s := grpc.NewServer(grpcOptions...)
-				api.RegisterDexServer(s, server.NewAPI(serverConfig.Storage, logger))
+				api.RegisterDexServer(s, server.NewAPI(serverConfig.Storage, logger, c.EnableMultiRefreshTokens))
 				grpcMetrics.InitializeMetrics(s)
 				if c.GRPC.Reflection {
 					logger.Info("enabling reflection in grpc service")

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -36,7 +36,7 @@ func newAPI(s storage.Storage, logger log.Logger, t *testing.T) *apiClient {
 	}
 
 	serv := grpc.NewServer()
-	api.RegisterDexServer(serv, NewAPI(s, logger))
+	api.RegisterDexServer(serv, NewAPI(s, logger, false))
 	go serv.Serve(l)
 
 	// Dial will retry automatically if the serv.Serve() goroutine

--- a/server/server.go
+++ b/server/server.go
@@ -93,6 +93,8 @@ type Config struct {
 	Logger log.Logger
 
 	PrometheusRegistry *prometheus.Registry
+
+	EnableMultiRefreshTokens bool
 }
 
 // WebConfig holds the server's frontend templates and asset configuration.
@@ -163,6 +165,8 @@ type Server struct {
 	deviceRequestsValidFor time.Duration
 
 	logger log.Logger
+
+	enableMultiRefreshTokens bool
 }
 
 // NewServer constructs a server from the provided config.
@@ -223,19 +227,20 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	}
 
 	s := &Server{
-		issuerURL:              *issuerURL,
-		connectors:             make(map[string]Connector),
-		storage:                newKeyCacher(c.Storage, now),
-		supportedResponseTypes: supported,
-		idTokensValidFor:       value(c.IDTokensValidFor, 24*time.Hour),
-		authRequestsValidFor:   value(c.AuthRequestsValidFor, 24*time.Hour),
-		deviceRequestsValidFor: value(c.DeviceRequestsValidFor, 5*time.Minute),
-		skipApproval:           c.SkipApprovalScreen,
-		alwaysShowLogin:        c.AlwaysShowLoginScreen,
-		now:                    now,
-		templates:              tmpls,
-		passwordConnector:      c.PasswordConnector,
-		logger:                 c.Logger,
+		issuerURL:                *issuerURL,
+		connectors:               make(map[string]Connector),
+		storage:                  newKeyCacher(c.Storage, now),
+		supportedResponseTypes:   supported,
+		idTokensValidFor:         value(c.IDTokensValidFor, 24*time.Hour),
+		authRequestsValidFor:     value(c.AuthRequestsValidFor, 24*time.Hour),
+		deviceRequestsValidFor:   value(c.DeviceRequestsValidFor, 5*time.Minute),
+		skipApproval:             c.SkipApprovalScreen,
+		alwaysShowLogin:          c.AlwaysShowLoginScreen,
+		now:                      now,
+		templates:                tmpls,
+		passwordConnector:        c.PasswordConnector,
+		logger:                   c.Logger,
+		enableMultiRefreshTokens: c.EnableMultiRefreshTokens,
 	}
 
 	// Retrieves connector objects in backend storage. This list includes the static connectors


### PR DESCRIPTION
fixes #981

This PR introduces `enableMultiRefreshTokens` option into config to enable multi refresh tokens per user.
In our environment, each user uses multiple id tokens in laptops so this feature is very helpful.

## Details

- `enableMultiRefreshTokens` option defaults to false and in that case this PR does not change any behavior.
- When `enableMultiRefreshTokens` is true, Dex skips to delete a refresh token in issuing an id token.
- To minimize changes in storage layer, `ListRefresh` and `RevokeRefresh` gRPC API use `Storage.ListRefreshTokens` in `enableMultiRefreshTokens` mode. This can be heavy but num of refresh tokens not is expected very high (same as num of id tokens).
- `storage.OfflineSessions.Refresh` contains the latest-issued refresh token.