### PR TITLE
Copy module dependencies to Docker image for CVE scanning / dependency analysis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,10 @@ USER 1001:1001
 
 COPY --from=0 /go/bin/dex /usr/local/bin/dex
 
+# Copy module dependencies for CVE scanning / dependency analysis.
+COPY go.mod go.sum                 /opt/dex/dependencies/
+COPY api/v2/go.mod api/v2/go.sum   /opt/dex/dependencies/api/v2/
+
 # Import frontend assets and set the correct CWD directory so the assets
 # are in the default path.
 COPY web web


### PR DESCRIPTION
Signed-off-by: Martin Heide <martin.heide@faro.com>

<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

**Overview**:
- Add go.mod + go.sum to Dex docker image.

**What problem does it solve?**:
- Inventory of Go modules for analysis of CVEs and open source licenses.
- Important for commercial projects.

**Special notes for a reviewer**:

Example inventory result from WhiteSource:
![image](https://user-images.githubusercontent.com/66078329/98940334-1f8a3d80-24eb-11eb-80b1-cc0c82b67df9.png)
