### PR TITLE
fix: do not update offlinesession lastUsed field if refresh token was not updated

### DIFF
--- a/storage/kubernetes/storage.go
+++ b/storage/kubernetes/storage.go
@@ -740,13 +740,14 @@ func retryOnConflict(ctx context.Context, action func() error) error {
 	for {
 		select {
 		case <-time.After(getNextStep()):
-			if err := action(); err == nil || !isKubernetesAPIConflictError(err) {
+			err := action()
+			if err == nil || !isKubernetesAPIConflictError(err) {
 				return err
 			}
 
 			attempts++
 			if attempts >= 4 {
-				return errors.New("maximum timeout reached while retrying a conflicted request")
+				return fmt.Errorf("maximum timeout reached while retrying a conflicted request: %w", err)
 			}
 		case <-ctx.Done():
 			return errors.New("canceled")

--- a/storage/kubernetes/storage_test.go
+++ b/storage/kubernetes/storage_test.go
@@ -262,7 +262,7 @@ func TestRetryOnConflict(t *testing.T) {
 		{
 			"Timeout reached",
 			func() error { err := httpErr{status: 409}; return error(&err) },
-			"maximum timeout reached while retrying a conflicted request",
+			"maximum timeout reached while retrying a conflicted request:   Conflict: response from server \"\"",
 		},
 		{
 			"HTTP Error",


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

As for now, Dex updates the lastUsed field of OfflineSession on every refresh token touching. It causes unnecessary conflict errors for etcd and Kubernetes storages.

#### What this PR does / why we need it

Closes #2187

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Do not update OfflineSession lastUsed field on allowed refresh token reusing
```
