### PR TITLE
Support for multiple refresh tokens per user

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -342,9 +342,16 @@ type Logger struct {
 	Format string `json:"format"`
 }
 
+type MultipleRefreshToken struct {
+	Allow             bool   `json:"allow"`
+	MaximumCount      int    `json:"maximumCount"`
+	ReplacementPolicy string `json:"replacementPolicy"`
+}
+
 type RefreshToken struct {
-	DisableRotation   bool   `json:"disableRotation"`
-	ReuseInterval     string `json:"reuseInterval"`
-	AbsoluteLifetime  string `json:"absoluteLifetime"`
-	ValidIfNotUsedFor string `json:"validIfNotUsedFor"`
+	DisableRotation   bool                 `json:"disableRotation"`
+	MultipleTokens    MultipleRefreshToken `json:"multipleTokens"`
+	ReuseInterval     string               `json:"reuseInterval"`
+	AbsoluteLifetime  string               `json:"absoluteLifetime"`
+	ValidIfNotUsedFor string               `json:"validIfNotUsedFor"`
 }

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -310,7 +310,9 @@ func runServe(options serveOptions) error {
 		c.Expiry.RefreshTokens.ValidIfNotUsedFor,
 		c.Expiry.RefreshTokens.AbsoluteLifetime,
 		c.Expiry.RefreshTokens.ReuseInterval,
-	)
+		c.Expiry.RefreshTokens.MultipleTokens.Allow,
+		c.Expiry.RefreshTokens.MultipleTokens.MaximumCount,
+		c.Expiry.RefreshTokens.MultipleTokens.ReplacementPolicy)
 	if err != nil {
 		return fmt.Errorf("invalid refresh token expiration policy config: %v", err)
 	}
@@ -449,7 +451,7 @@ func runServe(options serveOptions) error {
 		}
 
 		grpcSrv := grpc.NewServer(grpcOptions...)
-		api.RegisterDexServer(grpcSrv, server.NewAPI(serverConfig.Storage, logger, version))
+		api.RegisterDexServer(grpcSrv, server.NewAPI(serverConfig.Storage, logger, version, c.Expiry.RefreshTokens.MultipleTokens.Allow))
 
 		grpcMetrics.InitializeMetrics(grpcSrv)
 		if c.GRPC.Reflection {

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -36,7 +36,7 @@ func newAPI(s storage.Storage, logger log.Logger, t *testing.T) *apiClient {
 	}
 
 	serv := grpc.NewServer()
-	api.RegisterDexServer(serv, NewAPI(s, logger, "test"))
+	api.RegisterDexServer(serv, NewAPI(s, logger, "test", false))
 	go serv.Serve(l)
 
 	// Dial will retry automatically if the serv.Serve() goroutine

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -961,13 +961,19 @@ func (s *Server) exchangeAuthCode(w http.ResponseWriter, authCode storage.AuthCo
 				return nil, err
 			}
 		} else {
-			if oldTokenRef, ok := session.Refresh[tokenRef.ClientID]; ok {
-				// Delete old refresh token from storage.
-				if err := s.storage.DeleteRefresh(oldTokenRef.ID); err != nil && err != storage.ErrNotFound {
-					s.logger.Errorf("failed to delete refresh token: %v", err)
-					s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
-					deleteToken = true
-					return nil, err
+			if !s.refreshTokenPolicy.allowMultiple {
+				if oldTokenRef, ok := session.Refresh[tokenRef.ClientID]; ok {
+					// Delete old refresh token from storage.
+					if err := s.storage.DeleteRefresh(oldTokenRef.ID); err != nil && err != storage.ErrNotFound {
+						s.logger.Errorf("failed to delete refresh token: %v", err)
+						s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
+						deleteToken = true
+						return nil, err
+					}
+				}
+			} else {
+				if err := s.deleteRefreshTokens(refresh.ConnectorID, refresh.Claims.UserID); err != nil {
+					s.logger.Errorf("error while deleting refresh token: %v", err)
 				}
 			}
 
@@ -1205,17 +1211,23 @@ func (s *Server) handlePasswordGrant(w http.ResponseWriter, r *http.Request, cli
 				return
 			}
 		} else {
-			if oldTokenRef, ok := session.Refresh[tokenRef.ClientID]; ok {
-				// Delete old refresh token from storage.
-				if err := s.storage.DeleteRefresh(oldTokenRef.ID); err != nil {
-					if err == storage.ErrNotFound {
-						s.logger.Warnf("database inconsistent, refresh token missing: %v", oldTokenRef.ID)
-					} else {
-						s.logger.Errorf("failed to delete refresh token: %v", err)
-						s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
-						deleteToken = true
-						return
+			if !s.refreshTokenPolicy.allowMultiple {
+				if oldTokenRef, ok := session.Refresh[tokenRef.ClientID]; ok {
+					// Delete old refresh token from storage.
+					if err := s.storage.DeleteRefresh(oldTokenRef.ID); err != nil {
+						if err == storage.ErrNotFound {
+							s.logger.Warnf("database inconsistent, refresh token missing: %v", oldTokenRef.ID)
+						} else {
+							s.logger.Errorf("failed to delete refresh token: %v", err)
+							s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
+							deleteToken = true
+							return
+						}
 					}
+				}
+			} else {
+				if err := s.deleteRefreshTokens(refresh.ConnectorID, refresh.Claims.UserID); err != nil {
+					s.logger.Errorf("error while deleting refresh token: %v", err)
 				}
 			}
 
@@ -1235,6 +1247,48 @@ func (s *Server) handlePasswordGrant(w http.ResponseWriter, r *http.Request, cli
 
 	resp := s.toAccessTokenResponse(idToken, accessToken, refreshToken, expiry)
 	s.writeAccessToken(w, resp)
+}
+
+func (s *Server) deleteRefreshTokens(connectorID string, userID string) error {
+	refreshTokens, err := s.storage.ListRefreshTokens()
+	if err != nil {
+		return err
+	}
+
+	var userRefreshTokens []storage.RefreshToken
+	for index := range refreshTokens {
+		refreshToken := refreshTokens[index]
+		if refreshToken.ConnectorID == connectorID && refreshToken.Claims.UserID == userID {
+			userRefreshTokens = append(userRefreshTokens, refreshToken)
+		}
+	}
+
+	if len(userRefreshTokens) <= s.refreshTokenPolicy.maxTokens {
+		return nil
+	}
+
+	sort.SliceStable(userRefreshTokens, func(i, j int) bool {
+		if s.refreshTokenPolicy.tokenReplacementPolicy == FCFS {
+			return userRefreshTokens[i].CreatedAt.Before(userRefreshTokens[j].CreatedAt)
+		} else {
+			return userRefreshTokens[i].LastUsed.Before(userRefreshTokens[j].LastUsed)
+		}
+	})
+
+	tokensToDelete := userRefreshTokens[:len(userRefreshTokens)-s.refreshTokenPolicy.maxTokens]
+	var deletionError bool
+	for index := range tokensToDelete {
+		refreshToken := tokensToDelete[index]
+		if err := s.storage.DeleteRefresh(refreshToken.ID); err != nil {
+			deletionError = true
+			s.logger.Errorf("error while deleting refresh token: %v", err)
+		}
+	}
+
+	if deletionError {
+		return fmt.Errorf("error while deleting refresh token for userID %s of connector %s", userID, connectorID)
+	}
+	return nil
 }
 
 type accessTokenResponse struct {

--- a/server/rotation_test.go
+++ b/server/rotation_test.go
@@ -110,7 +110,7 @@ func TestRefreshTokenPolicy(t *testing.T) {
 		Level:     logrus.DebugLevel,
 	}
 
-	r, err := NewRefreshTokenPolicy(l, true, "1m", "1m", "1m")
+	r, err := NewRefreshTokenPolicy(l, true, "1m", "1m", "1m", false, 0, "")
 	require.NoError(t, err)
 
 	t.Run("Allowed", func(t *testing.T) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -122,7 +122,7 @@ func newTestServer(ctx context.Context, t *testing.T, updateConfig func(c *Confi
 
 	// Default rotation policy
 	if server.refreshTokenPolicy == nil {
-		server.refreshTokenPolicy, err = NewRefreshTokenPolicy(logger, false, "", "", "")
+		server.refreshTokenPolicy, err = NewRefreshTokenPolicy(logger, false, "", "", "", false, 0, "")
 		if err != nil {
 			t.Fatalf("failed to prepare rotation policy: %v", err)
 		}

--- a/storage/kubernetes/storage.go
+++ b/storage/kubernetes/storage.go
@@ -366,8 +366,17 @@ func (cli *client) ListClients() ([]storage.Client, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (cli *client) ListRefreshTokens() ([]storage.RefreshToken, error) {
-	return nil, errors.New("not implemented")
+func (cli *client) ListRefreshTokens() (refreshTokens []storage.RefreshToken, err error) {
+	var refreshList RefreshList
+	if err = cli.list(resourceRefreshToken, &refreshList); err != nil {
+		return refreshTokens, fmt.Errorf("failed to list refresh tokens: %v", err)
+	}
+
+	for _, refreshToken := range refreshList.RefreshTokens {
+		refreshTokens = append(refreshTokens, toStorageRefreshToken(refreshToken))
+	}
+
+	return
 }
 
 func (cli *client) ListPasswords() (passwords []storage.Password, err error) {


### PR DESCRIPTION
Closes https://github.com/dexidp/dex/issues/981

This PR introduces `multipleTokens` option under `expiry.refreshTokens` in config to configure multi refresh tokens per user.

**Details**

- `multipleTokens.allow` option defaults to false and in that case this PR does not change any behavior.
- `multipleTokens.maximumCount` option specifies maximum refresh tokens per user which defaults to `50` - 
- `multipleTokens.replacementPolicy` specifies then old token deletion/replacement policy if number of tokens issued crossed specified `multipleTokens.maximumCount` which defaults to LRU.
- When `multipleTokens.allow` is true, Dex skips to delete a refresh token in issuing an id token.
- To minimize changes in storage layer, `ListRefresh` and `RevokeRefresh` gRPC API use `Storage.ListRefreshTokens` in `multipleTokens.allow` mode. This can be heavy but num of refresh tokens not is expected very high (same as num of id tokens).
- `storage.OfflineSessions.Refresh` contains the latest-issued refresh token.