### PR TITLE
Discard package "version"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ group=$(shell id -g -n)
 
 export GOBIN=$(PWD)/bin
 
-LD_FLAGS="-w -X $(REPO_PATH)/version.Version=$(VERSION)"
+LD_FLAGS="-w -X main.version=$(VERSION) -X $(REPO_PATH)/server.version=$(VERSION)"
 
 # Dependency versions
 GOLANGCI_VERSION = 1.32.2

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ group=$(shell id -g -n)
 
 export GOBIN=$(PWD)/bin
 
-LD_FLAGS="-w -X main.version=$(VERSION) -X $(REPO_PATH)/server.version=$(VERSION)"
+LD_FLAGS="-w -X main.version=$(VERSION)"
 
 # Dependency versions
 GOLANGCI_VERSION = 1.32.2

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -449,7 +449,7 @@ func runServe(options serveOptions) error {
 		}
 
 		grpcSrv := grpc.NewServer(grpcOptions...)
-		api.RegisterDexServer(grpcSrv, server.NewAPI(serverConfig.Storage, logger))
+		api.RegisterDexServer(grpcSrv, server.NewAPI(serverConfig.Storage, logger, version))
 
 		grpcMetrics.InitializeMetrics(grpcSrv)
 		if c.GRPC.Reflection {

--- a/cmd/dex/version.go
+++ b/cmd/dex/version.go
@@ -5,17 +5,9 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
-
-	"github.com/dexidp/dex/server"
 )
 
 var version = "DEV"
-
-// nolint:gochecknoinits
-func init() {
-	// inject version for API endpoint
-	server.Version = version
-}
 
 func commandVersion() *cobra.Command {
 	return &cobra.Command{

--- a/cmd/dex/version.go
+++ b/cmd/dex/version.go
@@ -5,9 +5,9 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
-
-	"github.com/dexidp/dex/version"
 )
+
+var version = "was not built properly"
 
 func commandVersion() *cobra.Command {
 	return &cobra.Command{
@@ -16,7 +16,7 @@ func commandVersion() *cobra.Command {
 		Run: func(_ *cobra.Command, _ []string) {
 			fmt.Printf(
 				"Dex Version: %s\nGo Version: %s\nGo OS/ARCH: %s %s\n",
-				version.Version,
+				version,
 				runtime.Version(),
 				runtime.GOOS,
 				runtime.GOARCH,

--- a/cmd/dex/version.go
+++ b/cmd/dex/version.go
@@ -5,9 +5,17 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
+
+	"github.com/dexidp/dex/server"
 )
 
-var version = "was not built properly"
+var version = "DEV"
+
+// nolint:gochecknoinits
+func init() {
+	// inject version for API endpoint
+	server.Version = version
+}
 
 func commandVersion() *cobra.Command {
 	return &cobra.Command{

--- a/server/api.go
+++ b/server/api.go
@@ -11,7 +11,6 @@ import (
 	"github.com/dexidp/dex/pkg/log"
 	"github.com/dexidp/dex/server/internal"
 	"github.com/dexidp/dex/storage"
-	"github.com/dexidp/dex/version"
 )
 
 // apiVersion increases every time a new call is added to the API. Clients should use this info
@@ -28,6 +27,9 @@ const (
 	// load on a dex server.
 	upBoundCost = 16
 )
+
+// version is the version of the Dex server. It is injected during build stage.
+var version = "was not built properly"
 
 // NewAPI returns a server which implements the gRPC API interface.
 func NewAPI(s storage.Storage, logger log.Logger) api.DexServer {
@@ -223,7 +225,7 @@ func (d dexAPI) DeletePassword(ctx context.Context, req *api.DeletePasswordReq) 
 
 func (d dexAPI) GetVersion(ctx context.Context, req *api.VersionReq) (*api.VersionResp, error) {
 	return &api.VersionResp{
-		Server: version.Version,
+		Server: version,
 		Api:    apiVersion,
 	}, nil
 }

--- a/server/api.go
+++ b/server/api.go
@@ -28,8 +28,8 @@ const (
 	upBoundCost = 16
 )
 
-// version is the version of the Dex server. It is injected during build stage.
-var version = "was not built properly"
+// Version is the version of the Dex server. It is injected during main package initialization.
+var Version = "DEV"
 
 // NewAPI returns a server which implements the gRPC API interface.
 func NewAPI(s storage.Storage, logger log.Logger) api.DexServer {
@@ -225,7 +225,7 @@ func (d dexAPI) DeletePassword(ctx context.Context, req *api.DeletePasswordReq) 
 
 func (d dexAPI) GetVersion(ctx context.Context, req *api.VersionReq) (*api.VersionResp, error) {
 	return &api.VersionResp{
-		Server: version,
+		Server: Version,
 		Api:    apiVersion,
 	}, nil
 }

--- a/server/api.go
+++ b/server/api.go
@@ -28,22 +28,21 @@ const (
 	upBoundCost = 16
 )
 
-// Version is the version of the Dex server. It is injected during main package initialization.
-var Version = "DEV"
-
 // NewAPI returns a server which implements the gRPC API interface.
-func NewAPI(s storage.Storage, logger log.Logger) api.DexServer {
+func NewAPI(s storage.Storage, logger log.Logger, version string) api.DexServer {
 	return dexAPI{
-		s:      s,
-		logger: logger,
+		s:       s,
+		logger:  logger,
+		version: version,
 	}
 }
 
 type dexAPI struct {
 	api.UnimplementedDexServer
 
-	s      storage.Storage
-	logger log.Logger
+	s       storage.Storage
+	logger  log.Logger
+	version string
 }
 
 func (d dexAPI) CreateClient(ctx context.Context, req *api.CreateClientReq) (*api.CreateClientResp, error) {
@@ -225,7 +224,7 @@ func (d dexAPI) DeletePassword(ctx context.Context, req *api.DeletePasswordReq) 
 
 func (d dexAPI) GetVersion(ctx context.Context, req *api.VersionReq) (*api.VersionResp, error) {
 	return &api.VersionResp{
-		Server: Version,
+		Server: d.version,
 		Api:    apiVersion,
 	}, nil
 }

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -36,7 +36,7 @@ func newAPI(s storage.Storage, logger log.Logger, t *testing.T) *apiClient {
 	}
 
 	serv := grpc.NewServer()
-	api.RegisterDexServer(serv, NewAPI(s, logger))
+	api.RegisterDexServer(serv, NewAPI(s, logger, "test"))
 	go serv.Serve(l)
 
 	// Dial will retry automatically if the serv.Serve() goroutine

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,0 @@
-// Package version contains version information for this app.
-package version
-
-// Version is set by the build scripts.
-var Version = "was not built properly"


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

#### Overview
* Delete "version" package
* Inject version variable in two places

#### What this PR does / why we need it
Closes https://github.com/dexidp/dex/issues/1944

#### Special notes for your reviewer
I thought about this issue. It seems that injecting the version twice  (during the build stage) as good as injecting it once and then importing it two times. There is no possibility to import the version anymore, though (which was our goal).

#### Does this PR introduce a user-facing change?
```release-note
Discard package "version."
```
