### PR TITLE
chore: warning about deprecated LDAP groupSearch fields

### DIFF
--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -192,7 +192,7 @@ func userMatchers(c *Config, logger log.Logger) []UserMatcher {
 		return c.GroupSearch.UserMatchers
 	}
 
-	logger.Warn(`ldap: fields groupSearch userAttr/groupAttr are deprecated, use groupSearch.userMatchers instead.`)
+	log.Deprecated(logger, `LDAP: use groupSearch.userMatchers option instead of "userAttr/groupAttr" fields.`)
 	return []UserMatcher{
 		{
 			UserAttr:  c.GroupSearch.UserAttr,

--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -187,11 +187,12 @@ func parseScope(s string) (int, bool) {
 // Function exists here to allow backward compatibility between old and new
 // group to user matching implementations.
 // See "Config.GroupSearch.UserMatchers" comments for the details
-func (c *ldapConnector) userMatchers() []UserMatcher {
+func userMatchers(c *Config, logger log.Logger) []UserMatcher {
 	if len(c.GroupSearch.UserMatchers) > 0 && c.GroupSearch.UserMatchers[0].UserAttr != "" {
 		return c.GroupSearch.UserMatchers
 	}
 
+	logger.Warn(`ldap: fields groupSearch userAttr/groupAttr are deprecated, use groupSearch.userMatchers instead.`)
 	return []UserMatcher{
 		{
 			UserAttr:  c.GroupSearch.UserAttr,
@@ -283,6 +284,9 @@ func (c *Config) openConnector(logger log.Logger) (*ldapConnector, error) {
 	if !ok {
 		return nil, fmt.Errorf("groupSearch.Scope unknown value %q", c.GroupSearch.Scope)
 	}
+
+	// TODO(nabokihms): remove it after deleting deprecated groupSearch options
+	c.GroupSearch.UserMatchers = userMatchers(c, logger)
 	return &ldapConnector{*c, userSearchScope, groupSearchScope, tlsConfig, logger}, nil
 }
 
@@ -417,7 +421,7 @@ func (c *ldapConnector) userEntry(conn *ldap.Conn, username string) (user ldap.E
 		},
 	}
 
-	for _, matcher := range c.userMatchers() {
+	for _, matcher := range c.GroupSearch.UserMatchers {
 		req.Attributes = append(req.Attributes, matcher.UserAttr)
 	}
 
@@ -574,7 +578,7 @@ func (c *ldapConnector) groups(ctx context.Context, user ldap.Entry) ([]string, 
 	}
 
 	var groups []*ldap.Entry
-	for _, matcher := range c.userMatchers() {
+	for _, matcher := range c.GroupSearch.UserMatchers {
 		for _, attr := range getAttrs(user, matcher.UserAttr) {
 			filter := fmt.Sprintf("(%s=%s)", matcher.GroupAttr, ldap.EscapeFilter(attr))
 			if c.GroupSearch.Filter != "" {

--- a/pkg/log/deprecated.go
+++ b/pkg/log/deprecated.go
@@ -1,0 +1,5 @@
+package log
+
+func Deprecated(logger Logger, f string, args ...interface{}) {
+	logger.Warnf("Deprecated: "+f, args...)
+}

--- a/server/deviceflowhandlers.go
+++ b/server/deviceflowhandlers.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dexidp/dex/pkg/log"
 	"github.com/dexidp/dex/storage"
 )
 
@@ -152,7 +153,7 @@ func (s *Server) handleDeviceCode(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleDeviceTokenDeprecated(w http.ResponseWriter, r *http.Request) {
-	s.logger.Warn(`The deprecated "/device/token" endpoint was called. It will be removed, use "/token" instead.`)
+	log.Deprecated(s.logger, `The /device/token endpoint was called. It will be removed, use /token instead.`)
 
 	w.Header().Set("Content-Type", "application/json")
 	switch r.Method {


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview
* print warning message if deprecated fields are used
* calculate user matches only on the connector opening

#### What this PR does / why we need it
We cannot remove deprecated fields without letting users know about our intentions.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
Users will see a warning message in dex logs if they have deprecated fields in their LDAP connector config.

```release-note
ldap: deprecation warning about `groupSearch.userAttr` and `groupSearch.groupAttr`
```
