### PR TITLE
OIDC connector: Support cases where there is no id_token when using a refresh_token grant

### DIFF
--- a/connector/oauth/oauth.go
+++ b/connector/oauth/oauth.go
@@ -209,12 +209,18 @@ func (c *oauthConnector) HandleCallback(s connector.Scopes, r *http.Request) (id
 		return identity, fmt.Errorf("OAuth Connector: failed to parse userinfo: %v", err)
 	}
 
-	userID, found := userInfoResult[c.userIDKey].(string)
+	userID, found := userInfoResult[c.userIDKey]
 	if !found {
 		return identity, fmt.Errorf("OAuth Connector: not found %v claim", c.userIDKey)
 	}
 
-	identity.UserID = userID
+	switch userID.(type) {
+	case float64, int64, string:
+		identity.UserID = fmt.Sprintf("%v", userID)
+	default:
+		return identity, fmt.Errorf("OAuth Connector: %v claim should be string or number, got %T", c.userIDKey, userID)
+	}
+
 	identity.Username, _ = userInfoResult[c.userNameKey].(string)
 	identity.PreferredUsername, _ = userInfoResult[c.preferredUsernameKey].(string)
 	identity.Email, _ = userInfoResult[c.emailKey].(string)

--- a/connector/oauth/oauth_test.go
+++ b/connector/oauth/oauth_test.go
@@ -84,7 +84,7 @@ func TestHandleCallBackForGroupsInUserInfo(t *testing.T) {
 	defer testServer.Close()
 
 	conn := newConnector(t, testServer.URL)
-	req := newRequestWithAuthCode(t, testServer.URL, "some-code")
+	req := newRequestWithAuthCode(t, testServer.URL, "TestHandleCallBackForGroupsInUserInfo")
 
 	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
 	assert.Equal(t, err, nil)
@@ -120,7 +120,7 @@ func TestHandleCallBackForGroupMapsInUserInfo(t *testing.T) {
 	defer testServer.Close()
 
 	conn := newConnector(t, testServer.URL)
-	req := newRequestWithAuthCode(t, testServer.URL, "some-code")
+	req := newRequestWithAuthCode(t, testServer.URL, "TestHandleCallBackForGroupMapsInUserInfo")
 
 	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
 	assert.Equal(t, err, nil)
@@ -154,7 +154,7 @@ func TestHandleCallBackForGroupsInToken(t *testing.T) {
 	defer testServer.Close()
 
 	conn := newConnector(t, testServer.URL)
-	req := newRequestWithAuthCode(t, testServer.URL, "some-code")
+	req := newRequestWithAuthCode(t, testServer.URL, "TestHandleCallBackForGroupsInToken")
 
 	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
 	assert.Equal(t, err, nil)
@@ -184,7 +184,7 @@ func TestHandleCallbackForNumericUserID(t *testing.T) {
 	defer testServer.Close()
 
 	conn := newConnector(t, testServer.URL)
-	req := newRequestWithAuthCode(t, testServer.URL, "some-code")
+	req := newRequestWithAuthCode(t, testServer.URL, "TestHandleCallbackForNumericUserID")
 
 	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
 	assert.Equal(t, err, nil)

--- a/connector/oauth/oauth_test.go
+++ b/connector/oauth/oauth_test.go
@@ -168,6 +168,34 @@ func TestHandleCallBackForGroupsInToken(t *testing.T) {
 	assert.Equal(t, identity.EmailVerified, false)
 }
 
+func TestHandleCallbackForNumericUserID(t *testing.T) {
+	tokenClaims := map[string]interface{}{}
+
+	userInfoClaims := map[string]interface{}{
+		"name":               "test-name",
+		"user_id_key":        1000,
+		"user_name_key":      "test-username",
+		"preferred_username": "test-preferred-username",
+		"mail":               "mod_mail",
+		"has_verified_email": false,
+	}
+
+	testServer := testSetup(t, tokenClaims, userInfoClaims)
+	defer testServer.Close()
+
+	conn := newConnector(t, testServer.URL)
+	req := newRequestWithAuthCode(t, testServer.URL, "some-code")
+
+	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+	assert.Equal(t, err, nil)
+
+	assert.Equal(t, identity.UserID, "1000")
+	assert.Equal(t, identity.Username, "test-username")
+	assert.Equal(t, identity.PreferredUsername, "test-preferred-username")
+	assert.Equal(t, identity.Email, "mod_mail")
+	assert.Equal(t, identity.EmailVerified, false)
+}
+
 func testSetup(t *testing.T, tokenClaims map[string]interface{}, userInfoClaims map[string]interface{}) *httptest.Server {
 	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -278,6 +278,7 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 	rawIDToken, ok := token.Extra("id_token").(string)
 	var sub_source string
 	var claims map[string]interface{}
+
 	if !ok {
 		// ID tokens aren't mandatory in the reply when using a refresh_token grant
 		if caller != "refresh" {
@@ -304,7 +305,12 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 		if err := userInfo.Claims(&claims); err != nil {
 			return identity, fmt.Errorf("oidc: failed to decode userinfo claims: %v", err)
 		}
-		sub_source = userInfo.Subject
+
+		// If the subject wasn't assigned from the ID token, assign the sub from the userinfo endpoint
+		if sub_source == "" {
+			sub_source = userInfo.Subject
+		}
+
 	}
 
 	userNameKey := "name"

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -226,6 +226,7 @@ func (c *oidcConnector) LoginURL(s connector.Scopes, callbackURL, state string) 
 	}
 	return c.oauth2Config.AuthCodeURL(state, opts...), nil
 }
+
 type oauth2Error struct {
 	error            string
 	errorDescription string

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -280,9 +280,11 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 	var claims map[string]interface{}
 
 	rawIDToken, ok := token.Extra("id_token").(string)
-	if !ok && caller != refreshCaller {
-		// ID tokens aren't mandatory in the reply when using a refresh_token grant
-		return identity, errors.New("oidc: no id_token in token response")
+	if !ok {
+		if caller != refreshCaller {
+			// ID tokens aren't mandatory in the reply when using a refresh_token grant
+			return identity, errors.New("oidc: no id_token in token response")
+		}
 	} else {
 		idToken, err := c.verifier.Verify(ctx, rawIDToken)
 		if err != nil {

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -276,7 +276,7 @@ func (c *oidcConnector) Refresh(ctx context.Context, s connector.Scopes, identit
 }
 
 func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.Identity, token *oauth2.Token, caller string) (connector.Identity, error) {
-	var sub_source string
+	var subSource string
 	var claims map[string]interface{}
 
 	rawIDToken, ok := token.Extra("id_token").(string)
@@ -294,7 +294,7 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 		if err := idToken.Claims(&claims); err != nil {
 			return identity, fmt.Errorf("oidc: failed to decode claims: %v", err)
 		}
-		sub_source = idToken.Subject
+		subSource = idToken.Subject
 	}
 
 	// We immediately want to run getUserInfo if configured before we validate the claims
@@ -309,8 +309,8 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 
 		// If the subject wasn't assigned from the ID token, assign the sub from the userinfo endpoint
 		// Only if this is a refresh call, though
-		if sub_source == "" && caller == refreshCaller {
-			sub_source = userInfo.Subject
+		if subSource == "" && caller == refreshCaller {
+			subSource = userInfo.Subject
 		}
 
 	}
@@ -403,7 +403,7 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 	}
 
 	identity = connector.Identity{
-		UserID:            sub_source,
+		UserID:            subSource,
 		Username:          name,
 		PreferredUsername: preferredUsername,
 		Email:             email,

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -282,7 +282,7 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 
 	if !ok {
 		// ID tokens aren't mandatory in the reply when using a refresh_token grant
-		if caller != "refresh" {
+		if caller != refreshCaller {
 			return identity, errors.New("oidc: no id_token in token response")
 		}
 	} else {

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -276,15 +276,13 @@ func (c *oidcConnector) Refresh(ctx context.Context, s connector.Scopes, identit
 }
 
 func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.Identity, token *oauth2.Token, caller string) (connector.Identity, error) {
-	rawIDToken, ok := token.Extra("id_token").(string)
 	var sub_source string
 	var claims map[string]interface{}
 
-	if !ok {
+	rawIDToken, ok := token.Extra("id_token").(string)
+	if !ok && caller != refreshCaller {
 		// ID tokens aren't mandatory in the reply when using a refresh_token grant
-		if caller != refreshCaller {
-			return identity, errors.New("oidc: no id_token in token response")
-		}
+		return identity, errors.New("oidc: no id_token in token response")
 	} else {
 		idToken, err := c.verifier.Verify(ctx, rawIDToken)
 		if err != nil {
@@ -293,8 +291,8 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 
 		if err := idToken.Claims(&claims); err != nil {
 			return identity, fmt.Errorf("oidc: failed to decode claims: %v", err)
-			sub_source = idToken.Subject
 		}
+		sub_source = idToken.Subject
 	}
 
 	// We immediately want to run getUserInfo if configured before we validate the claims
@@ -308,7 +306,8 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 		}
 
 		// If the subject wasn't assigned from the ID token, assign the sub from the userinfo endpoint
-		if sub_source == "" {
+		// Only if this is a refresh call, though
+		if sub_source == "" && caller == refreshCaller {
 			sub_source = userInfo.Subject
 		}
 

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -275,7 +275,8 @@ func TestHandleCallback(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			testServer, err := setupServer(tc.token)
+			IdTokenDesired := true
+			testServer, err := setupServer(tc.token, IdTokenDesired)
 			if err != nil {
 				t.Fatal("failed to setup test server", err)
 			}
@@ -331,7 +332,87 @@ func TestHandleCallback(t *testing.T) {
 	}
 }
 
-func setupServer(tok map[string]interface{}) (*httptest.Server, error) {
+func TestRefresh(t *testing.T) {
+	t.Helper()
+
+	tests := []struct {
+		name           string
+		expectUserID   string
+		expectUserName string
+		IdTokenDesired bool
+		token          map[string]interface{}
+	}{
+		{
+			name:           "IDTokenOnRefresh",
+			expectUserID:   "subvalue",
+			expectUserName: "namevalue",
+			IdTokenDesired: true,
+			token: map[string]interface{}{
+				"sub":  "subvalue",
+				"name": "namevalue",
+			},
+		},
+		{
+			name:           "NoIDTokenOnRefresh",
+			expectUserID:   "subvalue",
+			expectUserName: "namevalue",
+			IdTokenDesired: false,
+			token: map[string]interface{}{
+				"sub":  "subvalue",
+				"name": "namevalue",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			testServer, err := setupServer(tc.token, tc.IdTokenDesired)
+			if err != nil {
+				t.Fatal("failed to setup test server", err)
+			}
+			defer testServer.Close()
+
+			scopes := []string{"openid", "offline_access"}
+			serverURL := testServer.URL
+			config := Config{
+				Issuer:       serverURL,
+				ClientID:     "clientID",
+				ClientSecret: "clientSecret",
+				Scopes:       scopes,
+				RedirectURI:  fmt.Sprintf("%s/callback", serverURL),
+				GetUserInfo:  true,
+			}
+
+			conn, err := newConnector(config)
+			if err != nil {
+				t.Fatal("failed to create new connector", err)
+			}
+
+			req, err := newRequestWithAuthCode(testServer.URL, "someCode")
+			if err != nil {
+				t.Fatal("failed to create request", err)
+			}
+
+			refresh_token_str := "{\"RefreshToken\":\"asdf\"}"
+			refresh_token := []byte(refresh_token_str)
+
+			identity := connector.Identity{
+				UserID:        tc.expectUserID,
+				Username:      tc.expectUserName,
+				ConnectorData: refresh_token,
+			}
+
+			refresh_identity, err := conn.Refresh(req.Context(), connector.Scopes{OfflineAccess: true}, identity)
+			if err != nil {
+				t.Fatal("Refresh failed", err)
+			}
+
+			expectEquals(t, refresh_identity.UserID, tc.expectUserID)
+			expectEquals(t, refresh_identity.Username, tc.expectUserName)
+		})
+	}
+}
+
+func setupServer(tok map[string]interface{}, IdTokenDesired bool) (*httptest.Server, error) {
 	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate rsa key: %v", err)
@@ -368,11 +449,21 @@ func setupServer(tok map[string]interface{}) (*httptest.Server, error) {
 		}
 
 		w.Header().Add("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(&map[string]string{
-			"access_token": token,
-			"id_token":     token,
-			"token_type":   "Bearer",
-		})
+		if IdTokenDesired {
+			json.NewEncoder(w).Encode(&map[string]string{
+				"access_token": token,
+				"id_token":     token,
+				"token_type":   "Bearer"})
+		} else {
+			json.NewEncoder(w).Encode(&map[string]string{
+				"access_token": token,
+				"token_type":   "Bearer"})
+		}
+	})
+
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		json.Marshal(tok)
 	})
 
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -463,7 +463,7 @@ func setupServer(tok map[string]interface{}, IdTokenDesired bool) (*httptest.Ser
 
 	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
-		json.Marshal(tok)
+	        json.NewEncoder(w).Encode(tok)
 	})
 
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -275,8 +275,8 @@ func TestHandleCallback(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			IdTokenDesired := true
-			testServer, err := setupServer(tc.token, IdTokenDesired)
+			idTokenDesired := true
+			testServer, err := setupServer(tc.token, idTokenDesired)
 			if err != nil {
 				t.Fatal("failed to setup test server", err)
 			}
@@ -339,14 +339,14 @@ func TestRefresh(t *testing.T) {
 		name           string
 		expectUserID   string
 		expectUserName string
-		IdTokenDesired bool
+		idTokenDesired bool
 		token          map[string]interface{}
 	}{
 		{
 			name:           "IDTokenOnRefresh",
 			expectUserID:   "subvalue",
 			expectUserName: "namevalue",
-			IdTokenDesired: true,
+			idTokenDesired: true,
 			token: map[string]interface{}{
 				"sub":  "subvalue",
 				"name": "namevalue",
@@ -356,7 +356,7 @@ func TestRefresh(t *testing.T) {
 			name:           "NoIDTokenOnRefresh",
 			expectUserID:   "subvalue",
 			expectUserName: "namevalue",
-			IdTokenDesired: false,
+			idTokenDesired: false,
 			token: map[string]interface{}{
 				"sub":  "subvalue",
 				"name": "namevalue",
@@ -365,7 +365,7 @@ func TestRefresh(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			testServer, err := setupServer(tc.token, tc.IdTokenDesired)
+			testServer, err := setupServer(tc.token, tc.idTokenDesired)
 			if err != nil {
 				t.Fatal("failed to setup test server", err)
 			}
@@ -392,27 +392,27 @@ func TestRefresh(t *testing.T) {
 				t.Fatal("failed to create request", err)
 			}
 
-			refresh_token_str := "{\"RefreshToken\":\"asdf\"}"
-			refresh_token := []byte(refresh_token_str)
+			refreshTokenStr := "{\"RefreshToken\":\"asdf\"}"
+			refreshToken := []byte(refreshTokenStr)
 
 			identity := connector.Identity{
 				UserID:        tc.expectUserID,
 				Username:      tc.expectUserName,
-				ConnectorData: refresh_token,
+				ConnectorData: refreshToken,
 			}
 
-			refresh_identity, err := conn.Refresh(req.Context(), connector.Scopes{OfflineAccess: true}, identity)
+			refreshIdentity, err := conn.Refresh(req.Context(), connector.Scopes{OfflineAccess: true}, identity)
 			if err != nil {
 				t.Fatal("Refresh failed", err)
 			}
 
-			expectEquals(t, refresh_identity.UserID, tc.expectUserID)
-			expectEquals(t, refresh_identity.Username, tc.expectUserName)
+			expectEquals(t, refreshIdentity.UserID, tc.expectUserID)
+			expectEquals(t, refreshIdentity.Username, tc.expectUserName)
 		})
 	}
 }
 
-func setupServer(tok map[string]interface{}, IdTokenDesired bool) (*httptest.Server, error) {
+func setupServer(tok map[string]interface{}, idTokenDesired bool) (*httptest.Server, error) {
 	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate rsa key: %v", err)
@@ -449,7 +449,7 @@ func setupServer(tok map[string]interface{}, IdTokenDesired bool) (*httptest.Ser
 		}
 
 		w.Header().Add("Content-Type", "application/json")
-		if IdTokenDesired {
+		if idTokenDesired {
 			json.NewEncoder(w).Encode(&map[string]string{
 				"access_token": token,
 				"id_token":     token,

--- a/connector/openshift/openshift.go
+++ b/connector/openshift/openshift.go
@@ -28,14 +28,13 @@ const (
 
 // Config holds configuration options for OpenShift login
 type Config struct {
-	Issuer               string   `json:"issuer"`
-	ClientID             string   `json:"clientID"`
-	ClientSecret         string   `json:"clientSecret"`
-	RedirectURI          string   `json:"redirectURI"`
-	Groups               []string `json:"groups"`
-	InsecureCA           bool     `json:"insecureCA"`
-	RootCA               string   `json:"rootCA"`
-	IncludeSystemRootCAs bool     `json:"includeSystemRootCAs"`
+	Issuer       string   `json:"issuer"`
+	ClientID     string   `json:"clientID"`
+	ClientSecret string   `json:"clientSecret"`
+	RedirectURI  string   `json:"redirectURI"`
+	Groups       []string `json:"groups"`
+	InsecureCA   bool     `json:"insecureCA"`
+	RootCA       string   `json:"rootCA"`
 }
 
 var (
@@ -44,18 +43,17 @@ var (
 )
 
 type openshiftConnector struct {
-	apiURL               string
-	redirectURI          string
-	clientID             string
-	clientSecret         string
-	cancel               context.CancelFunc
-	logger               log.Logger
-	httpClient           *http.Client
-	oauth2Config         *oauth2.Config
-	insecureCA           bool
-	rootCA               string
-	includeSystemRootCAs bool
-	groups               []string
+	apiURL       string
+	redirectURI  string
+	clientID     string
+	clientSecret string
+	cancel       context.CancelFunc
+	logger       log.Logger
+	httpClient   *http.Client
+	oauth2Config *oauth2.Config
+	insecureCA   bool
+	rootCA       string
+	groups       []string
 }
 
 type user struct {
@@ -69,27 +67,34 @@ type user struct {
 // Open returns a connector which can be used to login users through an upstream
 // OpenShift OAuth2 provider.
 func (c *Config) Open(id string, logger log.Logger) (conn connector.Connector, err error) {
+	httpClient, err := newHTTPClient(c.InsecureCA, c.RootCA)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+	}
+
+	return c.OpenWithHTTPClient(id, logger, httpClient)
+}
+
+// OpenWithHTTPClient returns a connector which can be used to login users through an upstream
+// OpenShift OAuth2 provider. It provides the ability to inject a http.Client.
+func (c *Config) OpenWithHTTPClient(id string, logger log.Logger,
+	httpClient *http.Client) (conn connector.Connector, err error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	wellKnownURL := strings.TrimSuffix(c.Issuer, "/") + wellKnownURLPath
 	req, err := http.NewRequest(http.MethodGet, wellKnownURL, nil)
 
 	openshiftConnector := openshiftConnector{
-		apiURL:               c.Issuer,
-		cancel:               cancel,
-		clientID:             c.ClientID,
-		clientSecret:         c.ClientSecret,
-		insecureCA:           c.InsecureCA,
-		logger:               logger,
-		redirectURI:          c.RedirectURI,
-		rootCA:               c.RootCA,
-		includeSystemRootCAs: c.IncludeSystemRootCAs,
-		groups:               c.Groups,
-	}
-
-	if openshiftConnector.httpClient, err = newHTTPClient(c.InsecureCA, c.RootCA, c.IncludeSystemRootCAs); err != nil {
-		cancel()
-		return nil, fmt.Errorf("failed to create HTTP client: %v", err)
+		apiURL:       c.Issuer,
+		cancel:       cancel,
+		clientID:     c.ClientID,
+		clientSecret: c.ClientSecret,
+		insecureCA:   c.InsecureCA,
+		logger:       logger,
+		redirectURI:  c.RedirectURI,
+		rootCA:       c.RootCA,
+		groups:       c.Groups,
+		httpClient:   httpClient,
 	}
 
 	var metadata struct {
@@ -100,14 +105,14 @@ func (c *Config) Open(id string, logger log.Logger) (conn connector.Connector, e
 	resp, err := openshiftConnector.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		cancel()
-		return nil, fmt.Errorf("failed to query OpenShift endpoint %v", err)
+		return nil, fmt.Errorf("failed to query OpenShift endpoint %w", err)
 	}
 
 	defer resp.Body.Close()
 
 	if err := json.NewDecoder(resp.Body).Decode(&metadata); err != nil {
 		cancel()
-		return nil, fmt.Errorf("discovery through endpoint %s failed to decode body: %v",
+		return nil, fmt.Errorf("discovery through endpoint %s failed to decode body: %w",
 			wellKnownURL, err)
 	}
 
@@ -131,7 +136,8 @@ func (c *openshiftConnector) Close() error {
 // LoginURL returns the URL to redirect the user to login with.
 func (c *openshiftConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
 	if c.redirectURI != callbackURL {
-		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
+		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q",
+			callbackURL, c.redirectURI)
 	}
 	return c.oauth2Config.AuthCodeURL(state), nil
 }
@@ -149,7 +155,8 @@ func (e *oauth2Error) Error() string {
 }
 
 // HandleCallback parses the request and returns the user's identity
-func (c *openshiftConnector) HandleCallback(s connector.Scopes, r *http.Request) (identity connector.Identity, err error) {
+func (c *openshiftConnector) HandleCallback(s connector.Scopes,
+	r *http.Request) (identity connector.Identity, err error) {
 	q := r.URL.Query()
 	if errType := q.Get("error"); errType != "" {
 		return identity, &oauth2Error{errType, q.Get("error_description")}
@@ -168,7 +175,8 @@ func (c *openshiftConnector) HandleCallback(s connector.Scopes, r *http.Request)
 	return c.identity(ctx, s, token)
 }
 
-func (c *openshiftConnector) Refresh(ctx context.Context, s connector.Scopes, oldID connector.Identity) (connector.Identity, error) {
+func (c *openshiftConnector) Refresh(ctx context.Context, s connector.Scopes,
+	oldID connector.Identity) (connector.Identity, error) {
 	var token oauth2.Token
 	err := json.Unmarshal(oldID.ConnectorData, &token)
 	if err != nil {
@@ -180,7 +188,8 @@ func (c *openshiftConnector) Refresh(ctx context.Context, s connector.Scopes, ol
 	return c.identity(ctx, s, &token)
 }
 
-func (c *openshiftConnector) identity(ctx context.Context, s connector.Scopes, token *oauth2.Token) (identity connector.Identity, err error) {
+func (c *openshiftConnector) identity(ctx context.Context, s connector.Scopes,
+	token *oauth2.Token) (identity connector.Identity, err error) {
 	client := c.oauth2Config.Client(ctx, token)
 	user, err := c.user(ctx, client)
 	if err != nil {
@@ -251,21 +260,12 @@ func validateAllowedGroups(userGroups, allowedGroups []string) bool {
 }
 
 // newHTTPClient returns a new HTTP client
-func newHTTPClient(insecureCA bool, rootCA string, includeSystemRootCAs bool) (*http.Client, error) {
+func newHTTPClient(insecureCA bool, rootCA string) (*http.Client, error) {
 	tlsConfig := tls.Config{}
-
 	if insecureCA {
 		tlsConfig = tls.Config{InsecureSkipVerify: true}
 	} else if rootCA != "" {
-		if !includeSystemRootCAs {
-			tlsConfig = tls.Config{RootCAs: x509.NewCertPool()}
-		} else {
-			systemCAs, err := x509.SystemCertPool()
-			if err != nil {
-				return nil, fmt.Errorf("failed to read host CA: %w", err)
-			}
-			tlsConfig = tls.Config{RootCAs: systemCAs}
-		}
+		tlsConfig = tls.Config{RootCAs: x509.NewCertPool()}
 		rootCABytes, err := os.ReadFile(rootCA)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read root-ca: %w", err)

--- a/connector/openshift/openshift_test.go
+++ b/connector/openshift/openshift_test.go
@@ -70,7 +70,7 @@ func TestGetUser(t *testing.T) {
 	_, err = http.NewRequest("GET", hostURL.String(), nil)
 	expectNil(t, err)
 
-	h, err := newHTTPClient(true, "", false)
+	h, err := newHTTPClient(true, "")
 
 	expectNil(t, err)
 
@@ -128,7 +128,7 @@ func TestVerifyGroup(t *testing.T) {
 	_, err = http.NewRequest("GET", hostURL.String(), nil)
 	expectNil(t, err)
 
-	h, err := newHTTPClient(true, "", false)
+	h, err := newHTTPClient(true, "")
 
 	expectNil(t, err)
 
@@ -164,7 +164,7 @@ func TestCallbackIdentity(t *testing.T) {
 	req, err := http.NewRequest("GET", hostURL.String(), nil)
 	expectNil(t, err)
 
-	h, err := newHTTPClient(true, "", false)
+	h, err := newHTTPClient(true, "")
 
 	expectNil(t, err)
 
@@ -198,7 +198,7 @@ func TestRefreshIdentity(t *testing.T) {
 	})
 	defer s.Close()
 
-	h, err := newHTTPClient(true, "", false)
+	h, err := newHTTPClient(true, "")
 	expectNil(t, err)
 
 	oc := openshiftConnector{apiURL: s.URL, httpClient: h, oauth2Config: &oauth2.Config{
@@ -237,7 +237,7 @@ func TestRefreshIdentityFailure(t *testing.T) {
 	})
 	defer s.Close()
 
-	h, err := newHTTPClient(true, "", false)
+	h, err := newHTTPClient(true, "")
 	expectNil(t, err)
 
 	oc := openshiftConnector{apiURL: s.URL, httpClient: h, oauth2Config: &oauth2.Config{

--- a/connector/openshift/openshift_test.go
+++ b/connector/openshift/openshift_test.go
@@ -70,7 +70,7 @@ func TestGetUser(t *testing.T) {
 	_, err = http.NewRequest("GET", hostURL.String(), nil)
 	expectNil(t, err)
 
-	h, err := newHTTPClient(true, "")
+	h, err := newHTTPClient(true, "", false)
 
 	expectNil(t, err)
 
@@ -128,7 +128,7 @@ func TestVerifyGroup(t *testing.T) {
 	_, err = http.NewRequest("GET", hostURL.String(), nil)
 	expectNil(t, err)
 
-	h, err := newHTTPClient(true, "")
+	h, err := newHTTPClient(true, "", false)
 
 	expectNil(t, err)
 
@@ -164,7 +164,7 @@ func TestCallbackIdentity(t *testing.T) {
 	req, err := http.NewRequest("GET", hostURL.String(), nil)
 	expectNil(t, err)
 
-	h, err := newHTTPClient(true, "")
+	h, err := newHTTPClient(true, "", false)
 
 	expectNil(t, err)
 
@@ -198,7 +198,7 @@ func TestRefreshIdentity(t *testing.T) {
 	})
 	defer s.Close()
 
-	h, err := newHTTPClient(true, "")
+	h, err := newHTTPClient(true, "", false)
 	expectNil(t, err)
 
 	oc := openshiftConnector{apiURL: s.URL, httpClient: h, oauth2Config: &oauth2.Config{
@@ -237,7 +237,7 @@ func TestRefreshIdentityFailure(t *testing.T) {
 	})
 	defer s.Close()
 
-	h, err := newHTTPClient(true, "")
+	h, err := newHTTPClient(true, "", false)
 	expectNil(t, err)
 
 	oc := openshiftConnector{apiURL: s.URL, httpClient: h, oauth2Config: &oauth2.Config{


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

Signed-off-by: Anthony Brandelli <abrandel@cisco.com>

#### Overview

<!-- Describe your changes briefly here. -->
Allows for dex to function with IDPs that do not return an ID token in the reply when using a refresh_token grant. 

#### What this PR does / why we need it

Although this seems to be rare, the OIDC spec does not require that an id_token be present in the reply when using a refresh_token grant. Additional info in #2498. 

This is a toggle in PingFed, so there is at least one common IDP out there where there won't always be a refresh token. 

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
Closes #2498 

#### Special notes for your reviewer

Note that if a user has an IDP where ID tokens aren't present when using a refresh_token grant, AND also chooses not to enable the userinfo endpoint, this will choke. The claims have to come from somewhere, so I would say this really is just an unsupported configuration should someone choose to try this. The OIDC spec says that userinfo must always contain the sub additionally. 

I tried to keep behaviour as close as possible to current. Although its extra code, and probably not needed, I chose to prefer the sub from the ID token if its present, over assigning the one from the userinfo. 

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

NONE

```
