### PR TITLE
chore: update golangci-lint download script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ bin/gotestsum:
 
 bin/golangci-lint:
 	@mkdir -p bin
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | BINARY=golangci-lint bash -s -- v${GOLANGCI_VERSION}
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | BINARY=golangci-lint bash -s -- v${GOLANGCI_VERSION}
 
 bin/protoc:
 	@mkdir -p bin/protoc


### PR DESCRIPTION
> "this script is deprecated, please do not use it anymore. check https://github.com/goreleaser/godownloader/issues/207"

