### PR TITLE
Allow a user to overwrite Auth and Token URL

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -44,6 +44,12 @@ type Config struct {
 	// InsecureEnableGroups enables groups claims. This is disabled by default until https://github.com/dexidp/dex/issues/1065 is resolved
 	InsecureEnableGroups bool `json:"insecureEnableGroups"`
 
+	// AuthURL provides a way to user overwrite the Auth URL from .well-known/openid-configuration
+	AuthURL string `json:"authURL"`
+
+	// TokenURL provides a way to user overwrite the Token URL from .well-known/openid-configuration
+	TokenURL string `json:"tokenURL"`
+
 	// GetUserInfo uses the userinfo endpoint to get additional claims for
 	// the token. This is especially useful where upstreams return "thin"
 	// id tokens
@@ -108,6 +114,14 @@ func (c *Config) Open(id string, logger log.Logger) (conn connector.Connector, e
 	}
 
 	endpoint := provider.Endpoint()
+
+	if c.AuthURL != "" {
+		endpoint.AuthURL = c.AuthURL
+	}
+
+	if c.TokenURL != "" {
+		endpoint.TokenURL = c.TokenURL
+	}
 
 	if c.BasicAuthUnsupported != nil {
 		// Setting "basicAuthUnsupported" always overrides our detection.


### PR DESCRIPTION
Signed-off-by: Ricardo Katz <rkatz@vmware.com>

#### Overview

This change adds two new configuration fields in OIDC Connector: authURL and tokenURL.

#### What this PR does / why we need it

This change adds two new configuration fields in OIDC Connector: authURL and tokenURL.

Dex uses the go-oidc library, which does auto-discovery based in .well-known/openid-configuration from the issuer configured.

Happens that in some cases the issuer is not the same as Auth and Token URL. In this case, is desired that the user can overwrite those configurations (instead of relying into the auto discovered by go-oidc) allowing the correct login page redirection.

#### Special notes for your reviewer

In some cases UserInfoURL and JWKSURL should also be overwritable. The main issue is that, opposite to Auth and Token URL, go-oidc does not support overwriting UserInfo and JWKS but this might appear as a need in future

#### Does this PR introduce a user-facing change?

```release-note
Add authURL and tokenURL configurations in OIDC connector
```
