### PR TITLE
Add Emacs backups to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 _output
 .idea
 /vendor/
+*~


### PR DESCRIPTION
Emacs backup files should be in .gitignore, to avoid accidental check-ins.

Signed-off-by: Alastair Houghton <alastair@alastairs-place.net>