### PR TITLE
Return connector state from LoginURL() and pass it to HandleCallback()

### DIFF
--- a/connector/authproxy/authproxy.go
+++ b/connector/authproxy/authproxy.go
@@ -37,20 +37,20 @@ type callback struct {
 }
 
 // LoginURL returns the URL to redirect the user to login with.
-func (m *callback) LoginURL(s connector.Scopes, callbackURL, state string) (string, error) {
+func (m *callback) LoginURL(s connector.Scopes, callbackURL, state string) (string, []byte, error) {
 	u, err := url.Parse(callbackURL)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse callbackURL %q: %v", callbackURL, err)
+		return "", nil, fmt.Errorf("failed to parse callbackURL %q: %v", callbackURL, err)
 	}
 	u.Path += m.pathSuffix
 	v := u.Query()
 	v.Set("state", state)
 	u.RawQuery = v.Encode()
-	return u.String(), nil
+	return u.String(), nil, nil
 }
 
 // HandleCallback parses the request and returns the user's identity
-func (m *callback) HandleCallback(s connector.Scopes, r *http.Request) (connector.Identity, error) {
+func (m *callback) HandleCallback(s connector.Scopes, connData []byte, r *http.Request) (connector.Identity, error) {
 	remoteUser := r.Header.Get(m.userHeader)
 	if remoteUser == "" {
 		return connector.Identity{}, fmt.Errorf("required HTTP header %s is not set", m.userHeader)

--- a/connector/bitbucketcloud/bitbucketcloud.go
+++ b/connector/bitbucketcloud/bitbucketcloud.go
@@ -111,12 +111,12 @@ func (b *bitbucketConnector) oauth2Config(scopes connector.Scopes) *oauth2.Confi
 	}
 }
 
-func (b *bitbucketConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
+func (b *bitbucketConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, []byte, error) {
 	if b.redirectURI != callbackURL {
-		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, b.redirectURI)
+		return "", nil, fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, b.redirectURI)
 	}
 
-	return b.oauth2Config(scopes).AuthCodeURL(state), nil
+	return b.oauth2Config(scopes).AuthCodeURL(state), nil, nil
 }
 
 type oauth2Error struct {
@@ -131,7 +131,7 @@ func (e *oauth2Error) Error() string {
 	return e.error + ": " + e.errorDescription
 }
 
-func (b *bitbucketConnector) HandleCallback(s connector.Scopes, r *http.Request) (identity connector.Identity, err error) {
+func (b *bitbucketConnector) HandleCallback(s connector.Scopes, connData []byte, r *http.Request) (identity connector.Identity, err error) {
 	q := r.URL.Query()
 	if errType := q.Get("error"); errType != "" {
 		return identity, &oauth2Error{errType, q.Get("error_description")}

--- a/connector/bitbucketcloud/bitbucketcloud_test.go
+++ b/connector/bitbucketcloud/bitbucketcloud_test.go
@@ -102,7 +102,7 @@ func TestUsernameIncludedInFederatedIdentity(t *testing.T) {
 	expectNil(t, err)
 
 	bitbucketConnector := bitbucketConnector{apiURL: s.URL, hostName: hostURL.Host, httpClient: newClient()}
-	identity, err := bitbucketConnector.HandleCallback(connector.Scopes{}, req)
+	identity, err := bitbucketConnector.HandleCallback(connector.Scopes{}, nil, req)
 
 	expectNil(t, err)
 	expectEquals(t, identity.Username, "some-login")

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -63,10 +63,10 @@ type CallbackConnector interface {
 	// requested if one has already been issues. There's no good general answer
 	// for these kind of restrictions, and may require this package to become more
 	// aware of the global set of user/connector interactions.
-	LoginURL(s Scopes, callbackURL, state string) (string, error)
+	LoginURL(s Scopes, callbackURL, state string) (string, []byte, error)
 
 	// Handle the callback to the server and return an identity.
-	HandleCallback(s Scopes, r *http.Request) (identity Identity, err error)
+	HandleCallback(s Scopes, connData []byte, r *http.Request) (identity Identity, err error)
 }
 
 // SAMLConnector represents SAML connectors which implement the HTTP POST binding.

--- a/connector/gitea/gitea.go
+++ b/connector/gitea/gitea.go
@@ -82,11 +82,11 @@ func (c *giteaConnector) oauth2Config(_ connector.Scopes) *oauth2.Config {
 	}
 }
 
-func (c *giteaConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
+func (c *giteaConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, []byte, error) {
 	if c.redirectURI != callbackURL {
-		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", c.redirectURI, callbackURL)
+		return "", nil, fmt.Errorf("expected callback URL %q did not match the URL in the config %q", c.redirectURI, callbackURL)
 	}
-	return c.oauth2Config(scopes).AuthCodeURL(state), nil
+	return c.oauth2Config(scopes).AuthCodeURL(state), nil, nil
 }
 
 type oauth2Error struct {
@@ -101,7 +101,7 @@ func (e *oauth2Error) Error() string {
 	return e.error + ": " + e.errorDescription
 }
 
-func (c *giteaConnector) HandleCallback(s connector.Scopes, r *http.Request) (identity connector.Identity, err error) {
+func (c *giteaConnector) HandleCallback(s connector.Scopes, connData []byte, r *http.Request) (identity connector.Identity, err error) {
 	q := r.URL.Query()
 	if errType := q.Get("error"); errType != "" {
 		return identity, &oauth2Error{errType, q.Get("error_description")}

--- a/connector/gitea/gitea_test.go
+++ b/connector/gitea/gitea_test.go
@@ -30,14 +30,14 @@ func TestUsernameIncludedInFederatedIdentity(t *testing.T) {
 	expectNil(t, err)
 
 	c := giteaConnector{baseURL: s.URL, httpClient: newClient()}
-	identity, err := c.HandleCallback(connector.Scopes{}, req)
+	identity, err := c.HandleCallback(connector.Scopes{}, nil, req)
 
 	expectNil(t, err)
 	expectEquals(t, identity.Username, "some@email.com")
 	expectEquals(t, identity.UserID, "12345678")
 
 	c = giteaConnector{baseURL: s.URL, httpClient: newClient()}
-	identity, err = c.HandleCallback(connector.Scopes{}, req)
+	identity, err = c.HandleCallback(connector.Scopes{}, nil, req)
 
 	expectNil(t, err)
 	expectEquals(t, identity.Username, "some@email.com")

--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -187,12 +187,12 @@ func (c *githubConnector) oauth2Config(scopes connector.Scopes) *oauth2.Config {
 	}
 }
 
-func (c *githubConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
+func (c *githubConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, []byte, error) {
 	if c.redirectURI != callbackURL {
-		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
+		return "", nil, fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}
 
-	return c.oauth2Config(scopes).AuthCodeURL(state), nil
+	return c.oauth2Config(scopes).AuthCodeURL(state), nil, nil
 }
 
 type oauth2Error struct {
@@ -235,7 +235,7 @@ func newHTTPClient(rootCA string) (*http.Client, error) {
 	}, nil
 }
 
-func (c *githubConnector) HandleCallback(s connector.Scopes, r *http.Request) (identity connector.Identity, err error) {
+func (c *githubConnector) HandleCallback(s connector.Scopes, connData []byte, r *http.Request) (identity connector.Identity, err error) {
 	q := r.URL.Query()
 	if errType := q.Get("error"); errType != "" {
 		return identity, &oauth2Error{errType, q.Get("error_description")}

--- a/connector/github/github_test.go
+++ b/connector/github/github_test.go
@@ -150,7 +150,7 @@ func TestUsernameIncludedInFederatedIdentity(t *testing.T) {
 	expectNil(t, err)
 
 	c := githubConnector{apiURL: s.URL, hostName: hostURL.Host, httpClient: newClient()}
-	identity, err := c.HandleCallback(connector.Scopes{Groups: true}, req)
+	identity, err := c.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 
 	expectNil(t, err)
 	expectEquals(t, identity.Username, "some-login")
@@ -158,7 +158,7 @@ func TestUsernameIncludedInFederatedIdentity(t *testing.T) {
 	expectEquals(t, 0, len(identity.Groups))
 
 	c = githubConnector{apiURL: s.URL, hostName: hostURL.Host, httpClient: newClient(), loadAllGroups: true}
-	identity, err = c.HandleCallback(connector.Scopes{Groups: true}, req)
+	identity, err = c.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 
 	expectNil(t, err)
 	expectEquals(t, identity.Username, "some-login")
@@ -191,7 +191,7 @@ func TestLoginUsedAsIDWhenConfigured(t *testing.T) {
 	expectNil(t, err)
 
 	c := githubConnector{apiURL: s.URL, hostName: hostURL.Host, httpClient: newClient(), useLoginAsID: true}
-	identity, err := c.HandleCallback(connector.Scopes{Groups: true}, req)
+	identity, err := c.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 
 	expectNil(t, err)
 	expectEquals(t, identity.UserID, "some-login")

--- a/connector/gitlab/gitlab.go
+++ b/connector/gitlab/gitlab.go
@@ -98,11 +98,11 @@ func (c *gitlabConnector) oauth2Config(scopes connector.Scopes) *oauth2.Config {
 	}
 }
 
-func (c *gitlabConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
+func (c *gitlabConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, []byte, error) {
 	if c.redirectURI != callbackURL {
-		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", c.redirectURI, callbackURL)
+		return "", nil, fmt.Errorf("expected callback URL %q did not match the URL in the config %q", c.redirectURI, callbackURL)
 	}
-	return c.oauth2Config(scopes).AuthCodeURL(state), nil
+	return c.oauth2Config(scopes).AuthCodeURL(state), nil, nil
 }
 
 type oauth2Error struct {
@@ -117,7 +117,7 @@ func (e *oauth2Error) Error() string {
 	return e.error + ": " + e.errorDescription
 }
 
-func (c *gitlabConnector) HandleCallback(s connector.Scopes, r *http.Request) (identity connector.Identity, err error) {
+func (c *gitlabConnector) HandleCallback(s connector.Scopes, connData []byte, r *http.Request) (identity connector.Identity, err error) {
 	q := r.URL.Query()
 	if errType := q.Get("error"); errType != "" {
 		return identity, &oauth2Error{errType, q.Get("error_description")}

--- a/connector/gitlab/gitlab_test.go
+++ b/connector/gitlab/gitlab_test.go
@@ -84,7 +84,7 @@ func TestUsernameIncludedInFederatedIdentity(t *testing.T) {
 	expectNil(t, err)
 
 	c := gitlabConnector{baseURL: s.URL, httpClient: newClient()}
-	identity, err := c.HandleCallback(connector.Scopes{Groups: false}, req)
+	identity, err := c.HandleCallback(connector.Scopes{Groups: false}, nil, req)
 
 	expectNil(t, err)
 	expectEquals(t, identity.Username, "some@email.com")
@@ -92,7 +92,7 @@ func TestUsernameIncludedInFederatedIdentity(t *testing.T) {
 	expectEquals(t, 0, len(identity.Groups))
 
 	c = gitlabConnector{baseURL: s.URL, httpClient: newClient()}
-	identity, err = c.HandleCallback(connector.Scopes{Groups: true}, req)
+	identity, err = c.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 
 	expectNil(t, err)
 	expectEquals(t, identity.Username, "some@email.com")
@@ -120,7 +120,7 @@ func TestLoginUsedAsIDWhenConfigured(t *testing.T) {
 	expectNil(t, err)
 
 	c := gitlabConnector{baseURL: s.URL, httpClient: newClient(), useLoginAsID: true}
-	identity, err := c.HandleCallback(connector.Scopes{Groups: true}, req)
+	identity, err := c.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 
 	expectNil(t, err)
 	expectEquals(t, identity.UserID, "joebloggs")
@@ -147,7 +147,7 @@ func TestLoginWithTeamWhitelisted(t *testing.T) {
 	expectNil(t, err)
 
 	c := gitlabConnector{baseURL: s.URL, httpClient: newClient(), groups: []string{"team-1"}}
-	identity, err := c.HandleCallback(connector.Scopes{Groups: true}, req)
+	identity, err := c.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 
 	expectNil(t, err)
 	expectEquals(t, identity.UserID, "12345678")
@@ -174,7 +174,7 @@ func TestLoginWithTeamNonWhitelisted(t *testing.T) {
 	expectNil(t, err)
 
 	c := gitlabConnector{baseURL: s.URL, httpClient: newClient(), groups: []string{"team-2"}}
-	_, err = c.HandleCallback(connector.Scopes{Groups: true}, req)
+	_, err = c.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 
 	expectNotNil(t, err, "HandleCallback error")
 	expectEquals(t, err.Error(), "gitlab: get groups: gitlab: user \"joebloggs\" is not in any of the required groups")

--- a/connector/google/google.go
+++ b/connector/google/google.go
@@ -120,9 +120,9 @@ func (c *googleConnector) Close() error {
 	return nil
 }
 
-func (c *googleConnector) LoginURL(s connector.Scopes, callbackURL, state string) (string, error) {
+func (c *googleConnector) LoginURL(s connector.Scopes, callbackURL, state string) (string, []byte, error) {
 	if c.redirectURI != callbackURL {
-		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
+		return "", nil, fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}
 
 	var opts []oauth2.AuthCodeOption
@@ -137,7 +137,7 @@ func (c *googleConnector) LoginURL(s connector.Scopes, callbackURL, state string
 	if s.OfflineAccess {
 		opts = append(opts, oauth2.AccessTypeOffline, oauth2.SetAuthURLParam("prompt", "consent"))
 	}
-	return c.oauth2Config.AuthCodeURL(state, opts...), nil
+	return c.oauth2Config.AuthCodeURL(state, opts...), nil, nil
 }
 
 type oauth2Error struct {
@@ -152,7 +152,7 @@ func (e *oauth2Error) Error() string {
 	return e.error + ": " + e.errorDescription
 }
 
-func (c *googleConnector) HandleCallback(s connector.Scopes, r *http.Request) (identity connector.Identity, err error) {
+func (c *googleConnector) HandleCallback(s connector.Scopes, connData []byte, r *http.Request) (identity connector.Identity, err error) {
 	q := r.URL.Query()
 	if errType := q.Get("error"); errType != "" {
 		return identity, &oauth2Error{errType, q.Get("error_description")}

--- a/connector/linkedin/linkedin.go
+++ b/connector/linkedin/linkedin.go
@@ -62,17 +62,17 @@ var (
 )
 
 // LoginURL returns an access token request URL
-func (c *linkedInConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
+func (c *linkedInConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, []byte, error) {
 	if c.oauth2Config.RedirectURL != callbackURL {
-		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q",
+		return "", nil, fmt.Errorf("expected callback URL %q did not match the URL in the config %q",
 			callbackURL, c.oauth2Config.RedirectURL)
 	}
 
-	return c.oauth2Config.AuthCodeURL(state), nil
+	return c.oauth2Config.AuthCodeURL(state), nil, nil
 }
 
 // HandleCallback handles HTTP redirect from LinkedIn
-func (c *linkedInConnector) HandleCallback(s connector.Scopes, r *http.Request) (identity connector.Identity, err error) {
+func (c *linkedInConnector) HandleCallback(s connector.Scopes, connData []byte, r *http.Request) (identity connector.Identity, err error) {
 	q := r.URL.Query()
 	if errType := q.Get("error"); errType != "" {
 		return identity, &oauth2Error{errType, q.Get("error_description")}

--- a/connector/microsoft/microsoft.go
+++ b/connector/microsoft/microsoft.go
@@ -145,15 +145,15 @@ func (c *microsoftConnector) oauth2Config(scopes connector.Scopes) *oauth2.Confi
 	}
 }
 
-func (c *microsoftConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
+func (c *microsoftConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, []byte, error) {
 	if c.redirectURI != callbackURL {
-		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
+		return "", nil, fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}
 
-	return c.oauth2Config(scopes).AuthCodeURL(state), nil
+	return c.oauth2Config(scopes).AuthCodeURL(state), nil, nil
 }
 
-func (c *microsoftConnector) HandleCallback(s connector.Scopes, r *http.Request) (identity connector.Identity, err error) {
+func (c *microsoftConnector) HandleCallback(s connector.Scopes, connData []byte, r *http.Request) (identity connector.Identity, err error) {
 	q := r.URL.Query()
 	if errType := q.Get("error"); errType != "" {
 		return identity, &oauth2Error{errType, q.Get("error_description")}

--- a/connector/microsoft/microsoft_test.go
+++ b/connector/microsoft/microsoft_test.go
@@ -35,7 +35,7 @@ func TestUserIdentityFromGraphAPI(t *testing.T) {
 	req, _ := http.NewRequest("GET", s.URL, nil)
 
 	c := microsoftConnector{apiURL: s.URL, graphURL: s.URL, tenant: tenant}
-	identity, err := c.HandleCallback(connector.Scopes{Groups: false}, req)
+	identity, err := c.HandleCallback(connector.Scopes{Groups: false}, nil, req)
 	expectNil(t, err)
 	expectEquals(t, identity.Username, "Jane Doe")
 	expectEquals(t, identity.UserID, "S56767889")
@@ -58,7 +58,7 @@ func TestUserGroupsFromGraphAPI(t *testing.T) {
 	req, _ := http.NewRequest("GET", s.URL, nil)
 
 	c := microsoftConnector{apiURL: s.URL, graphURL: s.URL, tenant: tenant}
-	identity, err := c.HandleCallback(connector.Scopes{Groups: true}, req)
+	identity, err := c.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 	expectNil(t, err)
 	expectEquals(t, identity.Groups, []string{"a", "b"})
 }

--- a/connector/mock/connectortest.go
+++ b/connector/mock/connectortest.go
@@ -43,21 +43,21 @@ type Callback struct {
 }
 
 // LoginURL returns the URL to redirect the user to login with.
-func (m *Callback) LoginURL(s connector.Scopes, callbackURL, state string) (string, error) {
+func (m *Callback) LoginURL(s connector.Scopes, callbackURL, state string) (string, []byte, error) {
 	u, err := url.Parse(callbackURL)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse callbackURL %q: %v", callbackURL, err)
+		return "", nil, fmt.Errorf("failed to parse callbackURL %q: %v", callbackURL, err)
 	}
 	v := u.Query()
 	v.Set("state", state)
 	u.RawQuery = v.Encode()
-	return u.String(), nil
+	return u.String(), nil, nil
 }
 
 var connectorData = []byte("foobar")
 
 // HandleCallback parses the request and returns the user's identity
-func (m *Callback) HandleCallback(s connector.Scopes, r *http.Request) (connector.Identity, error) {
+func (m *Callback) HandleCallback(s connector.Scopes, connData []byte, r *http.Request) (connector.Identity, error) {
 	return m.Identity, nil
 }
 

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -188,9 +188,9 @@ func (c *oidcConnector) Close() error {
 	return nil
 }
 
-func (c *oidcConnector) LoginURL(s connector.Scopes, callbackURL, state string) (string, error) {
+func (c *oidcConnector) LoginURL(s connector.Scopes, callbackURL, state string) (string, []byte, error) {
 	if c.redirectURI != callbackURL {
-		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
+		return "", nil, fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}
 
 	var opts []oauth2.AuthCodeOption
@@ -205,7 +205,7 @@ func (c *oidcConnector) LoginURL(s connector.Scopes, callbackURL, state string) 
 	if s.OfflineAccess {
 		opts = append(opts, oauth2.AccessTypeOffline, oauth2.SetAuthURLParam("prompt", c.promptType))
 	}
-	return c.oauth2Config.AuthCodeURL(state, opts...), nil
+	return c.oauth2Config.AuthCodeURL(state, opts...), nil, nil
 }
 
 type oauth2Error struct {
@@ -220,7 +220,7 @@ func (e *oauth2Error) Error() string {
 	return e.error + ": " + e.errorDescription
 }
 
-func (c *oidcConnector) HandleCallback(s connector.Scopes, r *http.Request) (identity connector.Identity, err error) {
+func (c *oidcConnector) HandleCallback(s connector.Scopes, connData []byte, r *http.Request) (identity connector.Identity, err error) {
 	q := r.URL.Query()
 	if errType := q.Get("error"); errType != "" {
 		return identity, &oauth2Error{errType, q.Get("error_description")}

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -278,7 +278,7 @@ func TestHandleCallback(t *testing.T) {
 				t.Fatal("failed to create request", err)
 			}
 
-			identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+			identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 			if err != nil {
 				t.Fatal("handle callback failed", err)
 			}

--- a/connector/openshift/openshift.go
+++ b/connector/openshift/openshift.go
@@ -117,11 +117,11 @@ func (c *openshiftConnector) Close() error {
 }
 
 // LoginURL returns the URL to redirect the user to login with.
-func (c *openshiftConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
+func (c *openshiftConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, []byte, error) {
 	if c.redirectURI != callbackURL {
-		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
+		return "", nil, fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}
-	return c.oauth2Config.AuthCodeURL(state), nil
+	return c.oauth2Config.AuthCodeURL(state), nil, nil
 }
 
 type oauth2Error struct {
@@ -137,7 +137,7 @@ func (e *oauth2Error) Error() string {
 }
 
 // HandleCallback parses the request and returns the user's identity
-func (c *openshiftConnector) HandleCallback(s connector.Scopes, r *http.Request) (identity connector.Identity, err error) {
+func (c *openshiftConnector) HandleCallback(s connector.Scopes, connData []byte, r *http.Request) (identity connector.Identity, err error) {
 	q := r.URL.Query()
 	if errType := q.Get("error"); errType != "" {
 		return identity, &oauth2Error{errType, q.Get("error_description")}

--- a/connector/openshift/openshift_test.go
+++ b/connector/openshift/openshift_test.go
@@ -173,7 +173,7 @@ func TestCallbackIdentity(t *testing.T) {
 			TokenURL: fmt.Sprintf("%s/oauth/token", s.URL),
 		},
 	}}
-	identity, err := oc.HandleCallback(connector.Scopes{Groups: true}, req)
+	identity, err := oc.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 
 	expectNil(t, err)
 	expectEquals(t, identity.UserID, "12345")


### PR DESCRIPTION
#### Overview

Additional return value and argument in connector API:
* `LoginURL()` returns `connectorData []byte`
* `HandleCallback()` receives `connectorData []byte`

#### What this PR does / why we need it

When writing a connector for Vault (#2039), I found that it was necessary to maintain state between the `LoginURL()` and `HandleCallback()` calls.  This is because Vault provides its own OIDC callback `state` which must be carried forward.

Dex already maintains `ConnectorData []byte` in the authReq structure, but currently does not make this available to `LoginURL()` and `HandleCallback()`

Closes: #2040

#### Special notes for your reviewer

Minimal changes made to existing connectors to return a nil slice from `LoginURL()`, and ignore the slice passed in to `HandleCallback()`

This change would likely be exposed as an optional field for external connectors, when they are implemented.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
