### PR TITLE
feat: move integration tests to docker-compose

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,38 +13,6 @@ jobs:
     env:
       GOFLAGS: -mod=readonly
 
-    services:
-      postgres:
-        image: postgres:10.8
-        ports:
-          - 5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
-      mysql:
-        image: mysql:5.7
-        env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: dex
-        ports:
-          - 3306:3306
-        options: --health-cmd "mysql -proot -e \"show databases;\"" --health-interval 10s --health-timeout 5s --health-retries 5
-
-      etcd:
-        image: gcr.io/etcd-development/etcd:v3.2.9
-        ports:
-          - 2379
-        env:
-          ETCD_LISTEN_CLIENT_URLS: http://0.0.0.0:2379
-          ETCD_ADVERTISE_CLIENT_URLS: http://0.0.0.0:2379
-        options: --health-cmd "ETCDCTL_API=3 etcdctl --endpoints http://localhost:2379 endpoint health" --health-interval 10s --health-timeout 5s --health-retries 5
-
-      keystone:
-        image: openio/openstack-keystone:pike
-        ports:
-          - 5000
-          - 35357
-        options: --health-cmd "curl --fail http://localhost:5000/v3" --health-interval 10s --health-timeout 5s --health-retries 5
-
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2
@@ -54,30 +22,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Start services
-        run: docker-compose -f docker-compose.test.yaml up -d
-
       - name: Test
-        run: make testall
-        env:
-          DEX_MYSQL_DATABASE: dex
-          DEX_MYSQL_USER: root
-          DEX_MYSQL_PASSWORD: root
-          DEX_MYSQL_HOST: 127.0.0.1
-          DEX_MYSQL_PORT: 3306
-          DEX_POSTGRES_DATABASE: postgres
-          DEX_POSTGRES_USER: postgres
-          DEX_POSTGRES_PASSWORD: postgres
-          DEX_POSTGRES_HOST: localhost
-          DEX_POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
-          DEX_ETCD_ENDPOINTS: http://localhost:${{ job.services.etcd.ports[2379] }}
-          DEX_LDAP_HOST: localhost
-          DEX_LDAP_PORT: 389
-          DEX_LDAP_TLS_PORT: 636
-          DEX_KEYSTONE_URL: http://localhost:${{ job.services.keystone.ports[5000] }}
-          DEX_KEYSTONE_ADMIN_URL: http://localhost:${{ job.services.keystone.ports[35357] }}
-          DEX_KEYSTONE_ADMIN_USER: demo
-          DEX_KEYSTONE_ADMIN_PASS: DEMO_PASS
+        run: make testall-e2e
 
       - name: Lint
         run: make lint

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ up: docker-compose.override.yaml ## Launch the development environment
 	docker-compose up -d
 
 .PHONY: down
-down: clear ## Destroy the development environment
+down: clean ## Destroy the development environment
 	docker-compose down --volumes --remove-orphans --rmi local
 
 test: bin/test/kube-apiserver bin/test/etcd
@@ -111,6 +111,9 @@ clean:
 
 testall: testrace
 
+testall-e2e: bin/test/kube-apiserver bin/test/etcd
+	$(SHELL) ./scripts/testall-e2e all
+
 FORCE:
 
-.PHONY: test testrace testall
+.PHONY: test testrace testall testall-e2e

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,7 +1,7 @@
 version: "3.8"
 
 services:
-    ldap:
+    connector_ldap:
         image: osixia/openldap:1.4.0
         # Copying is required because the entrypoint modifies the *.ldif files.
         # For verbose output, use:  command: ["--copy-service", "--loglevel", "debug"]
@@ -16,3 +16,50 @@ services:
         volumes:
             - ./connector/ldap/testdata/certs:/container/service/slapd/assets/certs
             - ./connector/ldap/testdata/schema.ldif:/container/service/slapd/assets/config/bootstrap/ldif/99-schema.ldif
+
+    connector_keystone:
+        image: openio/openstack-keystone:pike
+        ports:
+            - 5000:5000
+            - 35357:35357
+        healthcheck:
+            test: [ "CMD-SHELL", "curl --fail http://localhost:5000/v3" ]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+
+    storage_postgres:
+        image: postgres:10.8
+        ports:
+            - 5432:5432
+        healthcheck:
+            test: [ "CMD-SHELL", "pg_isready" ]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+
+    storage_mysql:
+        image: mysql:5.7
+        environment:
+            MYSQL_ROOT_PASSWORD: root
+            MYSQL_DATABASE: dex
+        ports:
+            - 3306:3306
+        healthcheck:
+            test: [ "CMD-SHELL", "mysql -proot -e \"show databases;\"" ]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+
+    storage_etcd:
+        image: gcr.io/etcd-development/etcd:v3.2.9
+        ports:
+            - 2379:2379
+        environment:
+            ETCD_LISTEN_CLIENT_URLS: http://0.0.0.0:2379
+            ETCD_ADVERTISE_CLIENT_URLS: http://0.0.0.0:2379
+        healthcheck:
+            test: [ "CMD-SHELL", "ETCDCTL_API=3 etcdctl --endpoints http://localhost:2379 endpoint health" ]
+            interval: 10s
+            timeout: 5s
+            retries: 5

--- a/scripts/testall-e2e
+++ b/scripts/testall-e2e
@@ -1,0 +1,126 @@
+#!/bin/sh -e
+
+SERVICES=""
+
+function e2e_up() {
+  services=$1
+  docker-compose -f docker-compose.test.yaml up --force-recreate -d $services
+
+  printf "Waiting for services to become healthy "
+  for i in $(seq 1 120); do
+    for id in $(docker-compose -f docker-compose.test.yaml ps -q); do
+      container=$(docker inspect "$id")
+      if [[ $(echo "$container" | grep '"Health"') != "" ]]; then
+        if [[ $(echo "$container" | grep '"Status": "healthy"') == "" ]]; then
+          printf "."
+          sleep 1
+          continue 2
+        fi
+      fi
+    done
+    echo "OK!"
+    return
+  done
+
+  >&2 echo "Timeout!"
+  return 1
+}
+
+function e2e_down() {
+  docker-compose -f docker-compose.test.yaml down --volumes --remove-orphans --rmi local
+}
+
+function e2e_tests() {
+  go test -v --race ./...
+}
+
+function e2e_storage_mysql {
+  export DEX_MYSQL_DATABASE=dex
+  export DEX_MYSQL_USER=root
+  export DEX_MYSQL_PASSWORD=root
+  export DEX_MYSQL_HOST=127.0.0.1
+  export DEX_MYSQL_PORT=3306
+
+  SERVICES="$SERVICES storage_mysql"
+}
+
+function e2e_storage_postgres {
+  export DEX_POSTGRES_DATABASE=postgres
+  export DEX_POSTGRES_USER=postgres
+  export DEX_POSTGRES_PASSWORD=postgres
+  export DEX_POSTGRES_HOST=localhost
+  export DEX_POSTGRES_PORT=5432
+
+  SERVICES="$SERVICES storage_postgres"
+}
+
+function e2e_storage_etcd {
+  export DEX_ETCD_ENDPOINTS=http://localhost:2379
+
+  SERVICES="$SERVICES storage_etcd"
+}
+
+function e2e_connector_ldap {
+  export DEX_LDAP_HOST=localhost
+  export DEX_LDAP_TLS_PORT=636
+
+  SERVICES="$SERVICES connector_ldap"
+}
+
+function e2e_connector_keystone {
+  export DEX_KEYSTONE_URL=http://localhost:5000
+  export DEX_KEYSTONE_ADMIN_URL=http://localhost:35357
+  export DEX_KEYSTONE_ADMIN_USER=demo
+  export DEX_KEYSTONE_ADMIN_PASS=DEMO_PASS
+
+  SERVICES="$SERVICES connector_keystone"
+}
+
+function e2e_run() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      "storage_mysql")
+        e2e_storage_mysql
+        shift
+        ;;
+      "storage_postgres")
+        e2e_storage_postgres
+        shift
+	      ;;
+      "storage_etcd")
+        e2e_storage_etcd
+        shift
+        ;;
+      "connector_ldap")
+        e2e_connector_ldap
+        shift
+	      ;;
+      "connector_keystone")
+        e2e_connector_keystone
+	      shift
+        ;;
+      "all")
+        e2e_storage_mysql
+        e2e_storage_postgres
+        e2e_storage_etcd
+        e2e_connector_ldap
+        e2e_connector_keystone
+        shift
+        ;;
+      *)
+        echo "Illegal option $1"
+        return 1
+        ;;
+    esac
+  done
+
+  EXIT_CODE=0
+
+  e2e_up "$SERVICES"
+  e2e_tests || EXIT_CODE=$?
+  e2e_down
+
+  exit "$EXIT_CODE"
+}
+
+e2e_run $@


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

#### Overview
* Provide script to run e2e tests locally
* Move services from github-actions to docker-compose

#### What this PR does / why we need it
Users and developers have no opportunity to run integration tests locally. CI system is not always an option for external PRs.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

This PR aims to help developers testing their features locally. 
```release-note

```
