### PR TITLE
fix: use /token endpoint to get tokens with device flow

### DIFF
--- a/server/deviceflowhandlers.go
+++ b/server/deviceflowhandlers.go
@@ -152,6 +152,9 @@ func (s *Server) handleDeviceCode(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleDeviceTokenGrant(w http.ResponseWriter, r *http.Request) {
+	s.logger.Warn(`Request to the deprecated "/device/token" endpoint was received.`)
+	s.logger.Warn(`The "/device/token" endpoint will be removed in a future release.`)
+
 	w.Header().Set("Content-Type", "application/json")
 	switch r.Method {
 	case http.MethodPost:

--- a/server/deviceflowhandlers.go
+++ b/server/deviceflowhandlers.go
@@ -151,9 +151,8 @@ func (s *Server) handleDeviceCode(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) handleDeviceTokenGrant(w http.ResponseWriter, r *http.Request) {
-	s.logger.Warn(`Request to the deprecated "/device/token" endpoint was received.`)
-	s.logger.Warn(`The "/device/token" endpoint will be removed in a future release.`)
+func (s *Server) handleDeviceTokenDeprecated(w http.ResponseWriter, r *http.Request) {
+	s.logger.Warn(`The deprecated "/device/token" endpoint was called. It will be removed, use "/token" instead.`)
 
 	w.Header().Set("Content-Type", "application/json")
 	switch r.Method {

--- a/server/deviceflowhandlers.go
+++ b/server/deviceflowhandlers.go
@@ -151,7 +151,7 @@ func (s *Server) handleDeviceCode(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) handleDeviceToken(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleDeviceTokenGrant(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	switch r.Method {
 	case http.MethodPost:
@@ -162,68 +162,72 @@ func (s *Server) handleDeviceToken(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		deviceCode := r.Form.Get("device_code")
-		if deviceCode == "" {
-			s.tokenErrHelper(w, errInvalidRequest, "No device code received", http.StatusBadRequest)
-			return
-		}
-
 		grantType := r.PostFormValue("grant_type")
 		if grantType != grantTypeDeviceCode {
 			s.tokenErrHelper(w, errInvalidGrant, "", http.StatusBadRequest)
 			return
 		}
 
-		now := s.now()
-
-		// Grab the device token, check validity
-		deviceToken, err := s.storage.GetDeviceToken(deviceCode)
-		if err != nil {
-			if err != storage.ErrNotFound {
-				s.logger.Errorf("failed to get device code: %v", err)
-			}
-			s.tokenErrHelper(w, errInvalidRequest, "Invalid Device code.", http.StatusBadRequest)
-			return
-		} else if now.After(deviceToken.Expiry) {
-			s.tokenErrHelper(w, deviceTokenExpired, "", http.StatusBadRequest)
-			return
-		}
-
-		// Rate Limiting check
-		slowDown := false
-		pollInterval := deviceToken.PollIntervalSeconds
-		minRequestTime := deviceToken.LastRequestTime.Add(time.Second * time.Duration(pollInterval))
-		if now.Before(minRequestTime) {
-			slowDown = true
-			// Continually increase the poll interval until the user waits the proper time
-			pollInterval += 5
-		} else {
-			pollInterval = 5
-		}
-
-		switch deviceToken.Status {
-		case deviceTokenPending:
-			updater := func(old storage.DeviceToken) (storage.DeviceToken, error) {
-				old.PollIntervalSeconds = pollInterval
-				old.LastRequestTime = now
-				return old, nil
-			}
-			// Update device token last request time in storage
-			if err := s.storage.UpdateDeviceToken(deviceCode, updater); err != nil {
-				s.logger.Errorf("failed to update device token: %v", err)
-				s.renderError(r, w, http.StatusInternalServerError, "")
-				return
-			}
-			if slowDown {
-				s.tokenErrHelper(w, deviceTokenSlowDown, "", http.StatusBadRequest)
-			} else {
-				s.tokenErrHelper(w, deviceTokenPending, "", http.StatusUnauthorized)
-			}
-		case deviceTokenComplete:
-			w.Write([]byte(deviceToken.Token))
-		}
+		s.handleDeviceToken(w, r)
 	default:
 		s.renderError(r, w, http.StatusBadRequest, "Requested resource does not exist.")
+	}
+}
+
+func (s *Server) handleDeviceToken(w http.ResponseWriter, r *http.Request) {
+	deviceCode := r.Form.Get("device_code")
+	if deviceCode == "" {
+		s.tokenErrHelper(w, errInvalidRequest, "No device code received", http.StatusBadRequest)
+		return
+	}
+
+	now := s.now()
+
+	// Grab the device token, check validity
+	deviceToken, err := s.storage.GetDeviceToken(deviceCode)
+	if err != nil {
+		if err != storage.ErrNotFound {
+			s.logger.Errorf("failed to get device code: %v", err)
+		}
+		s.tokenErrHelper(w, errInvalidRequest, "Invalid Device code.", http.StatusBadRequest)
+		return
+	} else if now.After(deviceToken.Expiry) {
+		s.tokenErrHelper(w, deviceTokenExpired, "", http.StatusBadRequest)
+		return
+	}
+
+	// Rate Limiting check
+	slowDown := false
+	pollInterval := deviceToken.PollIntervalSeconds
+	minRequestTime := deviceToken.LastRequestTime.Add(time.Second * time.Duration(pollInterval))
+	if now.Before(minRequestTime) {
+		slowDown = true
+		// Continually increase the poll interval until the user waits the proper time
+		pollInterval += 5
+	} else {
+		pollInterval = 5
+	}
+
+	switch deviceToken.Status {
+	case deviceTokenPending:
+		updater := func(old storage.DeviceToken) (storage.DeviceToken, error) {
+			old.PollIntervalSeconds = pollInterval
+			old.LastRequestTime = now
+			return old, nil
+		}
+		// Update device token last request time in storage
+		if err := s.storage.UpdateDeviceToken(deviceCode, updater); err != nil {
+			s.logger.Errorf("failed to update device token: %v", err)
+			s.renderError(r, w, http.StatusInternalServerError, "")
+			return
+		}
+		if slowDown {
+			s.tokenErrHelper(w, deviceTokenSlowDown, "", http.StatusBadRequest)
+		} else {
+			s.tokenErrHelper(w, deviceTokenPending, "", http.StatusUnauthorized)
+		}
+	case deviceTokenComplete:
+		w.Write([]byte(deviceToken.Token))
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -320,7 +320,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	handleFunc("/device", s.handleDeviceExchange)
 	handleFunc("/device/auth/verify_code", s.verifyUserCode)
 	handleFunc("/device/code", s.handleDeviceCode)
-	// TODO(nabokihms): deprecate and remove this endpoint, use /token instead
+	// TODO(nabokihms): "/device/token" endpoint is deprecated, consider using /token endpoint instead
 	handleFunc("/device/token", s.handleDeviceTokenGrant)
 	handleFunc(deviceCallbackURI, s.handleDeviceCallback)
 	r.HandleFunc(path.Join(issuerURL.Path, "/callback"), func(w http.ResponseWriter, r *http.Request) {

--- a/server/server.go
+++ b/server/server.go
@@ -321,7 +321,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	handleFunc("/device/auth/verify_code", s.verifyUserCode)
 	handleFunc("/device/code", s.handleDeviceCode)
 	// TODO(nabokihms): "/device/token" endpoint is deprecated, consider using /token endpoint instead
-	handleFunc("/device/token", s.handleDeviceTokenGrant)
+	handleFunc("/device/token", s.handleDeviceTokenDeprecated)
 	handleFunc(deviceCallbackURI, s.handleDeviceCallback)
 	r.HandleFunc(path.Join(issuerURL.Path, "/callback"), func(w http.ResponseWriter, r *http.Request) {
 		// Strip the X-Remote-* headers to prevent security issues on

--- a/server/server.go
+++ b/server/server.go
@@ -320,7 +320,8 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	handleFunc("/device", s.handleDeviceExchange)
 	handleFunc("/device/auth/verify_code", s.verifyUserCode)
 	handleFunc("/device/code", s.handleDeviceCode)
-	handleFunc("/device/token", s.handleDeviceToken)
+	// TODO(nabokihms): deprecate and remove this endpoint, use /token instead
+	handleFunc("/device/token", s.handleDeviceTokenGrant)
 	handleFunc(deviceCallbackURI, s.handleDeviceCallback)
 	r.HandleFunc(path.Join(issuerURL.Path, "/callback"), func(w http.ResponseWriter, r *http.Request) {
 		// Strip the X-Remote-* headers to prevent security issues on

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1583,7 +1583,7 @@ func TestOAuth2DeviceFlow(t *testing.T) {
 
 			// Hit the Token Endpoint, and try and get an access token
 			tokenURL, _ := url.Parse(issuer.String())
-			tokenURL.Path = path.Join(tokenURL.Path, "/device/token")
+			tokenURL.Path = path.Join(tokenURL.Path, "/token")
 			v := url.Values{}
 			v.Add("grant_type", grantTypeDeviceCode)
 			v.Add("device_code", deviceCode.DeviceCode)


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview
[rfc6749#section-3.2](https://tools.ietf.org/html/rfc6749#section-3.2)
* Make `/token` endpoint responding to requests with device auth grant
* Allow only POST requests `/token` endpoint
* Do not search for a client in storage if an invalid grant type is provided

#### What this PR does / why we need it

Fixes https://github.com/dexidp/dex/issues/1953 
As was mentioned in the issue above, the main problem that the token endpoint is not discoverable.

#### Special notes for your reviewer
This MR leaves the possibility to get a token from the `/device/token` endpoint. 

#### Does this PR introduce a user-facing change?

There are no breaking changes, but it will be better to avoid using /device/token endpoint in the feature.

```release-note
Make `/token` endpoint responding to requests with device auth grant. The `/device/token` endpoint becomes DEPRECATED.
```
