### PR TITLE
Bump Alpine to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=alpine:3.15.1
+ARG BASEIMAGE=alpine:3.15.4
 
 FROM golang:1.17.8-alpine3.14 AS builder
 


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

This bump Alpine to the latest version.

#### What this PR does / why we need it

This bumps Alpine to the latest version and fixes a high CVE -2022-0778 that was fixed in Alpine 3.15.2

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Bump Alpine to 3.15.4

```
