### PR TITLE
Bump Dex image to v2.30.0 for Kubernetes deployment example

### DIFF
--- a/examples/k8s/dex.yaml
+++ b/examples/k8s/dex.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       serviceAccountName: dex # This is created below
       containers:
-      - image: dexidp/dex:v2.27.0 #or quay.io/dexidp/dex:v2.26.0
+      - image: ghcr.io/dexidp/dex:v2.30.0
         name: dex
         command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
 


### PR DESCRIPTION
Bump Dex image to v2.30.0 for Kubernetes deployment example

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->

The Dex version in the Kubernetes yaml file is outdated and also has the issue of failing with newer Kubernetes releases caused by the way namespace is read.

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

The following PR bumps the Dex version used in the Kubernetes deployment example to v2.30.0 (which includes the fix for the namespace failure issue).

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```
