### PR TITLE
fix: close storage on shutdown

### DIFF
--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -193,6 +193,8 @@ func runServe(options serveOptions) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize storage: %v", err)
 	}
+	defer s.Close()
+
 	logger.Infof("config storage: %s", c.Storage.Type)
 
 	if len(c.StaticClients) > 0 {


### PR DESCRIPTION
#### Overview
Call the `Close` method on storage in case of graceful shutdown

#### What this PR does / why we need it
Closes #1523

#### Does this PR introduce a user-facing change?
```release-note
Close storage on graceful shutdown
```
