### PR TITLE
Fix  keystone auth  domain object error

### DIFF
--- a/connector/keystone/keystone.go
+++ b/connector/keystone/keystone.go
@@ -75,7 +75,7 @@ type user struct {
 }
 
 type domain struct {
-	ID string `json:"id"`
+	Name string `json:"name"`
 }
 
 type token struct {
@@ -199,7 +199,7 @@ func (p *conn) getTokenResponse(ctx context.Context, username, pass string) (res
 				Password: password{
 					User: user{
 						Name:     username,
-						Domain:   domain{ID: p.Domain},
+						Domain:   domain{Name: p.Domain},
 						Password: pass,
 					},
 				},

--- a/connector/keystone/keystone_test.go
+++ b/connector/keystone/keystone_test.go
@@ -52,7 +52,7 @@ func getAdminToken(t *testing.T, adminName, adminPass string) (token, id string)
 				Password: password{
 					User: user{
 						Name:     adminName,
-						Domain:   domain{ID: testDomain},
+						Domain:   domain{Name: testDomain},
 						Password: adminPass,
 					},
 				},


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

see openstack docs

https://docs.openstack.org/api-ref/identity/v3/?expanded=password-authentication-with-unscoped-authorization-detail#password-authentication-with-unscoped-authorization

```
{
    "auth": {
        "identity": {
            "methods": [
                "password"
            ],
            "password": {
                "user": {
                    "name": "admin",
                    "domain": {
                        "name": "Default"
                    },
                    "password": "devstacker"
                }
            }
        }
    }
}
```

this is openstack example, domain object key is `name` not `id`.

