### PR TITLE
chore: fix ioutil lint error after merging MySQL ent storage

### DIFF
--- a/storage/ent/mysql.go
+++ b/storage/ent/mysql.go
@@ -7,8 +7,8 @@ import (
 	"crypto/x509"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strconv"
 	"time"
 
@@ -135,7 +135,7 @@ func (m *MySQL) makeTLSConfig() error {
 	if m.SSL.CAFile != "" {
 		rootCertPool := x509.NewCertPool()
 
-		pem, err := ioutil.ReadFile(m.SSL.CAFile)
+		pem, err := os.ReadFile(m.SSL.CAFile)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Fix after merging https://github.com/dexidp/dex/pull/2272

#### What this PR does / why we need it

Ioutil is a deprecated package.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
