### PR TITLE
Fix MySQL connection to use the provided port

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: dex
         ports:
-          - 3306:3306
+          - 3306
         options: --health-cmd "mysql -proot -e \"show databases;\"" --health-interval 10s --health-timeout 5s --health-retries 5
 
       etcd:
@@ -64,7 +64,7 @@ jobs:
           DEX_MYSQL_USER: root
           DEX_MYSQL_PASSWORD: root
           DEX_MYSQL_HOST: 127.0.0.1
-          DEX_MYSQL_PORT: 3306
+          DEX_MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
           DEX_POSTGRES_DATABASE: postgres
           DEX_POSTGRES_USER: postgres
           DEX_POSTGRES_PASSWORD: postgres

--- a/storage/sql/config.go
+++ b/storage/sql/config.go
@@ -242,6 +242,10 @@ func (s *MySQL) open(logger log.Logger) (*conn, error) {
 		if s.Host[0] != '/' {
 			cfg.Net = "tcp"
 			cfg.Addr = s.Host
+
+			if s.Port != 0 {
+				cfg.Addr = net.JoinHostPort(s.Host, strconv.Itoa(int(s.Port)))
+			}
 		} else {
 			cfg.Net = "unix"
 			cfg.Addr = s.Host


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

The MySQL storage connector now uses the `port` field to allow connecting to MySQL instances running on a non-standard port.

#### What this PR does / why we need it

Fixes #2098

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Fix MySQL connection to use the provided port
```
