### PR TITLE
Adding an oidcConnector config to decide whether to validate that the Connector Callback must contain the same host as the issuer

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -44,6 +44,9 @@ type Config struct {
 	// InsecureEnableGroups enables groups claims. This is disabled by default until https://github.com/dexidp/dex/issues/1065 is resolved
 	InsecureEnableGroups bool `json:"insecureEnableGroups"`
 
+	// Skips checking whether the requested domain in the Login Callback matches the configured Issuer
+	SkipIssuerCallbackDomainCheck bool `json:"skipIssuerCallbackDomainCheck"`
+
 	// GetUserInfo uses the userinfo endpoint to get additional claims for
 	// the token. This is especially useful where upstreams return "thin"
 	// id tokens
@@ -144,18 +147,19 @@ func (c *Config) Open(id string, logger log.Logger) (conn connector.Connector, e
 		verifier: provider.Verifier(
 			&oidc.Config{ClientID: clientID},
 		),
-		logger:                    logger,
-		cancel:                    cancel,
-		hostedDomains:             c.HostedDomains,
-		insecureSkipEmailVerified: c.InsecureSkipEmailVerified,
-		insecureEnableGroups:      c.InsecureEnableGroups,
-		getUserInfo:               c.GetUserInfo,
-		promptType:                c.PromptType,
-		userIDKey:                 c.UserIDKey,
-		userNameKey:               c.UserNameKey,
-		preferredUsernameKey:      c.ClaimMapping.PreferredUsernameKey,
-		emailKey:                  c.ClaimMapping.EmailKey,
-		groupsKey:                 c.ClaimMapping.GroupsKey,
+		logger:                        logger,
+		cancel:                        cancel,
+		hostedDomains:                 c.HostedDomains,
+		insecureSkipEmailVerified:     c.InsecureSkipEmailVerified,
+		insecureEnableGroups:          c.InsecureEnableGroups,
+		skipIssuerCallbackDomainCheck: c.SkipIssuerCallbackDomainCheck,
+		getUserInfo:                   c.GetUserInfo,
+		promptType:                    c.PromptType,
+		userIDKey:                     c.UserIDKey,
+		userNameKey:                   c.UserNameKey,
+		preferredUsernameKey:          c.ClaimMapping.PreferredUsernameKey,
+		emailKey:                      c.ClaimMapping.EmailKey,
+		groupsKey:                     c.ClaimMapping.GroupsKey,
 	}, nil
 }
 
@@ -165,22 +169,23 @@ var (
 )
 
 type oidcConnector struct {
-	provider                  *oidc.Provider
-	redirectURI               string
-	oauth2Config              *oauth2.Config
-	verifier                  *oidc.IDTokenVerifier
-	cancel                    context.CancelFunc
-	logger                    log.Logger
-	hostedDomains             []string
-	insecureSkipEmailVerified bool
-	insecureEnableGroups      bool
-	getUserInfo               bool
-	promptType                string
-	userIDKey                 string
-	userNameKey               string
-	preferredUsernameKey      string
-	emailKey                  string
-	groupsKey                 string
+	provider                      *oidc.Provider
+	redirectURI                   string
+	oauth2Config                  *oauth2.Config
+	verifier                      *oidc.IDTokenVerifier
+	cancel                        context.CancelFunc
+	logger                        log.Logger
+	hostedDomains                 []string
+	insecureSkipEmailVerified     bool
+	insecureEnableGroups          bool
+	skipIssuerCallbackDomainCheck bool
+	getUserInfo                   bool
+	promptType                    string
+	userIDKey                     string
+	userNameKey                   string
+	preferredUsernameKey          string
+	emailKey                      string
+	groupsKey                     string
 }
 
 func (c *oidcConnector) Close() error {
@@ -189,7 +194,7 @@ func (c *oidcConnector) Close() error {
 }
 
 func (c *oidcConnector) LoginURL(s connector.Scopes, callbackURL, state string) (string, error) {
-	if c.redirectURI != callbackURL {
+	if c.redirectURI != callbackURL && !c.skipIssuerCallbackDomainCheck {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->
We would like to use dex to address a use-case where the Issuer URI is not the same as the host in its callback endpoint.
We add a field to the oidcConnector struct that can instruct to relax the validation.

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```
