### PR TITLE
fix: log only errors on refreshing

### DIFF
--- a/server/refreshhandlers.go
+++ b/server/refreshhandlers.go
@@ -66,11 +66,10 @@ func (s *Server) getRefreshTokenFromStorage(clientID string, token *internal.Ref
 
 	refresh, err := s.storage.GetRefresh(token.RefreshId)
 	if err != nil {
-		s.logger.Errorf("failed to get refresh token: %v", err)
 		if err != storage.ErrNotFound {
+			s.logger.Errorf("failed to get refresh token: %v", err)
 			return nil, newInternalServerError()
 		}
-
 		return nil, invalidErr
 	}
 


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Log only errors.

#### What this PR does / why we need it
If a user goes to the token refreshing endpoint with no existed token, it floods logs with the not found error.
```
{"level":"error","msg":"failed to get refresh token: not found","time":"2022-04-06T06:14:17Z"}
```
It is ok. Dex used to skip these errors previously. They accidentally came out after the token refreshing handler refactoring.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
fix: log only errors on refreshing a token
```
