### PR TITLE
chore: Add description templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+<!--
+Thank you for sending a bug report! Here some tips:
+
+1. Please fill the template below to make it easier to debug your problem.
+2. If you are not sure is it a bug or not, you can ask your question in the Kubernetes slack channel `#dexidp`
+-->
+
+**Expected behavior (what you expected to happen)**:
+
+**Actual behavior (what actually happened)**:
+
+**Steps how to reproduce it**:
+1. ...
+2. ...
+3. ...
+
+**Anything else we need to know?**:
+
+**Environment**:
+- Dex version:
+- Storage type:
+- Installation type (official docker image, helm chart, etc.):
+
+**Additional information for debugging (is necessary)**:
+- Dex configuration:
+- Dex logs during the problem:

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+- name: Dex Slack channel
+  url: https://kubernetes.slack.com/messages/dexidp
+  about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,8 @@
+<!--
+ Thank you for sending a feature request! 
+ Please describe in detail what do you want and why by filling the template below.
+ -->
+
+**What would you like to be added/changed**:
+
+**Why we need this**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!--
+Thank you for sending a pull request! Here some tips for contributors:
+
+1. Fill the description template below.
+2. Sign a DCO (if you haven't already signed it).
+3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
+4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
+-->
+
+**Overview**:
+<!-- Describe your changes briefly here. -->
+
+**What problem does it solve?**:
+<!--
+- Please state in detail why we need this PR and what it solves.
+- If your PR closes some of the existing issues, please add links to them here.
+  Mentioned issues will be automatically closed.
+  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
+-->
+
+**Special notes for a reviewer**:


### PR DESCRIPTION
**Overview**:
This PR adds issues templates and pull request template according to [this documentation](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/using-templates-to-encourage-useful-issues-and-pull-requests)

**What problem does it solve?**:
Templates make it easier to maintain the project.
* Bug report template will help with collecting the necessary information for debugging
* Pull request and feature request templates will help people to think about why they open / would like to open a PR

Adding them will standardize the communication process between maintainers and users.