### PR TITLE
Add frame ancestor configuration for web app to prevent clickjacking

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -146,6 +146,7 @@ type Web struct {
 	TLSCert        string   `json:"tlsCert"`
 	TLSKey         string   `json:"tlsKey"`
 	AllowedOrigins []string `json:"allowedOrigins"`
+	FrameAncestors []string `json:"frameAncestors"`
 }
 
 // Telemetry is the config format for telemetry including the HTTP server config.

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -253,6 +253,10 @@ func runServe(options serveOptions) error {
 		logger.Infof("config allowed origins: %s", c.Web.AllowedOrigins)
 	}
 
+	if len(c.Web.FrameAncestors) > 0 {
+		logger.Infof("config allowed frame ancestors: %s", c.Web.FrameAncestors)
+	}
+
 	// explicitly convert to UTC.
 	now := func() time.Time { return time.Now().UTC() }
 
@@ -264,6 +268,7 @@ func runServe(options serveOptions) error {
 		AlwaysShowLoginScreen:  c.OAuth2.AlwaysShowLoginScreen,
 		PasswordConnector:      c.OAuth2.PasswordConnector,
 		AllowedOrigins:         c.Web.AllowedOrigins,
+		FrameAncestors:         c.Web.FrameAncestors,
 		Issuer:                 c.Issuer,
 		Storage:                s,
 		Web:                    c.Frontend,


### PR DESCRIPTION
Signed-off-by: ariary <ariary9.2@hotmail.fr>

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Provide a way to configure the Content Security Policy frame-ancestor context to prevent clickjacking

#### What this PR does / why we need it

This PR enables the configuration of the Content-Security policy to prevent clickjacking. By filling dex configuration with the specific fields the application will send csp headers in responses defining the content security policy.

available CSP:
                ○ No domain could frame the content (recommended unless a specific need has been identified for framing.) DEFAULT
                ○ Only the  current site could frame the content
                ○ Only certain site could frame the content (must specify the protocol)
                ○ No CSP (ie any domain could frame the content, INSECURE)

#### Special notes for your reviewer

The most critical endpoints for clickjacking is the `/dex/auth` one (as a user interaction is needed to provide credential) but by default it is a good point to apply the same policy for all endpoints

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
