### PR TITLE
Fix the etcd PKCE AuthCode deserialization

### DIFF
--- a/storage/conformance/conformance.go
+++ b/storage/conformance/conformance.go
@@ -185,6 +185,10 @@ func testAuthCodeCRUD(t *testing.T, s storage.Storage) {
 		Expiry:        neverExpire,
 		ConnectorID:   "ldap",
 		ConnectorData: []byte(`{"some":"data"}`),
+		PKCE: storage.PKCE{
+			CodeChallenge:       "12345",
+			CodeChallengeMethod: "Whatever",
+		},
 		Claims: storage.Claims{
 			UserID:        "1",
 			Username:      "jane",

--- a/storage/etcd/etcd.go
+++ b/storage/etcd/etcd.go
@@ -156,7 +156,11 @@ func (c *conn) CreateAuthCode(a storage.AuthCode) error {
 func (c *conn) GetAuthCode(id string) (a storage.AuthCode, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultStorageTimeout)
 	defer cancel()
-	err = c.getKey(ctx, keyID(authCodePrefix, id), &a)
+	var ac AuthCode
+	err = c.getKey(ctx, keyID(authCodePrefix, id), &ac)
+	if err == nil {
+		a = toStorageAuthCode(ac)
+	}
 	return a, err
 }
 

--- a/storage/etcd/types.go
+++ b/storage/etcd/types.go
@@ -26,6 +26,24 @@ type AuthCode struct {
 	CodeChallengeMethod string `json:"code_challenge_method,omitempty"`
 }
 
+func toStorageAuthCode(a AuthCode) storage.AuthCode {
+	return storage.AuthCode{
+		ID:            a.ID,
+		ClientID:      a.ClientID,
+		RedirectURI:   a.RedirectURI,
+		ConnectorID:   a.ConnectorID,
+		ConnectorData: a.ConnectorData,
+		Nonce:         a.Nonce,
+		Scopes:        a.Scopes,
+		Claims:        toStorageClaims(a.Claims),
+		Expiry:        a.Expiry,
+		PKCE: storage.PKCE{
+			CodeChallenge:       a.CodeChallenge,
+			CodeChallengeMethod: a.CodeChallengeMethod,
+		},
+	}
+}
+
 func fromStorageAuthCode(a storage.AuthCode) AuthCode {
 	return AuthCode{
 		ID:                  a.ID,


### PR DESCRIPTION
#### Overview

This change fixes a bug in the PKCE implementation when using `etcd` as the storage engine. As of v2.27.0, this combination is broken and a `code_verifier` cannot be used to request a token. 

Specifically, you will get an errant error `No PKCE flow started. Cannot check code_verifier` error when requesting `/token` despite the fact that a `code_challenge` and `code_challenge_method` were indeed provided to `/auth`.

This PR also adds a PKCE AuthCode round-trip check to the storage conformance tests. Indeed that test fails on v2.27, and now it passes 🙏 .

#### What this PR does / why we need it

- In `CreateAuthCode`, the etcd storage implementation uses `fromStorageAuthCode()` to convert a `storage.AuthCode` into the etcd variant.
- In `GetAuthCode`, however, the implementation attempts to directly unmarshal the json into the `storage.AuthCode` without the etcd intermediate.
- This is wrong! Specifically, the PKCE data is inline in the etcd `AuthCode` struct, but is nested in the `storage.AuthCode` struct.
- So as a result, it kind of works because most fields line up, but the `CodeChallenge` is always the empty string.
- Therefore, `handlers.go:820` always gets `codeChallengeFromStorage = ""` and falls into the error condition.
- This PR adds the `toStorageAuthCode` equivalent to correctly deserialize, and uses it. 

#### Special notes for your reviewer

Enjoy! 💖

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
