### PR TITLE
Bump golag-ci lint version to 1.40.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,8 +6,6 @@ linters-settings:
         local-prefixes: github.com/dexidp/dex
     goimports:
         local-prefixes: github.com/dexidp/dex
-    golint:
-        min-confidence: 0
 
 
 linters:
@@ -24,7 +22,6 @@ linters:
         - gofmt
         - gofumpt
         - goimports
-        - golint
         - goprintffuncname
         - gosimple
         - govet
@@ -33,6 +30,7 @@ linters:
         - nakedret
         - nolintlint
         - prealloc
+        - revive
         - rowserrcheck
         - sqlclosecheck
         - staticcheck

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ export GOBIN=$(PWD)/bin
 LD_FLAGS="-w -X main.version=$(VERSION)"
 
 # Dependency versions
-GOLANGCI_VERSION = 1.32.2
+GOLANGCI_VERSION = 1.40.1
 
 PROTOC_VERSION = 3.15.6
 PROTOC_GEN_GO_VERSION = 1.26.0
@@ -86,9 +86,12 @@ bin/golangci-lint-${GOLANGCI_VERSION}:
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | BINARY=golangci-lint bash -s -- v${GOLANGCI_VERSION}
 	@mv bin/golangci-lint $@
 
-.PHONY: lint
+.PHONY: lint lint-fix
 lint: bin/golangci-lint ## Run linter
 	bin/golangci-lint run
+
+lint-fix: bin/golangci-lint ## Run linter and fix issues
+	bin/golangci-lint run --fix
 
 .PHONY: fix
 fix: bin/golangci-lint ## Fix lint violations

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	CodeChallengeMethodPlain = "plain"
-	CodeChallengeMethodS256  = "S256"
+	codeChallengeMethodPlain = "plain"
+	codeChallengeMethodS256  = "S256"
 )
 
 func (s *Server) handlePublicKeys(w http.ResponseWriter, r *http.Request) {
@@ -96,7 +96,7 @@ func (s *Server) discoveryHandler() (http.HandlerFunc, error) {
 		Subjects:          []string{"public"},
 		GrantTypes:        []string{grantTypeAuthorizationCode, grantTypeRefreshToken, grantTypeDeviceCode},
 		IDTokenAlgs:       []string{string(jose.RS256)},
-		CodeChallengeAlgs: []string{CodeChallengeMethodS256, CodeChallengeMethodPlain},
+		CodeChallengeAlgs: []string{codeChallengeMethodS256, codeChallengeMethodPlain},
 		Scopes:            []string{"openid", "email", "groups", "profile", "offline_access"},
 		AuthMethods:       []string{"client_secret_basic", "client_secret_post"},
 		Claims: []string{
@@ -724,9 +724,9 @@ func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) calculateCodeChallenge(codeVerifier, codeChallengeMethod string) (string, error) {
 	switch codeChallengeMethod {
-	case CodeChallengeMethodPlain:
+	case codeChallengeMethodPlain:
 		return codeVerifier, nil
-	case CodeChallengeMethodS256:
+	case codeChallengeMethodS256:
 		shaSum := sha256.Sum256([]byte(codeVerifier))
 		return base64.RawURLEncoding.EncodeToString(shaSum[:]), nil
 	default:

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -428,7 +428,7 @@ func (s *Server) parseAuthorizationRequest(r *http.Request) (*storage.AuthReques
 	codeChallengeMethod := q.Get("code_challenge_method")
 
 	if codeChallengeMethod == "" {
-		codeChallengeMethod = CodeChallengeMethodPlain
+		codeChallengeMethod = codeChallengeMethodPlain
 	}
 
 	client, err := s.storage.GetClient(clientID)
@@ -470,7 +470,7 @@ func (s *Server) parseAuthorizationRequest(r *http.Request) (*storage.AuthReques
 		return nil, newErr(errRequestNotSupported, "Server does not support request parameter.")
 	}
 
-	if codeChallengeMethod != CodeChallengeMethodS256 && codeChallengeMethod != CodeChallengeMethodPlain {
+	if codeChallengeMethod != codeChallengeMethodS256 && codeChallengeMethod != codeChallengeMethodPlain {
 		description := fmt.Sprintf("Unsupported PKCE challenge method (%q).", codeChallengeMethod)
 		return nil, newErr(errInvalidRequest, description)
 	}

--- a/storage/ent/client/offlinesession.go
+++ b/storage/ent/client/offlinesession.go
@@ -51,7 +51,7 @@ func (d *Database) DeleteOfflineSessions(userID, connID string) error {
 	return nil
 }
 
-// UpdatePassword changes an offline session by user id and connector id using an updater function.
+// UpdateOfflineSessions changes an offline session by user id and connector id using an updater function.
 func (d *Database) UpdateOfflineSessions(userID string, connID string, updater func(s storage.OfflineSessions) (storage.OfflineSessions, error)) error {
 	id := offlineSessionID(userID, connID, d.hasher)
 
@@ -86,7 +86,7 @@ func (d *Database) UpdateOfflineSessions(userID string, connID string, updater f
 	}
 
 	if err = tx.Commit(); err != nil {
-		return rollback(tx, "update password commit: %w", err)
+		return rollback(tx, "update offline session commit: %w", err)
 	}
 
 	return nil

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -29,8 +29,7 @@ func New(logger log.Logger) storage.Storage {
 // Config is an implementation of a storage configuration.
 //
 // TODO(ericchiang): Actually define a storage config interface and have registration.
-type Config struct {
-	// The in memory implementation has no config.
+type Config struct { // The in memory implementation has no config.
 }
 
 // Open always returns a new in memory storage.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -177,7 +177,7 @@ type Claims struct {
 	Groups []string
 }
 
-// Data needed for PKCE (RFC 7636)
+// PKCE is a container for the data needed to perform Proof Key for Code Exchange (RFC 7636) auth flow
 type PKCE struct {
 	CodeChallenge       string
 	CodeChallengeMethod string


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

#### Overview
* Bump golangci-lint
* Replace the [deprecated](https://github.com/golangci/golangci-lint/issues/1892) `golint` with the closest linter by its features - `revive`
> Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
* Fix some bugs
* Add lint-fix command to Makefile

#### What this PR does / why we need it
Maintenance.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
