### PR TITLE
chore: remove go dev badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/dexidp/dex/CI?style=flat-square)
 [![Go Report Card](https://goreportcard.com/badge/github.com/dexidp/dex?style=flat-square)](https://goreportcard.com/report/github.com/dexidp/dex)
-[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/mod/github.com/dexidp/dex)
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod&style=flat-square)](https://gitpod.io/#https://github.com/dexidp/dex)
 
 ![logo](docs/logos/dex-horizontal-color.png)


### PR DESCRIPTION
#### Overview
Delete go.dev badge

#### What this PR does / why we need it
This badge is confusing a little because it leads to the page with stale documentation.

#### Special notes for your reviewer
It was previously discussed here https://github.com/dexidp/dex/pull/2087

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
