### PR TITLE
Don't try to build sqlite storage when cgo isn't enabled

### DIFF
--- a/storage/sql/config.go
+++ b/storage/sql/config.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/lib/pq"
-	sqlite3 "github.com/mattn/go-sqlite3"
 
 	"github.com/dexidp/dex/pkg/log"
 	"github.com/dexidp/dex/storage"
@@ -31,47 +30,6 @@ const (
 	mysqlErrDupEntryWithKeyName = 1586
 	mysqlErrUnknownSysVar       = 1193
 )
-
-// SQLite3 options for creating an SQL db.
-type SQLite3 struct {
-	// File to
-	File string `json:"file"`
-}
-
-// Open creates a new storage implementation backed by SQLite3
-func (s *SQLite3) Open(logger log.Logger) (storage.Storage, error) {
-	conn, err := s.open(logger)
-	if err != nil {
-		return nil, err
-	}
-	return conn, nil
-}
-
-func (s *SQLite3) open(logger log.Logger) (*conn, error) {
-	db, err := sql.Open("sqlite3", s.File)
-	if err != nil {
-		return nil, err
-	}
-	if s.File == ":memory:" {
-		// sqlite3 uses file locks to coordinate concurrent access. In memory
-		// doesn't support this, so limit the number of connections to 1.
-		db.SetMaxOpenConns(1)
-	}
-
-	errCheck := func(err error) bool {
-		sqlErr, ok := err.(sqlite3.Error)
-		if !ok {
-			return false
-		}
-		return sqlErr.ExtendedCode == sqlite3.ErrConstraintPrimaryKey
-	}
-
-	c := &conn{db, &flavorSQLite3, logger, errCheck}
-	if _, err := c.migrate(); err != nil {
-		return nil, fmt.Errorf("failed to perform migrations: %v", err)
-	}
-	return c, nil
-}
 
 // nolint
 const (

--- a/storage/sql/config_test.go
+++ b/storage/sql/config_test.go
@@ -85,10 +85,6 @@ func testDB(t *testing.T, o opener, withTransactions bool) {
 	}
 }
 
-func TestSQLite3(t *testing.T) {
-	testDB(t, &SQLite3{":memory:"}, false)
-}
-
 func getenv(key, defaultVal string) string {
 	if val := os.Getenv(key); val != "" {
 		return val

--- a/storage/sql/crud_test.go
+++ b/storage/sql/crud_test.go
@@ -1,3 +1,5 @@
+// +build cgo
+
 package sql
 
 import (

--- a/storage/sql/migrate_test.go
+++ b/storage/sql/migrate_test.go
@@ -1,3 +1,5 @@
+// +build cgo
+
 package sql
 
 import (

--- a/storage/sql/sqlite.go
+++ b/storage/sql/sqlite.go
@@ -1,0 +1,54 @@
+// +build cgo
+
+package sql
+
+import (
+	"database/sql"
+	"fmt"
+
+	sqlite3 "github.com/mattn/go-sqlite3"
+
+	"github.com/dexidp/dex/pkg/log"
+	"github.com/dexidp/dex/storage"
+)
+
+// SQLite3 options for creating an SQL db.
+type SQLite3 struct {
+	// File to
+	File string `json:"file"`
+}
+
+// Open creates a new storage implementation backed by SQLite3
+func (s *SQLite3) Open(logger log.Logger) (storage.Storage, error) {
+	conn, err := s.open(logger)
+	if err != nil {
+		return nil, err
+	}
+	return conn, nil
+}
+
+func (s *SQLite3) open(logger log.Logger) (*conn, error) {
+	db, err := sql.Open("sqlite3", s.File)
+	if err != nil {
+		return nil, err
+	}
+	if s.File == ":memory:" {
+		// sqlite3 uses file locks to coordinate concurrent access. In memory
+		// doesn't support this, so limit the number of connections to 1.
+		db.SetMaxOpenConns(1)
+	}
+
+	errCheck := func(err error) bool {
+		sqlErr, ok := err.(sqlite3.Error)
+		if !ok {
+			return false
+		}
+		return sqlErr.ExtendedCode == sqlite3.ErrConstraintPrimaryKey
+	}
+
+	c := &conn{db, &flavorSQLite3, logger, errCheck}
+	if _, err := c.migrate(); err != nil {
+		return nil, fmt.Errorf("failed to perform migrations: %v", err)
+	}
+	return c, nil
+}

--- a/storage/sql/sqlite_test.go
+++ b/storage/sql/sqlite_test.go
@@ -1,0 +1,11 @@
+// +build cgo
+
+package sql
+
+import (
+	"testing"
+)
+
+func TestSQLite3(t *testing.T) {
+	testDB(t, &SQLite3{":memory:"}, false)
+}


### PR DESCRIPTION
**Overview**:
Split the SQLite storage backend into a separate file and add a build tag so dex can compile when cgo is disabled.

**What problem does it solve?**:
`github.com/mattn/go-sqlite3` requires cgo, which causes the entire `storage/sql` package to fail to compile:

```
go test ./storage/...
?   	github.com/dexidp/dex/storage	[no test files]
?   	github.com/dexidp/dex/storage/conformance	[no test files]
# github.com/dexidp/dex/storage/sql [github.com/dexidp/dex/storage/sql.test]
storage/sql/sqlite.go:40:22: undefined: sqlite3.Error
storage/sql/sqlite.go:44:33: undefined: sqlite3.ErrConstraintPrimaryKey
storage/sql/migrate_test.go:26:22: undefined: sqlite3.Error
storage/sql/migrate_test.go:30:33: undefined: sqlite3.ErrConstraintUnique
```
