### PR TITLE
Allow configuration of returned groups via authproxy connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Dex implements the following connectors:
 | [Google](https://dexidp.io/docs/connectors/google/) | yes | yes | yes | alpha | |
 | [LinkedIn](https://dexidp.io/docs/connectors/linkedin/) | yes | no | no | beta | |
 | [Microsoft](https://dexidp.io/docs/connectors/microsoft/) | yes | yes | no | beta | |
-| [AuthProxy](https://dexidp.io/docs/connectors/authproxy/) | no | no | no | alpha | Authentication proxies such as Apache2 mod_auth, etc. |
+| [AuthProxy](https://dexidp.io/docs/connectors/authproxy/) | no | yes | no | alpha | Authentication proxies such as Apache2 mod_auth, etc. |
 | [Bitbucket Cloud](https://dexidp.io/docs/connectors/bitbucketcloud/) | yes | yes | no | alpha | |
 | [OpenShift](https://dexidp.io/docs/connectors/openshift/) | no | yes | no | alpha | |
 | [Atlassian Crowd](https://dexidp.io/docs/connectors/atlassiancrowd/) | yes | yes | yes * | beta | preferred_username claim must be configured through config |

--- a/connector/authproxy/authproxy.go
+++ b/connector/authproxy/authproxy.go
@@ -13,9 +13,14 @@ import (
 )
 
 // Config holds the configuration parameters for a connector which returns an
-// identity with the HTTP header X-Remote-User as verified email.
+// identity with the HTTP header X-Remote-User as verified email,
+// X-Remote-Group and configured staticGroups as user's group.
+// Headers retrieved to fetch user's email and group can be configured
+// with userHeader and groupHeader.
 type Config struct {
-	UserHeader string `json:"userHeader"`
+	UserHeader  string   `json:"userHeader"`
+	GroupHeader string   `json:"groupHeader"`
+	Groups      []string `json:"staticGroups"`
 }
 
 // Open returns an authentication strategy which requires no user interaction.
@@ -24,16 +29,22 @@ func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error)
 	if userHeader == "" {
 		userHeader = "X-Remote-User"
 	}
+	groupHeader := c.GroupHeader
+	if groupHeader == "" {
+		groupHeader = "X-Remote-Group"
+	}
 
-	return &callback{userHeader: userHeader, logger: logger, pathSuffix: "/" + id}, nil
+	return &callback{userHeader: userHeader, groupHeader: groupHeader, logger: logger, pathSuffix: "/" + id, groups: c.Groups}, nil
 }
 
 // Callback is a connector which returns an identity with the HTTP header
 // X-Remote-User as verified email.
 type callback struct {
-	userHeader string
-	logger     log.Logger
-	pathSuffix string
+	userHeader  string
+	groupHeader string
+	groups      []string
+	logger      log.Logger
+	pathSuffix  string
 }
 
 // LoginURL returns the URL to redirect the user to login with.
@@ -55,11 +66,15 @@ func (m *callback) HandleCallback(s connector.Scopes, r *http.Request) (connecto
 	if remoteUser == "" {
 		return connector.Identity{}, fmt.Errorf("required HTTP header %s is not set", m.userHeader)
 	}
-	// TODO: add support for X-Remote-Group, see
-	// https://kubernetes.io/docs/admin/authentication/#authenticating-proxy
+	groups := m.groups
+	headerGroup := r.Header.Get(m.groupHeader)
+	if headerGroup != "" {
+		groups = append(groups, headerGroup)
+	}
 	return connector.Identity{
 		UserID:        remoteUser, // TODO: figure out if this is a bad ID value.
 		Email:         remoteUser,
 		EmailVerified: true,
+		Groups:        groups,
 	}, nil
 }


### PR DESCRIPTION
#### Overview

Added `groupHeader` and `groups` configuration for authproxy connector. 


Example :

```
connectors:
      - type: authproxy
        id: http-proxy
        name: http-proxy
        config:
          userHeader: X-Forwarded-User # default is X-Remote-User
          groupHeader: X-Forwarded-Group # default is X-Remote-Group
          staticGroups:
            - admin
```


#### What this PR does / why we need it

This allow users to configure argocd dex to use authproxy connector and specify the users default group and the HTTP header to read to get the group.
