### PR TITLE
Demonstrate use of `htpasswd` for bCrypt in `staticPasswords`

### DIFF
--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -141,7 +141,7 @@ enablePasswordDB: true
 # If this option isn't chosen users may be added through the gRPC API.
 staticPasswords:
 - email: "admin@example.com"
-  # bcrypt hash of the string "password"
+  # echo password | htpasswd -BinC 10 admin | cut -d: -f2
   hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
   username: "admin"
   userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -141,7 +141,7 @@ enablePasswordDB: true
 # If this option isn't chosen users may be added through the gRPC API.
 staticPasswords:
 - email: "admin@example.com"
-  # echo password | htpasswd -BinC 10 admin | cut -d: -f2
+  # bcrypt hash of the string "password": $(echo password | htpasswd -BinC 10 admin | cut -d: -f2)
   hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
   username: "admin"
   userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"

--- a/examples/k8s/dex.yaml
+++ b/examples/k8s/dex.yaml
@@ -103,7 +103,7 @@ data:
     enablePasswordDB: true
     staticPasswords:
     - email: "admin@example.com"
-      # echo password | htpasswd -BinC 10 admin | cut -d: -f2
+      # bcrypt hash of the string "password": $(echo password | htpasswd -BinC 10 admin | cut -d: -f2)
       hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
       username: "admin"
       userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"

--- a/examples/k8s/dex.yaml
+++ b/examples/k8s/dex.yaml
@@ -103,7 +103,7 @@ data:
     enablePasswordDB: true
     staticPasswords:
     - email: "admin@example.com"
-      # bcrypt hash of the string "password"
+      # echo password | htpasswd -BinC 10 admin | cut -d: -f2
       hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
       username: "admin"
       userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"


### PR DESCRIPTION
#### Overview

Include an example command using `htpasswd` to bCrypt passwords in `staticPasswords` sections in example config files.

#### What this PR does / why we need it

The former text

> bcrypt hash of the string "password"

is rather vague and not helpful if you are attempting to add your own static password here. I had to Google tools for running bCrypt from the command line, and found by trial and error that the default difficulty level of 5 is rejected by Dex (requires 10).

#### Special notes for your reviewer

N/A

#### Does this PR introduce a user-facing change?

Just examples, so I think not.

```release-note
NONE

```
