### PR TITLE
Allow public clients created with API to have no client_secret

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -50,7 +50,7 @@ func (d dexAPI) CreateClient(ctx context.Context, req *api.CreateClientReq) (*ap
 	if req.Client.Id == "" {
 		req.Client.Id = storage.NewID()
 	}
-	if req.Client.Secret == "" {
+	if req.Client.Secret == "" && !req.Client.Public {
 		req.Client.Secret = storage.NewID() + storage.NewID()
 	}
 


### PR DESCRIPTION
**Overview**:
Allows public clients created with the API to have no client_secret to support the PKCE flow.

**What problem does it solve?**:
Closes: #1870. Now all clients with no client_secret created by the API gets a random secret. This adds a check if the client is public and allows for empty client_secret if that is the case.