### PR TITLE
Allow using connector ID as oidc groups prefix

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -32,6 +32,9 @@ type Config struct {
 
 	Frontend server.WebConfig `json:"frontend"`
 
+	// If enabled, add connector ID as prefix for groups from auth response.
+	OIDCGroupsPrefix bool `json:"oidcGroupsPrefix,omitempty"`
+
 	// StaticConnectors are user defined connectors specified in the ConfigMap
 	// Write operations, like updating a connector, will fail.
 	StaticConnectors []Connector `json:"connectors"`

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -249,6 +249,9 @@ func runServe(options serveOptions) error {
 	if c.OAuth2.PasswordConnector != "" {
 		logger.Infof("config using password grant connector: %s", c.OAuth2.PasswordConnector)
 	}
+	if c.OIDCGroupsPrefix {
+		logger.Infof("config user connector ID as oidc groups prefix")
+	}
 	if len(c.Web.AllowedOrigins) > 0 {
 		logger.Infof("config allowed origins: %s", c.Web.AllowedOrigins)
 	}
@@ -263,6 +266,7 @@ func runServe(options serveOptions) error {
 		SkipApprovalScreen:     c.OAuth2.SkipApprovalScreen,
 		AlwaysShowLoginScreen:  c.OAuth2.AlwaysShowLoginScreen,
 		PasswordConnector:      c.OAuth2.PasswordConnector,
+		OIDCGroupsPrefix:       c.OIDCGroupsPrefix,
 		AllowedOrigins:         c.Web.AllowedOrigins,
 		Issuer:                 c.Issuer,
 		Storage:                s,

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -416,7 +416,6 @@ func (s *Server) finalizeLogin(identity connector.Identity, authReq storage.Auth
 				prefixedGroup := fmt.Sprintf("%s:%s", prefix, group)
 				oidcGroups = append(oidcGroups, prefixedGroup)
 			}
-
 		} else {
 			oidcGroups = identity.Groups
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -84,6 +84,9 @@ type Config struct {
 	// If set, the server will use this connector to handle password grants
 	PasswordConnector string
 
+	// If enabled, add connector ID as prefix for groups from auth response.
+	OIDCGroupsPrefix bool
+
 	GCFrequency time.Duration // Defaults to 5 minutes
 
 	// If specified, the server will use this function for determining time.
@@ -153,6 +156,9 @@ type Server struct {
 
 	// Used for password grant
 	passwordConnector string
+
+	// If enabled, add connector ID as prefix for groups from auth response.
+	oidcGroupsPrefix bool
 
 	supportedResponseTypes map[string]bool
 
@@ -235,6 +241,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 		now:                    now,
 		templates:              tmpls,
 		passwordConnector:      c.PasswordConnector,
+		oidcGroupsPrefix:       c.OIDCGroupsPrefix,
 		logger:                 c.Logger,
 	}
 


### PR DESCRIPTION
#### Overview

Adds prefixes for OIDC groups. I'm not sure if we want to implement this on a different level (middleware?).
But I've been using this for some time and it works fine for my use-case, which is mostly about the security side, not UX.
E.g. it is not possible to configure the exact OIDC prefix with this, but as connector IDs are unique - it makes OIDC groups unique as well. I'm open for discussion if this approach is not how the community would like to solve this. For me, it works and closes the issue https://github.com/dexidp/dex/issues/918, therefore, sharing this solution here.

Usage: "Closes https://github.com/dexidp/dex/issues/918"

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
This change allows enabling OIDC groups prefixes with connector IDs values. Having this makes it impossible for groups from different connectors to impersonate other group access by using the same group names.
```

This feature can be enabled with `oidcGroupsPrefix: true`. If this option is missing, it will be disabled by default. So it doesn't require any changes if you're updating from the old version
