### PR TITLE
Extend OpenLDAP example for LDAPS

### DIFF
--- a/examples/ldap/config-ldap.yaml
+++ b/examples/ldap/config-ldap.yaml
@@ -11,10 +11,23 @@ connectors:
   name: OpenLDAP
   id: ldap
   config:
+    # The following configurations seem to work with OpenLDAP:
+    #
+    # 1) Plain LDAP, without TLS:
     host: localhost:389
-
-    # No TLS for this setup.
     insecureNoSSL: true
+    #
+    # 2) LDAPS without certificate validation:
+    #host: localhost:636
+    #insecureNoSSL: false
+    #insecureSkipVerify: true
+    #
+    # 3) LDAPS with certificate validation:
+    #host: YOUR-HOSTNAME:636
+    #insecureNoSSL: false
+    #insecureSkipVerify: false
+    #rootCAData: 'CERT'
+    # ...where CERT="$( base64 -w 0 your-cert.crt )"
 
     # This would normally be a read-only user.
     bindDN: cn=admin,dc=example,dc=org

--- a/examples/ldap/docker-compose.yaml
+++ b/examples/ldap/docker-compose.yaml
@@ -1,11 +1,24 @@
 version: "3"
 
+# For LDAPS with certificate validation:
+# How to extract the TLS certificate from the OpenLDAP container, and encode it for the Dex config (`rootCAData`):
+#   $ docker-compose exec ldap cat /container/run/service/slapd/assets/certs/ca.crt | base64 -w 0
+# But note this issue: https://github.com/osixia/docker-openldap/issues/506
+
 services:
   ldap:
     image: osixia/openldap:1.4.0
     # Copying is required because the entrypoint modifies the *.ldif files.
     # For verbose output, use:  command: ["--copy-service", "--loglevel", "debug"]
     command: ["--copy-service"]
+    environment:
+      # Required if using LDAPS:
+      # Since Dex doesn't use a client TLS certificate, downgrade from "demand" to "try".
+      LDAP_TLS_VERIFY_CLIENT: try
+    # The hostname is required if using LDAPS with certificate validation.
+    # In Dex, use the same hostname (with port) for `connectors[].config.host`.
+    #hostname: YOUR-HOSTNAME
+    #
     # https://github.com/osixia/docker-openldap#seed-ldap-database-with-ldif
     # Option 1: Add custom seed file -> mount to         /container/service/slapd/assets/config/bootstrap/ldif/custom/
     # Option 2: Overwrite default seed file -> mount to  /container/service/slapd/assets/config/bootstrap/ldif/


### PR DESCRIPTION
Signed-off-by: Martin Heide <martin.heide@faro.com>

#### Overview

The OpenLDAP example config didn't cover LDAPS yet.

#### What this PR does / why we need it

It helps OpenLDAP users to run an example with LDAPS.

#### Special notes for your reviewer

The secure configuration "3)" with `insecureSkipVerify: false` worked for me before.
Because of https://github.com/osixia/docker-openldap/issues/506 , it doesn't work out of the box any more with the current Docker image.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
