### PR TITLE
fix: update auth methods and claims from discovery endpoint

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -184,10 +184,10 @@ func (s *Server) discoveryHandler() (http.HandlerFunc, error) {
 		IDTokenAlgs:       []string{string(jose.RS256)},
 		CodeChallengeAlgs: []string{CodeChallengeMethodS256, CodeChallengeMethodPlain},
 		Scopes:            []string{"openid", "email", "groups", "profile", "offline_access"},
-		AuthMethods:       []string{"client_secret_basic"},
+		AuthMethods:       []string{"client_secret_basic", "client_secret_post"},
 		Claims: []string{
-			"aud", "email", "email_verified", "exp",
-			"iat", "iss", "locale", "name", "sub",
+			"iss", "sub", "aud", "iat", "exp", "email", "email_verified",
+			"locale", "name", "preferred_username", "at_hash",
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

#### Overview
* Update claims_supported
* Update token_endpoint_auth_methods_supported

#### What this PR does / why we need it
Dex supports sending client credentials via post but doesn't say about it on discovery. The same about claims.

#### Special notes for your reviewer
Adding `client_secret_post` to auth metods is required to pass Basic OpenID certification tests.

#### Does this PR introduce a user-facing change?

```release-note
Discovery endpoint contains updated claims and auth methods.
```
