### PR TITLE
Allow configuration of returned auth proxy header

### DIFF
--- a/connector/authproxy/authproxy.go
+++ b/connector/authproxy/authproxy.go
@@ -15,7 +15,8 @@ import (
 // Config holds the configuration parameters for a connector which returns an
 // identity with the HTTP header X-Remote-User as verified email.
 type Config struct {
-	HeaderName string `json:"headerName"`
+	HeaderName string   `json:"headerName"`
+	Groups     []string `json:"groups"`
 }
 
 // Open returns an authentication strategy which requires no user interaction.
@@ -23,13 +24,14 @@ func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error)
 	if c.HeaderName == "" {
 		c.HeaderName = "X-Remote-User"
 	}
-	return &callback{headerName: c.HeaderName, logger: logger, pathSuffix: "/" + id}, nil
+	return &callback{headerName: c.HeaderName, logger: logger, pathSuffix: "/" + id, groups: c.Groups}, nil
 }
 
 // Callback is a connector which returns an identity with the HTTP header
 // X-Remote-User as verified email.
 type callback struct {
 	headerName string
+	groups     []string
 	logger     log.Logger
 	pathSuffix string
 }
@@ -59,5 +61,6 @@ func (m *callback) HandleCallback(s connector.Scopes, r *http.Request) (connecto
 		UserID:        remoteUser, // TODO: figure out if this is a bad ID value.
 		Email:         remoteUser,
 		EmailVerified: true,
+		Groups:        m.groups,
 	}, nil
 }


### PR DESCRIPTION
This is a small PR to allow configuration of the header returned by the auth proxy.
We are using traefik as reverse proxy + traefik-forward-auth plugged on google to access our argocd interface.
But in traefik-forward-auth, the returned header after authentication is `X-Forwarded-User`.
With this feature, we can now login to argocd using the dex config :
```
connectors:
      - type: authproxy
        id: traefik
        name: traefik
        config:
          headerName: X-Forwarded-User
```
dex will fetch the header set by traefik forward auth and authenticate the user with the correct user email.