### PR TITLE
update example/k8s/dex.yaml

### DIFF
--- a/examples/k8s/dex.yaml
+++ b/examples/k8s/dex.yaml
@@ -1,11 +1,21 @@
-apiVersion: extensions/v1beta1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dex
+---
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     app: dex
   name: dex
+  namespace: dex
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: dex
   template:
     metadata:
       labels:
@@ -13,7 +23,7 @@ spec:
     spec:
       serviceAccountName: dex # This is created below
       containers:
-      - image: quay.io/dexidp/dex:v2.10.0
+      - image: dexidp/dex:v2.27.0 #or quay.io/dexidp/dex:v2.26.0
         name: dex
         command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
 
@@ -38,6 +48,11 @@ spec:
             secretKeyRef:
               name: github-client
               key: client-secret
+
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 5556
       volumes:
       - name: config
         configMap:
@@ -53,6 +68,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: dex
+  namespace: dex
 data:
   config.yaml: |
     issuer: https://dex.example.com:32000
@@ -95,6 +111,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: dex
+  namespace: dex
 spec:
   type: NodePort
   ports:
@@ -112,8 +129,9 @@ metadata:
   labels:
     app: dex
   name: dex
+  namespace: dex
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: dex
@@ -125,7 +143,7 @@ rules:
   resources: ["customresourcedefinitions"]
   verbs: ["create"] # To manage its own resources, dex must be able to create customresourcedefinitions
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: dex
@@ -136,4 +154,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: dex           # Service account assigned to the dex pod, created above
-  namespace: default  # The namespace dex is running in
+  namespace: dex  # The namespace dex is running in


### PR DESCRIPTION
#### Overview

update example/k8s/dex.yaml

#### What this PR does / why we need it

example/k8s/dex.yaml is too old.
api version is not valid in lastest kubernetes cluster.
The service account may not have a default namespace when executing a kubectl command

#### Special notes for your reviewer
NONE

#### Does this PR introduce a user-facing change?
NONE

