### PR TITLE
Add parametrization of grant type supported in discovery endpoint

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -94,7 +94,6 @@ func (s *Server) discoveryHandler() (http.HandlerFunc, error) {
 		UserInfo:          s.absURL("/userinfo"),
 		DeviceEndpoint:    s.absURL("/device/code"),
 		Subjects:          []string{"public"},
-		GrantTypes:        []string{grantTypeAuthorizationCode, grantTypeRefreshToken, grantTypeDeviceCode},
 		IDTokenAlgs:       []string{string(jose.RS256)},
 		CodeChallengeAlgs: []string{codeChallengeMethodS256, codeChallengeMethodPlain},
 		Scopes:            []string{"openid", "email", "groups", "profile", "offline_access"},
@@ -109,6 +108,9 @@ func (s *Server) discoveryHandler() (http.HandlerFunc, error) {
 		d.ResponseTypes = append(d.ResponseTypes, responseType)
 	}
 	sort.Strings(d.ResponseTypes)
+
+	d.GrantTypes = s.supportedGrantTypes
+	sort.Strings(d.GrantTypes)
 
 	data, err := json.MarshalIndent(d, "", "  ")
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Modify the discovery endpoint result. The grant type supported are no longer fully "hard-coded". 

#### What this PR does / why we need it

The discovery endpoint is used to  help client application to know how dex is configured for the sign-in flow.
Currently the grant types supported were hard-coded, which does not always match the dex configuration.

The aim of this PR is to add `password` in the grant type supported list if it is the case 


#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE

```
