### PR TITLE
fix: do not run LDAP tests locally by default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,6 @@ jobs:
           DEX_POSTGRES_HOST: localhost
           DEX_POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
           DEX_ETCD_ENDPOINTS: http://localhost:${{ job.services.etcd.ports[2379] }}
-          DEX_LDAP_TESTS: yes
           DEX_LDAP_HOST: localhost
           DEX_LDAP_PORT: 389
           DEX_LDAP_TLS_PORT: 636

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,7 @@ jobs:
           DEX_POSTGRES_HOST: localhost
           DEX_POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
           DEX_ETCD_ENDPOINTS: http://localhost:${{ job.services.etcd.ports[2379] }}
+          DEX_LDAP_TESTS: yes
           DEX_LDAP_HOST: localhost
           DEX_LDAP_PORT: 389
           DEX_LDAP_TLS_PORT: 636

--- a/connector/ldap/ldap_test.go
+++ b/connector/ldap/ldap_test.go
@@ -526,8 +526,9 @@ func getenv(key, defaultVal string) string {
 // The tests require LDAP to be runnning.
 // You can use the provided docker-compose file to setup an LDAP server.
 func runTests(t *testing.T, connMethod connectionMethod, config *Config, tests []subtest) {
-	if os.Getenv("DEX_LDAP_TESTS") == "" {
-		t.Skip("Specify not-empty DEX_LDAP_TESTS env variable to enable LDAP tests")
+	ldapHost := os.Getenv("DEX_LDAP_HOST")
+	if ldapHost == "" {
+		t.Skipf(`test environment variable "DEX_LDAP_HOST" not set, skipping`)
 	}
 
 	// Shallow copy.
@@ -537,17 +538,17 @@ func runTests(t *testing.T, connMethod connectionMethod, config *Config, tests [
 	// group search configuration.
 	switch connMethod {
 	case connectStartTLS:
-		c.Host = fmt.Sprintf("%s:%s", getenv("DEX_LDAP_HOST", "localhost"), getenv("DEX_LDAP_PORT", "389"))
+		c.Host = fmt.Sprintf("%s:%s", ldapHost, getenv("DEX_LDAP_PORT", "389"))
 		c.RootCA = "testdata/certs/ca.crt"
 		c.StartTLS = true
 	case connectLDAPS:
-		c.Host = fmt.Sprintf("%s:%s", getenv("DEX_LDAP_HOST", "localhost"), getenv("DEX_LDAP_TLS_PORT", "636"))
+		c.Host = fmt.Sprintf("%s:%s", ldapHost, getenv("DEX_LDAP_TLS_PORT", "636"))
 		c.RootCA = "testdata/certs/ca.crt"
 	case connectInsecureSkipVerify:
-		c.Host = fmt.Sprintf("%s:%s", getenv("DEX_LDAP_HOST", "localhost"), getenv("DEX_LDAP_TLS_PORT", "636"))
+		c.Host = fmt.Sprintf("%s:%s", ldapHost, getenv("DEX_LDAP_TLS_PORT", "636"))
 		c.InsecureSkipVerify = true
 	case connectLDAP:
-		c.Host = fmt.Sprintf("%s:%s", getenv("DEX_LDAP_HOST", "localhost"), getenv("DEX_LDAP_PORT", "389"))
+		c.Host = fmt.Sprintf("%s:%s", ldapHost, getenv("DEX_LDAP_PORT", "389"))
 		c.InsecureNoSSL = true
 	}
 

--- a/connector/ldap/ldap_test.go
+++ b/connector/ldap/ldap_test.go
@@ -526,6 +526,10 @@ func getenv(key, defaultVal string) string {
 // The tests require LDAP to be runnning.
 // You can use the provided docker-compose file to setup an LDAP server.
 func runTests(t *testing.T, connMethod connectionMethod, config *Config, tests []subtest) {
+	if os.Getenv("DEX_LDAP_TESTS") == "" {
+		t.Skip("Specify not-empty DEX_LDAP_TESTS env variable to enable LDAP tests")
+	}
+
 	// Shallow copy.
 	c := *config
 


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview
Explicitly launch LDAP tests

#### What this PR does / why we need it
After merging #1997, it became impossible to use `make test` or `go test ./...` locally without a mock LDAP server. 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
