### PR TITLE
fix: Bump golangci-lint version and fix some linter's problems

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
   - goimports
   - golint
   - gosimple
+  - gocritic
   - govet
   - ineffassign
   - interfacer
@@ -40,6 +41,5 @@ linters:
   # - gocyclo
   # - lll
   # - goconst
-  # - gocritic
   # - errcheck
   # - dupl

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,34 +1,45 @@
 run:
-    timeout: 2m
+  timeout: 2m
 
 linters-settings:
-    golint:
-        min-confidence: 0.1
-    goimports:
-        local-prefixes: github.com/dexidp/dex
+  golint:
+    min-confidence: 0.1
+  goimports:
+    local-prefixes: github.com/dexidp/dex
 
 linters:
-    enable-all: true
-    disable:
-        - funlen
-        - maligned
-        - wsl
+  disable-all: true
+  enable:
+  - bodyclose
+  - deadcode
+  - depguard
+  - dogsled
+  - gochecknoinits
+  - gofmt
+  - goimports
+  - golint
+  - gosimple
+  - govet
+  - ineffassign
+  - interfacer
+  - misspell
+  - nakedret
+  - staticcheck
+  - structcheck
+  - stylecheck
+  - typecheck
+  - unconvert
+  - unused
+  - varcheck
+  - whitespace
 
-        # TODO: fix me
-        - unparam
-        - golint
-        - goconst
-        - staticcheck
-        - nakedret
-        - errcheck
-        - gosec
-        - gochecknoinits
-        - gochecknoglobals
-        - prealloc
-        - scopelint
-        - lll
-        - dupl
-        - gocritic
-        - gocyclo
-        - gocognit
-        - godox
+  # TODO: fix linter errors before enabling
+  # - unparam
+  # - scopelint
+  # - gosec
+  # - gocyclo
+  # - lll
+  # - goconst
+  # - gocritic
+  # - errcheck
+  # - dupl

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ export GOBIN=$(PWD)/bin
 LD_FLAGS="-w -X $(REPO_PATH)/version.Version=$(VERSION)"
 
 # Dependency versions
-GOLANGCI_VERSION = 1.21.0
+GOLANGCI_VERSION = 1.31.0
 
 build: bin/dex
 

--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -49,7 +49,7 @@ type Config struct {
 	StaticPasswords []password `json:"staticPasswords"`
 }
 
-//Validate the configuration
+// Validate the configuration
 func (c Config) Validate() error {
 	// Fast checks. Perform these first for a more responsive CLI.
 	checks := []struct {

--- a/connector/atlassiancrowd/atlassiancrowd.go
+++ b/connector/atlassiancrowd/atlassiancrowd.go
@@ -111,7 +111,7 @@ func (c *crowdConnector) Login(ctx context.Context, s connector.Scopes, username
 
 	// We want to return a different error if the user's password is incorrect vs
 	// if there was an error.
-	incorrectPass := false
+	var incorrectPass bool
 	var user crowdUser
 
 	client := c.crowdAPIClient()

--- a/connector/authproxy/authproxy.go
+++ b/connector/authproxy/authproxy.go
@@ -34,7 +34,7 @@ func (m *callback) LoginURL(s connector.Scopes, callbackURL, state string) (stri
 	if err != nil {
 		return "", fmt.Errorf("failed to parse callbackURL %q: %v", callbackURL, err)
 	}
-	u.Path = u.Path + m.pathSuffix
+	u.Path += m.pathSuffix
 	v := u.Query()
 	v.Set("state", state)
 	u.RawQuery = v.Encode()

--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -334,11 +334,12 @@ func (c *githubConnector) Refresh(ctx context.Context, s connector.Scopes, ident
 
 // getGroups retrieves GitHub orgs and teams a user is in, if any.
 func (c *githubConnector) getGroups(ctx context.Context, client *http.Client, groupScope bool, userLogin string) ([]string, error) {
-	if len(c.orgs) > 0 {
+	switch {
+	case len(c.orgs) > 0:
 		return c.groupsForOrgs(ctx, client, userLogin)
-	} else if c.org != "" {
+	case c.org != "":
 		return c.teamsForOrg(ctx, client, c.org)
-	} else if groupScope && c.loadAllGroups {
+	case groupScope && c.loadAllGroups:
 		return c.userGroups(ctx, client)
 	}
 	return nil, nil

--- a/connector/google/google.go
+++ b/connector/google/google.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	admin "google.golang.org/api/admin/directory/v1"
+	"google.golang.org/api/option"
 
 	"github.com/dexidp/dex/connector"
 	pkg_groups "github.com/dexidp/dex/pkg/groups"
@@ -289,7 +290,7 @@ func createDirectoryService(serviceAccountFilePath string, email string) (*admin
 	ctx := context.Background()
 	client := config.Client(ctx)
 
-	srv, err := admin.New(client)
+	srv, err := admin.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return nil, fmt.Errorf("unable to create directory service %v", err)
 	}

--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -56,6 +56,7 @@ import (
 //         nameAttr: name
 //
 
+// UserMatcher holds information about user and group matching.
 type UserMatcher struct {
 	UserAttr  string `json:"userAttr"`
 	GroupAttr string `json:"groupAttr"`
@@ -189,7 +190,7 @@ func (c *ldapConnector) userMatchers() []UserMatcher {
 	if len(c.GroupSearch.UserMatchers) > 0 && c.GroupSearch.UserMatchers[0].UserAttr != "" {
 		return c.GroupSearch.UserMatchers[:]
 	}
-	
+
 	return []UserMatcher{
 		{
 			UserAttr:  c.GroupSearch.UserAttr,
@@ -303,7 +304,7 @@ var (
 // do initializes a connection to the LDAP directory and passes it to the
 // provided function. It then performs appropriate teardown or reuse before
 // returning.
-func (c *ldapConnector) do(ctx context.Context, f func(c *ldap.Conn) error) error {
+func (c *ldapConnector) do(_ context.Context, f func(c *ldap.Conn) error) error {
 	// TODO(ericchiang): support context here
 	var (
 		conn *ldap.Conn

--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -188,7 +188,7 @@ func parseScope(s string) (int, bool) {
 // See "Config.GroupSearch.UserMatchers" comments for the details
 func (c *ldapConnector) userMatchers() []UserMatcher {
 	if len(c.GroupSearch.UserMatchers) > 0 && c.GroupSearch.UserMatchers[0].UserAttr != "" {
-		return c.GroupSearch.UserMatchers[:]
+		return c.GroupSearch.UserMatchers
 	}
 
 	return []UserMatcher{
@@ -245,9 +245,9 @@ func (c *Config) openConnector(logger log.Logger) (*ldapConnector, error) {
 	if host, _, err = net.SplitHostPort(c.Host); err != nil {
 		host = c.Host
 		if c.InsecureNoSSL {
-			c.Host = c.Host + ":389"
+			c.Host += ":389"
 		} else {
-			c.Host = c.Host + ":636"
+			c.Host += ":636"
 		}
 	}
 

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -291,7 +291,7 @@ func TestRefreshToken(t *testing.T) {
 		t.Errorf("failed to marshal offline session ID: %v", err)
 	}
 
-	//Testing the api.
+	// Testing the api.
 	listReq := api.ListRefreshReq{
 		UserId: subjectString,
 	}

--- a/server/deviceflowhandlers_test.go
+++ b/server/deviceflowhandlers_test.go
@@ -24,7 +24,7 @@ func TestDeviceVerificationURI(t *testing.T) {
 	defer cancel()
 	// Setup a dex server.
 	httpServer, s := newTestServer(ctx, t, func(c *Config) {
-		c.Issuer = c.Issuer + "/non-root-path"
+		c.Issuer += "/non-root-path"
 		c.Now = now
 	})
 	defer httpServer.Close()
@@ -76,7 +76,7 @@ func TestHandleDeviceCode(t *testing.T) {
 
 			// Setup a dex server.
 			httpServer, s := newTestServer(ctx, t, func(c *Config) {
-				c.Issuer = c.Issuer + "/non-root-path"
+				c.Issuer += "/non-root-path"
 				c.Now = now
 			})
 			defer httpServer.Close()
@@ -322,7 +322,7 @@ func TestDeviceCallback(t *testing.T) {
 
 			// Setup a dex server.
 			httpServer, s := newTestServer(ctx, t, func(c *Config) {
-				//c.Issuer = c.Issuer + "/non-root-path"
+				// c.Issuer = c.Issuer + "/non-root-path"
 				c.Now = now
 			})
 			defer httpServer.Close()
@@ -506,7 +506,7 @@ func TestDeviceTokenResponse(t *testing.T) {
 
 			// Setup a dex server.
 			httpServer, s := newTestServer(ctx, t, func(c *Config) {
-				c.Issuer = c.Issuer + "/non-root-path"
+				c.Issuer += "/non-root-path"
 				c.Now = now
 			})
 			defer httpServer.Close()
@@ -637,7 +637,7 @@ func TestVerifyCodeResponse(t *testing.T) {
 
 			// Setup a dex server.
 			httpServer, s := newTestServer(ctx, t, func(c *Config) {
-				c.Issuer = c.Issuer + "/non-root-path"
+				c.Issuer += "/non-root-path"
 				c.Now = now
 			})
 			defer httpServer.Close()

--- a/server/deviceflowhandlers_test.go
+++ b/server/deviceflowhandlers_test.go
@@ -546,7 +546,7 @@ func TestDeviceTokenResponse(t *testing.T) {
 				t.Errorf("Could read token response %v", err)
 			}
 			if tc.expectedResponseCode == http.StatusBadRequest || tc.expectedResponseCode == http.StatusUnauthorized {
-				expectJsonErrorResponse(tc.testName, body, tc.expectedServerResponse, t)
+				expectJSONErrorResponse(tc.testName, body, tc.expectedServerResponse, t)
 			} else if string(body) != tc.expectedServerResponse {
 				t.Errorf("Unexpected Server Response.  Expected %v got %v", tc.expectedServerResponse, string(body))
 			}
@@ -554,7 +554,7 @@ func TestDeviceTokenResponse(t *testing.T) {
 	}
 }
 
-func expectJsonErrorResponse(testCase string, body []byte, expectedError string, t *testing.T) {
+func expectJSONErrorResponse(testCase string, body []byte, expectedError string, t *testing.T) {
 	jsonMap := make(map[string]interface{})
 	err := json.Unmarshal(body, &jsonMap)
 	if err != nil {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -274,7 +274,7 @@ func (s *Server) handleAuthorization(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := s.templates.login(r, w, connectorInfos, r.URL.Path); err != nil {
+	if err := s.templates.login(r, w, connectorInfos); err != nil {
 		s.logger.Errorf("Server template error: %v", err)
 	}
 }
@@ -335,7 +335,7 @@ func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 			}
 			http.Redirect(w, r, callbackURL, http.StatusFound)
 		case connector.PasswordConnector:
-			if err := s.templates.password(r, w, r.URL.String(), "", usernamePrompt(conn), false, showBacklink, r.URL.Path); err != nil {
+			if err := s.templates.password(r, w, r.URL.String(), "", usernamePrompt(conn), false, showBacklink); err != nil {
 				s.logger.Errorf("Server template error: %v", err)
 			}
 		case connector.SAMLConnector:
@@ -383,7 +383,7 @@ func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !ok {
-			if err := s.templates.password(r, w, r.URL.String(), username, usernamePrompt(passwordConnector), true, showBacklink, r.URL.Path); err != nil {
+			if err := s.templates.password(r, w, r.URL.String(), username, usernamePrompt(passwordConnector), true, showBacklink); err != nil {
 				s.logger.Errorf("Server template error: %v", err)
 			}
 			return
@@ -577,7 +577,7 @@ func (s *Server) handleApproval(w http.ResponseWriter, r *http.Request) {
 			s.renderError(r, w, http.StatusInternalServerError, "Failed to retrieve client.")
 			return
 		}
-		if err := s.templates.approval(r, w, authReq.ID, authReq.Claims.Username, client.Name, authReq.Scopes, r.URL.Path); err != nil {
+		if err := s.templates.approval(r, w, authReq.ID, authReq.Claims.Username, client.Name, authReq.Scopes); err != nil {
 			s.logger.Errorf("Server template error: %v", err)
 		}
 	case http.MethodPost:
@@ -650,7 +650,7 @@ func (s *Server) sendCodeResponse(w http.ResponseWriter, r *http.Request, authRe
 			// Implicit and hybrid flows that try to use the OOB redirect URI are
 			// rejected earlier. If we got here we're using the code flow.
 			if authReq.RedirectURI == redirectURIOOB {
-				if err := s.templates.oob(r, w, code.ID, r.URL.Path); err != nil {
+				if err := s.templates.oob(r, w, code.ID); err != nil {
 					s.logger.Errorf("Server template error: %v", err)
 				}
 				return

--- a/server/server.go
+++ b/server/server.go
@@ -305,7 +305,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 		}
 		r.Handle(path.Join(issuerURL.Path, p), instrumentHandlerCounter(p, handler))
 	}
-	r.NotFoundHandler = http.HandlerFunc(http.NotFound)
+	r.NotFoundHandler = http.NotFoundHandler()
 
 	discoveryHandler, err := s.discoveryHandler()
 	if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -177,7 +177,7 @@ func TestDiscovery(t *testing.T) {
 	defer cancel()
 
 	httpServer, _ := newTestServer(ctx, t, func(c *Config) {
-		c.Issuer = c.Issuer + "/non-root-path"
+		c.Issuer += "/non-root-path"
 	})
 	defer httpServer.Close()
 
@@ -504,7 +504,7 @@ func TestOAuth2CodeFlow(t *testing.T) {
 
 			// Setup a dex server.
 			httpServer, s := newTestServer(ctx, t, func(c *Config) {
-				c.Issuer = c.Issuer + "/non-root-path"
+				c.Issuer += "/non-root-path"
 				c.Now = now
 				c.IDTokensValidFor = idTokensValidFor
 			})
@@ -766,7 +766,7 @@ func TestCrossClientScopes(t *testing.T) {
 	defer cancel()
 
 	httpServer, s := newTestServer(ctx, t, func(c *Config) {
-		c.Issuer = c.Issuer + "/non-root-path"
+		c.Issuer += "/non-root-path"
 	})
 	defer httpServer.Close()
 
@@ -889,7 +889,7 @@ func TestCrossClientScopesWithAzpInAudienceByDefault(t *testing.T) {
 	defer cancel()
 
 	httpServer, s := newTestServer(ctx, t, func(c *Config) {
-		c.Issuer = c.Issuer + "/non-root-path"
+		c.Issuer += "/non-root-path"
 	})
 	defer httpServer.Close()
 
@@ -1180,7 +1180,7 @@ type oauth2Client struct {
 // that only valid refresh tokens can be used to refresh an expired token.
 func TestRefreshTokenFlow(t *testing.T) {
 	state := "state"
-	now := func() time.Time { return time.Now() }
+	now := time.Now
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1300,7 +1300,7 @@ func TestOAuth2DeviceFlow(t *testing.T) {
 
 			// Setup a dex server.
 			httpServer, s := newTestServer(ctx, t, func(c *Config) {
-				c.Issuer = c.Issuer + "/non-root-path"
+				c.Issuer += "/non-root-path"
 				c.Now = now
 				c.IDTokensValidFor = idTokensValidFor
 			})
@@ -1314,7 +1314,7 @@ func TestOAuth2DeviceFlow(t *testing.T) {
 				t.Fatalf("failed to get provider: %v", err)
 			}
 
-			//Add the Clients to the test server
+			// Add the Clients to the test server
 			client := storage.Client{
 				ID:           clientID,
 				RedirectURIs: []string{deviceCallbackURI},
@@ -1324,13 +1324,13 @@ func TestOAuth2DeviceFlow(t *testing.T) {
 				t.Fatalf("failed to create client: %v", err)
 			}
 
-			//Grab the issuer that we'll reuse for the different endpoints to hit
+			// Grab the issuer that we'll reuse for the different endpoints to hit
 			issuer, err := url.Parse(s.issuerURL.String())
 			if err != nil {
 				t.Errorf("Could not parse issuer URL %v", err)
 			}
 
-			//Send a new Device Request
+			// Send a new Device Request
 			codeURL, _ := url.Parse(issuer.String())
 			codeURL.Path = path.Join(codeURL.Path, "device/code")
 
@@ -1350,13 +1350,13 @@ func TestOAuth2DeviceFlow(t *testing.T) {
 				t.Errorf("%v - Unexpected Response Type.  Expected 200 got  %v.  Response: %v", tc.name, resp.StatusCode, string(responseBody))
 			}
 
-			//Parse the code response
+			// Parse the code response
 			var deviceCode deviceCodeResponse
 			if err := json.Unmarshal(responseBody, &deviceCode); err != nil {
 				t.Errorf("Unexpected Device Code Response Format %v", string(responseBody))
 			}
 
-			//Mock the user hitting the verification URI and posting the form
+			// Mock the user hitting the verification URI and posting the form
 			verifyURL, _ := url.Parse(issuer.String())
 			verifyURL.Path = path.Join(verifyURL.Path, "/device/auth/verify_code")
 			urlData := url.Values{}
@@ -1374,7 +1374,7 @@ func TestOAuth2DeviceFlow(t *testing.T) {
 				t.Errorf("%v - Unexpected Response Type.  Expected 200 got  %v.  Response: %v", tc.name, resp.StatusCode, string(responseBody))
 			}
 
-			//Hit the Token Endpoint, and try and get an access token
+			// Hit the Token Endpoint, and try and get an access token
 			tokenURL, _ := url.Parse(issuer.String())
 			tokenURL.Path = path.Join(tokenURL.Path, "/device/token")
 			v := url.Values{}
@@ -1393,7 +1393,7 @@ func TestOAuth2DeviceFlow(t *testing.T) {
 				t.Errorf("%v - Unexpected Token Response Type.  Expected 200 got  %v.  Response: %v", tc.name, resp.StatusCode, string(responseBody))
 			}
 
-			//Parse the response
+			// Parse the response
 			var tokenRes accessTokenReponse
 			if err := json.Unmarshal(responseBody, &tokenRes); err != nil {
 				t.Errorf("Unexpected Device Access Token Response Format %v", string(responseBody))
@@ -1411,7 +1411,7 @@ func TestOAuth2DeviceFlow(t *testing.T) {
 				token.Expiry = time.Now().Add(time.Duration(secs) * time.Second)
 			}
 
-			//Run token tests to validate info is correct
+			// Run token tests to validate info is correct
 			// Create the OAuth2 config.
 			oauth2Config := &oauth2.Config{
 				ClientID:     client.ID,

--- a/server/templates.go
+++ b/server/templates.go
@@ -178,11 +178,11 @@ func loadTemplates(c webConfig, templatesDir string) (*templates, error) {
 // 3. For each part of reqPath remaining(minus one), go up one level (..)
 // 4. For each part of assetPath remaining, append it to result
 //
-//eg
-//server listens at localhost/dex so serverPath is dex
-//reqPath is /dex/auth
-//assetPath is static/main.css
-//relativeURL("/dex", "/dex/auth", "static/main.css") = "../static/main.css"
+// eg
+// server listens at localhost/dex so serverPath is dex
+// reqPath is /dex/auth
+// assetPath is static/main.css
+// relativeURL("/dex", "/dex/auth", "static/main.css") = "../static/main.css"
 func relativeURL(serverPath, reqPath, assetPath string) string {
 	if u, err := url.ParseRequestURI(assetPath); err == nil && u.Scheme != "" {
 		// assetPath points to the external URL, no changes needed

--- a/storage/conformance/conformance.go
+++ b/storage/conformance/conformance.go
@@ -763,10 +763,8 @@ func testGC(t *testing.T, s storage.Storage) {
 		result, err := s.GarbageCollect(expiry.Add(-time.Hour).In(tz))
 		if err != nil {
 			t.Errorf("garbage collection failed: %v", err)
-		} else {
-			if result.AuthCodes != 0 || result.AuthRequests != 0 {
-				t.Errorf("expected no garbage collection results, got %#v", result)
-			}
+		} else if result.AuthCodes != 0 || result.AuthRequests != 0 {
+			t.Errorf("expected no garbage collection results, got %#v", result)
 		}
 		if _, err := s.GetAuthCode(c.ID); err != nil {
 			t.Errorf("expected to be able to get auth code after GC: %v", err)
@@ -815,10 +813,8 @@ func testGC(t *testing.T, s storage.Storage) {
 		result, err := s.GarbageCollect(expiry.Add(-time.Hour).In(tz))
 		if err != nil {
 			t.Errorf("garbage collection failed: %v", err)
-		} else {
-			if result.AuthCodes != 0 || result.AuthRequests != 0 {
-				t.Errorf("expected no garbage collection results, got %#v", result)
-			}
+		} else if result.AuthCodes != 0 || result.AuthRequests != 0 {
+			t.Errorf("expected no garbage collection results, got %#v", result)
 		}
 		if _, err := s.GetAuthRequest(a.ID); err != nil {
 			t.Errorf("expected to be able to get auth request after GC: %v", err)
@@ -859,10 +855,8 @@ func testGC(t *testing.T, s storage.Storage) {
 		result, err := s.GarbageCollect(expiry.Add(-time.Hour).In(tz))
 		if err != nil {
 			t.Errorf("garbage collection failed: %v", err)
-		} else {
-			if result.DeviceRequests != 0 {
-				t.Errorf("expected no device garbage collection results, got %#v", result)
-			}
+		} else if result.DeviceRequests != 0 {
+			t.Errorf("expected no device garbage collection results, got %#v", result)
 		}
 		if _, err := s.GetDeviceRequest(d.UserCode); err != nil {
 			t.Errorf("expected to be able to get auth request after GC: %v", err)
@@ -897,10 +891,8 @@ func testGC(t *testing.T, s storage.Storage) {
 		result, err := s.GarbageCollect(expiry.Add(-time.Hour).In(tz))
 		if err != nil {
 			t.Errorf("garbage collection failed: %v", err)
-		} else {
-			if result.DeviceTokens != 0 {
-				t.Errorf("expected no device token garbage collection results, got %#v", result)
-			}
+		} else if result.DeviceTokens != 0 {
+			t.Errorf("expected no device token garbage collection results, got %#v", result)
 		}
 		if _, err := s.GetDeviceToken(dt.DeviceCode); err != nil {
 			t.Errorf("expected to be able to get device token after GC: %v", err)
@@ -987,12 +979,12 @@ func testDeviceRequestCRUD(t *testing.T, s storage.Storage) {
 	err = s.CreateDeviceRequest(d1)
 	mustBeErrAlreadyExists(t, "device request", err)
 
-	//No manual deletes for device requests, will be handled by garbage collection routines
-	//see testGC
+	// No manual deletes for device requests, will be handled by garbage collection routines
+	// see testGC
 }
 
 func testDeviceTokenCRUD(t *testing.T, s storage.Storage) {
-	//Create a Token
+	// Create a Token
 	d1 := storage.DeviceToken{
 		DeviceCode:          storage.NewID(),
 		Status:              "pending",
@@ -1010,7 +1002,7 @@ func testDeviceTokenCRUD(t *testing.T, s storage.Storage) {
 	err := s.CreateDeviceToken(d1)
 	mustBeErrAlreadyExists(t, "device token", err)
 
-	//Update the device token, simulate a redemption
+	// Update the device token, simulate a redemption
 	if err := s.UpdateDeviceToken(d1.DeviceCode, func(old storage.DeviceToken) (storage.DeviceToken, error) {
 		old.Token = "token data"
 		old.Status = "complete"
@@ -1019,13 +1011,13 @@ func testDeviceTokenCRUD(t *testing.T, s storage.Storage) {
 		t.Fatalf("failed to update device token: %v", err)
 	}
 
-	//Retrieve the device token
+	// Retrieve the device token
 	got, err := s.GetDeviceToken(d1.DeviceCode)
 	if err != nil {
 		t.Fatalf("failed to get device token: %v", err)
 	}
 
-	//Validate expected result set
+	// Validate expected result set
 	if got.Status != "complete" {
 		t.Fatalf("update failed, wanted token status=%v got %v", "complete", got.Status)
 	}

--- a/storage/kubernetes/k8sapi/client.go
+++ b/storage/kubernetes/k8sapi/client.go
@@ -24,7 +24,7 @@ type Config struct {
 	// Legacy field from pkg/api/types.go TypeMeta.
 	// TODO(jlowdermilk): remove this after eliminating downstream dependencies.
 	Kind string `json:"kind,omitempty"`
-	// DEPRECATED: APIVersion is the preferred api version for communicating with the kubernetes cluster (v1, v2, etc).
+	// Deprecated: APIVersion is the preferred api version for communicating with the kubernetes cluster (v1, v2, etc).
 	// Because a cluster can run multiple API groups and potentially multiple versions of each, it no longer makes sense to specify
 	// a single value for the cluster version.
 	// This field isn't really needed anyway, so we are deprecating it without replacement.

--- a/storage/kubernetes/types.go
+++ b/storage/kubernetes/types.go
@@ -679,7 +679,7 @@ type DeviceRequest struct {
 	Expiry       time.Time `json:"expiry"`
 }
 
-// AuthRequestList is a list of AuthRequests.
+// DeviceRequestList is a list of DeviceRequests.
 type DeviceRequestList struct {
 	k8sapi.TypeMeta `json:",inline"`
 	k8sapi.ListMeta `json:"metadata,omitempty"`

--- a/storage/sql/config.go
+++ b/storage/sql/config.go
@@ -289,16 +289,19 @@ func (s *MySQL) open(logger log.Logger) (*conn, error) {
 			cfg.Addr = s.Host
 		}
 	}
-	if s.SSL.CAFile != "" || s.SSL.CertFile != "" || s.SSL.KeyFile != "" {
+
+	switch {
+	case s.SSL.CAFile != "" || s.SSL.CertFile != "" || s.SSL.KeyFile != "":
 		if err := s.makeTLSConfig(); err != nil {
 			return nil, fmt.Errorf("failed to make TLS config: %v", err)
 		}
 		cfg.TLSConfig = mysqlSSLCustom
-	} else if s.SSL.Mode == "" {
+	case s.SSL.Mode == "":
 		cfg.TLSConfig = mysqlSSLTrue
-	} else {
+	default:
 		cfg.TLSConfig = s.SSL.Mode
 	}
+
 	for k, v := range s.params {
 		cfg.Params[k] = v
 	}

--- a/storage/sql/crud.go
+++ b/storage/sql/crud.go
@@ -84,7 +84,9 @@ type scanner interface {
 	Scan(dest ...interface{}) error
 }
 
-func (c *conn) GarbageCollect(now time.Time) (result storage.GCResult, err error) {
+func (c *conn) GarbageCollect(now time.Time) (storage.GCResult, error) {
+	result := storage.GCResult{}
+
 	r, err := c.Exec(`delete from auth_request where expiry < $1`, now)
 	if err != nil {
 		return result, fmt.Errorf("gc auth_request: %v", err)
@@ -117,7 +119,7 @@ func (c *conn) GarbageCollect(now time.Time) (result storage.GCResult, err error
 		result.DeviceTokens = n
 	}
 
-	return
+	return result, err
 }
 
 func (c *conn) CreateAuthRequest(a storage.AuthRequest) error {

--- a/storage/static.go
+++ b/storage/static.go
@@ -96,7 +96,7 @@ type staticPasswordsStorage struct {
 func WithStaticPasswords(s Storage, staticPasswords []Password, logger log.Logger) Storage {
 	passwordsByEmail := make(map[string]Password, len(staticPasswords))
 	for _, p := range staticPasswords {
-		//Enable case insensitive email comparison.
+		// Enable case insensitive email comparison.
 		lowerEmail := strings.ToLower(p.Email)
 		if _, ok := passwordsByEmail[lowerEmail]; ok {
 			logger.Errorf("Attempting to create StaticPasswords with the same email id: %s", p.Email)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -25,7 +25,7 @@ var (
 // TODO(ericchiang): refactor ID creation onto the storage.
 var encoding = base32.NewEncoding("abcdefghijklmnopqrstuvwxyz234567")
 
-//Valid characters for user codes
+// Valid characters for user codes
 const validUserCharacters = "BCDFGHJKLMNPQRSTVWXZ"
 
 // NewDeviceCode returns a 32 char alphanumeric cryptographically secure string

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -384,23 +384,24 @@ func randomString(n int) (string, error) {
 	return string(bytes), nil
 }
 
-//DeviceRequest represents an OIDC device authorization request.  It holds the state of a device request until the user
-//authenticates using their user code or the expiry time passes.
+// DeviceRequest represents an OIDC device authorization request. It holds the state of a device request until the user
+// authenticates using their user code or the expiry time passes.
 type DeviceRequest struct {
-	//The code the user will enter in a browser
+	// The code the user will enter in a browser
 	UserCode string
-	//The unique device code for device authentication
+	// The unique device code for device authentication
 	DeviceCode string
-	//The client ID the code is for
+	// The client ID the code is for
 	ClientID string
-	//The Client Secret
+	// The Client Secret
 	ClientSecret string
-	//The scopes the device requests
+	// The scopes the device requests
 	Scopes []string
-	//The expire time
+	// The expire time
 	Expiry time.Time
 }
 
+// DeviceToken is a structure which represents the actual token of an authorized device and its rotation parameters
 type DeviceToken struct {
 	DeviceCode          string
 	Status              string


### PR DESCRIPTION
There is a naughty warning in the "Run linter" CI job logs:
```
[runner] Can't run linter goanalysis_metalinter: ST1001: failed prerequisites:...
```
Examples: [1](https://github.com/dexidp/dex/runs/1264022987?check_suite_focus=true), [2](https://github.com/dexidp/dex/runs/1247767485?check_suite_focus=true), [3](https://github.com/dexidp/dex/runs/1260081191?check_suite_focus=true)

Bumping the golangci-lint version to the actual one fixes the problem. It requires golangci-linter configuration changes because the `enable-all` option was marked as deprecated. Users have to use the `disable-all` option and manually enable linters they want.

I also fixed some style problems to enable the following linters:
- golint
- gochecknoinits
- gocritic
- ineffassign
- nakedret
- staticcheck
- varcheck

Think it might be a useful improvement.