### PR TITLE
docs: Correct tlsClientCA example reference

### DIFF
--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -60,7 +60,7 @@ telemetry:
 #   addr: 127.0.0.1:5557
 #  tlsCert: examples/grpc-client/server.crt
 #  tlsKey: examples/grpc-client/server.key
-#  tlsClientCA: /etc/dex/client.crt
+#  tlsClientCA: examples/grpc-client/ca.crt
 
 # Uncomment this block to enable configuration for the expiration time durations.
 # expiry:


### PR DESCRIPTION
#### Overview

Update path reference in documentation example.

#### What this PR does / why we need it

The example path probably doesn't exist, and even if it does, the filename is pretty much certainly wrong.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
