### PR TITLE
Support setting the prompt type for the Microsoft connector

### DIFF
--- a/connector/microsoft/microsoft.go
+++ b/connector/microsoft/microsoft.go
@@ -53,6 +53,10 @@ type Config struct {
 	GroupNameFormat      GroupNameFormat `json:"groupNameFormat"`
 	UseGroupsAsWhitelist bool            `json:"useGroupsAsWhitelist"`
 	EmailToLowercase     bool            `json:"emailToLowercase"`
+
+	// PromptType is used for the prompt query parameter.
+	// For valid values, see https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code.
+	PromptType string `json:"promptType"`
 }
 
 // Open returns a strategy for logging in through Microsoft.
@@ -70,6 +74,7 @@ func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error)
 		useGroupsAsWhitelist: c.UseGroupsAsWhitelist,
 		logger:               logger,
 		emailToLowercase:     c.EmailToLowercase,
+		promptType:           c.PromptType,
 	}
 	// By default allow logins from both personal and business/school
 	// accounts.
@@ -113,6 +118,7 @@ type microsoftConnector struct {
 	useGroupsAsWhitelist bool
 	logger               log.Logger
 	emailToLowercase     bool
+	promptType           string
 }
 
 func (c *microsoftConnector) isOrgTenant() bool {
@@ -150,7 +156,12 @@ func (c *microsoftConnector) LoginURL(scopes connector.Scopes, callbackURL, stat
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}
 
-	return c.oauth2Config(scopes).AuthCodeURL(state), nil
+	var options []oauth2.AuthCodeOption
+	if c.promptType != "" {
+		options = append(options, oauth2.SetAuthURLParam("prompt", c.promptType))
+	}
+
+	return c.oauth2Config(scopes).AuthCodeURL(state, options...), nil
 }
 
 func (c *microsoftConnector) HandleCallback(s connector.Scopes, r *http.Request) (identity connector.Identity, err error) {


### PR DESCRIPTION
Signed-off-by: Erica Taylor <ricky@wellplayed.games>

#### Overview
This PR adds a `promptType` field to the configuration of the Microsoft connector.
Closes #1911.

#### What this PR does / why we need it
This allows users of Dex to specify which kind of prompt the Microsoft connector should display. Previously this used the default value which didn't prompt unless the user was signed out of Microsoft.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
```release-note
The prompt type which the Microsoft connector uses can now be configured with the `promptType` setting.
Valid values are `login`, `none`, `consent` and `select_account`.
```
