### PR TITLE
Use GitLab's refresh_token during Refresh.

### DIFF
--- a/connector/gitlab/gitlab.go
+++ b/connector/gitlab/gitlab.go
@@ -188,7 +188,7 @@ func (c *gitlabConnector) identity(ctx context.Context, s connector.Scopes, toke
 func (c *gitlabConnector) Refresh(ctx context.Context, s connector.Scopes, ident connector.Identity) (connector.Identity, error) {
 	var data connectorData
 	if err := json.Unmarshal(ident.ConnectorData, &data); err != nil {
-		return ident, fmt.Errorf("gitlab: unmarshal refresh token: %v", err)
+		return ident, fmt.Errorf("gitlab: unmarshal connector data: %v", err)
 	}
 	oauth2Config := c.oauth2Config(s)
 

--- a/connector/gitlab/gitlab_test.go
+++ b/connector/gitlab/gitlab_test.go
@@ -202,7 +202,10 @@ func TestRefresh(t *testing.T) {
 
 	c := gitlabConnector{baseURL: s.URL, httpClient: newClient()}
 
-	expectedConnectorData, err := json.Marshal(connectorData{RefreshToken: []byte("oRzxVjCnohYRHEYEhZshkmakKmoyVoTjfUGC")})
+	expectedConnectorData, err := json.Marshal(connectorData{
+		RefreshToken: []byte("oRzxVjCnohYRHEYEhZshkmakKmoyVoTjfUGC"),
+		AccessToken:  "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9",
+	})
 	expectNil(t, err)
 
 	identity, err := c.HandleCallback(connector.Scopes{OfflineAccess: true}, req)


### PR DESCRIPTION
#### Overview

Use GitLab's `refresh_token` instead of `acces_token` during `connector.Refresh` when `offline_access` is specified.

#### What this PR does / why we need it

Closes #2316 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
Fix GitLab connector to use refresh_tokens with `offline_access`
```
