### PR TITLE
feat: enable profiling endpoints

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -151,6 +151,8 @@ type Web struct {
 // Telemetry is the config format for telemetry including the HTTP server config.
 type Telemetry struct {
 	HTTP string `json:"http"`
+	// EnableProfiling makes profiling endpoints available via web interface host:port/debug/pprof/
+	EnableProfiling bool `json:"enableProfiling"`
 }
 
 // GRPC is the config for the gRPC API.

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"runtime"
 	"strings"
@@ -368,6 +369,10 @@ func runServe(options serveOptions) error {
 			return fmt.Errorf("listening (%s) on %s: %v", name, c.Telemetry.HTTP, err)
 		}
 
+		if c.Telemetry.EnableProfiling {
+			pprofHandler(telemetryRouter)
+		}
+
 		server := &http.Server{
 			Handler: telemetryRouter,
 		}
@@ -549,4 +554,12 @@ func applyConfigOverrides(options serveOptions, config *Config) {
 	if config.Frontend.Dir == "" {
 		config.Frontend.Dir = os.Getenv("DEX_FRONTEND_DIR")
 	}
+}
+
+func pprofHandler(router *http.ServeMux) {
+	router.HandleFunc("/debug/pprof/", pprof.Index)
+	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	router.HandleFunc("/debug/pprof/trace", pprof.Trace)
 }

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -63,6 +63,7 @@ web:
 # Configuration for telemetry
 telemetry:
   http: 0.0.0.0:5558
+  # enableProfiling: true
 
 # Uncomment this block to enable the gRPC API. This values MUST be different
 # from the HTTP endpoints.


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

#### Overview

Add profiling endpoints for the Dex telemetry server.

#### What this PR does / why we need it

Related to #778

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
feat: enable profiling endpoints
```
