### PR TITLE
Initial security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+To report a vulnerability, send an email to [cncf-dex-maintainers@lists.cncf.io](mailto:cncf-dex-maintainers@lists.cncf.io)
+detailing the issue and steps to reproduce. The reporter(s) can expect a
+response within 48 hours acknowledging the issue was received. If a response is
+not received within 48 hours, please reach out to any maintainer directly
+to confirm receipt of the issue.
+
+## Review Process
+
+Once a maintainer has confirmed the relevance of the report, a draft security
+advisory will be created on Github. The draft advisory will be used to discuss
+the issue with maintainers, the reporter(s).
+If the reporter(s) wishes to participate in this discussion, then provide
+reporter Github username(s) to be invited to the discussion. If the reporter(s)
+does not wish to participate directly in the discussion, then the reporter(s)
+can request to be updated regularly via email.
+
+If the vulnerability is accepted, a timeline for developing a patch, public
+disclosure, and patch release will be determined. The reporter(s) are expected
+to participate in the discussion of the timeline and abide by agreed upon dates
+for public disclosure.

--- a/README.md
+++ b/README.md
@@ -102,13 +102,9 @@ All changes or deprecations of connector features will be announced in the [rele
 * Client libraries
   * [Go][go-oidc]
 
-## Reporting a security vulnerability
+## Reporting a vulnerability
 
-Due to their public nature, GitHub and mailing lists are NOT appropriate places
-for reporting vulnerabilities.
-
-Please email the [maintainers list](mailto:cncf-dex-maintainers@lists.cncf.io) to report issues that may
-be security-related.
+Please see our [security policy](.github/SECURITY.md) for details about reporting vulnerabilities.
 
 ## Getting help
 


### PR DESCRIPTION
This is an initial version of the security policy. I've already requested a dedicated email address (`security@dexidp.io`) for this purpose. I will update the policy once that's set up, but it shouldn't block this PR.

Fixes #1617
Fixes #1867