### PR TITLE
Improve "Grant Access" template when client requests only openid scope

### DIFF
--- a/web/templates/approval.html
+++ b/web/templates/approval.html
@@ -5,12 +5,16 @@
 
   <hr class="dex-separator">
   <div>
+    {{ if .Scopes }}
     <div class="dex-subtle-text">{{ .Client }} would like to:</div>
     <ul class="dex-list">
       {{ range $scope := .Scopes }}
       <li>{{ $scope }}</li>
       {{ end }}
     </ul>
+    {{ else }}
+    <div class="dex-subtle-text">{{ .Client }} has not requested any personal information</div>
+    {{ end }}
   </div>
   <hr class="dex-separator">
 


### PR DESCRIPTION
#### Overview

Improve template for the case where a client requests only "openid" scope and nothing else (i.e. no "profile", "email" etc)

#### What this PR does / why we need it

Before:
![image](https://user-images.githubusercontent.com/44789/107673377-da161180-6c8d-11eb-9ad2-b1e77b7a6541.png)

After:
![image](https://user-images.githubusercontent.com/44789/107673160-a20ece80-6c8d-11eb-960c-9d040bfc0a0e.png)

Closes #1732

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

Only a correction to a web page displayed when granting access
