### PR TITLE
Build multi-platform images in a single build job

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -14,10 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm/v7
-          - linux/arm64
         variant:
           - alpine
           - distroless
@@ -62,7 +58,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
-          platforms: arm64,arm
+          platforms: all
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -86,7 +82,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: ${{ github.event_name == 'push' }}

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -17,8 +17,6 @@ jobs:
         variant:
           - alpine
           - distroless
-    outputs:
-      version: ${{ steps.details.outputs.version }}
 
     steps:
       - name: Checkout
@@ -103,38 +101,16 @@ jobs:
             org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
             org.opencontainers.image.documentation=https://dexidp.io/docs/
 
-  container-scan:
-    name: Container scan
-    runs-on: ubuntu-latest
-    needs: container-images
-    if: github.event_name == 'push'
-    strategy:
-      matrix:
-        variant:
-          - alpine
-          - distroless
-
-    steps:
-      # Workaround for lack of matrix output support
-      - name: Calculate container image details
-        id: details
-        run: |
-          VERSION="${{ needs.container-images.outputs.version }}"
-
-          if [[ "${{ matrix.variant }}" != "alpine" ]]; then
-            VERSION="${VERSION}-${{ matrix.variant }}"
-          fi
-
-          echo ::set-output name=version::${VERSION}
-
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.2.5
         with:
           image-ref: "ghcr.io/dexidp/dex:${{ steps.details.outputs.version }}"
           format: "sarif"
           output: "trivy-results.sarif"
+        if: github.event_name == 'push'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v1
         with:
           sarif_file: "trivy-results.sarif"
+        if: github.event_name == 'push'


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Revert the matrix build to a single built job per base image.

#### What this PR does / why we need it

Apparently matrix builds don't work with multi-platform images.

See https://github.com/docker/build-push-action/issues/130

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
