### PR TITLE
fix web static file path slash error for win platform

### DIFF
--- a/server/templates.go
+++ b/server/templates.go
@@ -109,7 +109,7 @@ func loadWebConfig(c webConfig) (http.Handler, http.Handler, *templates, error) 
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("read static dir: %v", err)
 	}
-	themeFiles, err := fs.Sub(c.webFS, filepath.Join("themes", c.theme))
+	themeFiles, err := fs.Sub(c.webFS, filepath.ToSlash(filepath.Join("themes", c.theme)))
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("read themes dir: %v", err)
 	}
@@ -133,7 +133,7 @@ func loadTemplates(c webConfig, templatesDir string) (*templates, error) {
 		if file.IsDir() {
 			continue
 		}
-		filenames = append(filenames, filepath.Join(templatesDir, file.Name()))
+		filenames = append(filenames, filepath.ToSlash(filepath.Join(templatesDir, file.Name())))
 	}
 	if len(filenames) == 0 {
 		return nil, fmt.Errorf("no files in template dir %q", templatesDir)

--- a/server/templates.go
+++ b/server/templates.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -109,7 +108,7 @@ func loadWebConfig(c webConfig) (http.Handler, http.Handler, *templates, error) 
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("read static dir: %v", err)
 	}
-	themeFiles, err := fs.Sub(c.webFS, filepath.ToSlash(filepath.Join("themes", c.theme)))
+	themeFiles, err := fs.Sub(c.webFS, path.Join("themes", c.theme))
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("read themes dir: %v", err)
 	}
@@ -133,7 +132,7 @@ func loadTemplates(c webConfig, templatesDir string) (*templates, error) {
 		if file.IsDir() {
 			continue
 		}
-		filenames = append(filenames, filepath.ToSlash(filepath.Join(templatesDir, file.Name())))
+		filenames = append(filenames, path.Join(templatesDir, file.Name()))
 	}
 	if len(filenames) == 0 {
 		return nil, fmt.Errorf("no files in template dir %q", templatesDir)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it
I test dex on Win10 platform, i found it dont launch success, I try to solve this problem, found slash convert is be necessary.
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
It should also be able to run on Linux.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```
