### PR TITLE
set readinessProbe to https

### DIFF
--- a/examples/k8s/dex.yaml
+++ b/examples/k8s/dex.yaml
@@ -53,6 +53,7 @@ spec:
           httpGet:
             path: /healthz
             port: 5556
+            scheme: HTTPS
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
Fix the error
Readiness probe failed: Get "http://100.105.5.5:5556/healthz": dial tcp 100.105.5.5:5556: connect: connection refused
Client sent an HTTP request to an HTTPS server.

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```
