### PR TITLE
Embed web assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,13 +54,9 @@ COPY --from=builder /usr/local/src/dex/go.mod /usr/local/src/dex/go.sum /usr/loc
 COPY --from=builder /usr/local/src/dex/api/v2/go.mod /usr/local/src/dex/api/v2/go.sum /usr/local/src/dex/api/v2/
 
 COPY --from=builder /go/bin/dex /usr/local/bin/dex
+COPY --from=builder /usr/local/src/dex/web /srv/dex/web
+
 COPY --from=gomplate /usr/local/bin/gomplate /usr/local/bin/gomplate
-
-USER 1001:1001
-
-# Import frontend assets and set the correct CWD directory so the assets
-# are in the default path.
-COPY --from=builder /usr/local/src/dex/web /web
 
 USER 1001:1001
 

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -523,4 +523,8 @@ func applyConfigOverrides(options serveOptions, config *Config) {
 	if options.grpcAddr != "" {
 		config.GRPC.Addr = options.grpcAddr
 	}
+
+	if config.Frontend.Dir == "" {
+		config.Frontend.Dir = os.Getenv("DEX_FRONTEND_DIR")
+	}
 }

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -60,7 +60,7 @@ web:
 # frontend:
 #   issuer: dex
 #   logoURL: theme/logo.png
-#   dir: web/
+#   dir: ""
 #   theme: light
 
 # Telemetry configuration

--- a/server/templates.go
+++ b/server/templates.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"path/filepath"
 	"sort"
@@ -45,7 +44,6 @@ type templates struct {
 }
 
 type webConfig struct {
-	dir       string
 	webFS     fs.FS
 	logoURL   string
 	issuer    string
@@ -76,11 +74,6 @@ func loadWebConfig(c webConfig) (http.Handler, http.Handler, *templates, error) 
 	}
 	if c.issuer == "" {
 		c.issuer = "dex"
-	}
-	if c.dir != "" {
-		c.webFS = os.DirFS(c.dir)
-	} else if c.webFS == nil {
-		c.webFS = os.DirFS("./web")
 	}
 	if c.logoURL == "" {
 		c.logoURL = "theme/logo.png"

--- a/web/web.go
+++ b/web/web.go
@@ -1,0 +1,14 @@
+package web
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed static/* templates/* themes/*
+var files embed.FS
+
+// FS returns a filesystem with the default web assets.
+func FS() fs.FS {
+	return files
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview
Embed web assets into the Dex binary

#### What this PR does / why we need it

This change should simplify the distribution of Dex since it won't rely on the filesystem (except the config).

It also simplifies configuration since we don't need a default value anymore.

Fixes  #1959

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Default web asset location is changed to none (users should remove it from their configuration)
Web assets in the official container image are moved to `/srv/dex/web`
```
