### PR TITLE
Add LDAP alias dereferencing

### DIFF
--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -284,6 +284,10 @@ func (c *Config) openConnector(logger log.Logger) (*ldapConnector, error) {
 		}
 	}
 
+	if c.UserSearch.EmailAttr == "" && c.UserSearch.EmailSuffix == "" {
+		return nil, fmt.Errorf("ldap: either emailAttr or emailSuffix must be provided")
+	}
+
 	var (
 		host string
 		err  error

--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -114,7 +114,7 @@ type Config struct {
 		// * "sub" - search the whole sub tree
 		// * "one" - only search one level
 		Scope string `json:"scope"`
-		
+
 		// Can be:
 		// * "never"
 		// * "searching"
@@ -143,7 +143,7 @@ type Config struct {
 		Filter string `json:"filter"`
 
 		Scope string `json:"scope"` // Defaults to "sub"
-		
+
 		// Can be:
 		// * "never"
 		// * "searching"
@@ -208,7 +208,7 @@ func derefString(i int) string {
 	case ldap.DerefFindingBaseObj:
 		return "finding"
 	case ldap.DerefAlways:
-		return "always"	
+		return "always"
 	default:
 		return ""
 	}
@@ -487,7 +487,7 @@ func (c *ldapConnector) userEntry(conn *ldap.Conn, username string) (user ldap.E
 	}
 
 	c.logger.Infof("performing ldap search %s %s %s %s",
-				   req.BaseDN, scopeString(req.Scope), derefString(req.Deref), req.Filter)
+				   req.BaseDN, scopeString(req.Scope), derefString(req.DerefAliases), req.Filter)
 	resp, err := conn.Search(req)
 	if err != nil {
 		return ldap.Entry{}, false, fmt.Errorf("ldap: search with filter %q failed: %v", req.Filter, err)
@@ -649,7 +649,7 @@ func (c *ldapConnector) groups(ctx context.Context, user ldap.Entry) ([]string, 
 			gotGroups := false
 			if err := c.do(ctx, func(conn *ldap.Conn) error {
 				c.logger.Infof("performing ldap search %s %s %s %s",
-							   req.BaseDN, scopeString(req.Scope), derefString(req.Deref), req.Filter)
+							   req.BaseDN, scopeString(req.Scope), derefString(req.DerefAliases), req.Filter)
 				resp, err := conn.Search(req)
 				if err != nil {
 					return fmt.Errorf("ldap: search failed: %v", err)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Implementation of LDAP alias directory dereferencing option in LDAP connector.  Our LDAP tree uses baseline user directories (with passwords) under *dc=[org]* and per-system aliases to user directories granted access to [system] in *ou=[system],dc=[org]*.  If DEX cannot dereference LDAP alias directories, it cannot properly lookup or bind to the user's base directory.

#### What this PR does / why we need it

For LDAP directory trees that include alias directories, the user/group searches will not dereference an alias directory to the target.  The Go LDAP module defaults to `never` dereferencing alias directories.

The `userSearch` and `groupSearch` config objects now have a `deref` key-value pair that can take values: `never` (default), `always`, `searching`, `finding` inline with the LDAPv3 module's capabilities.  Setting `deref: always` allows aliased user directories to be dereferenced to their target LDAP directory, and the DN and attributes of the target are returned instead of those of the alias directory.

One minor additional fixup:  if neither the `emailAttr` nor the `emailSuffix` keys are defined on the `userSearch` config object, then the code will not object but fail authentication with the message:

```
time="2021-10-27T17:33:41Z" level=error msg="Failed to login user: ldap: entry \"uid=[uid],ou=People,dc=[org]\" missing following required attribute(s): [\"\"]"
```

A check of the config was added to abort startup if both `emailAttr` and `emailSuffix` are undefined in the `userSearch` config.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
