### PR TITLE
Remove google specific hd / hosted domain claim config from oidc connector

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -34,10 +34,6 @@ type Config struct {
 
 	Scopes []string `json:"scopes"` // defaults to "profile" and "email"
 
-	// Optional list of whitelisted domains when using Google
-	// If this field is nonempty, only users from a listed domain will be allowed to log in
-	HostedDomains []string `json:"hostedDomains"`
-
 	// Override the value of email_verified to true in the returned claims
 	InsecureSkipEmailVerified bool `json:"insecureSkipEmailVerified"`
 
@@ -156,7 +152,6 @@ func (c *Config) Open(id string, logger log.Logger) (conn connector.Connector, e
 		),
 		logger:                    logger,
 		cancel:                    cancel,
-		hostedDomains:             c.HostedDomains,
 		insecureSkipEmailVerified: c.InsecureSkipEmailVerified,
 		insecureEnableGroups:      c.InsecureEnableGroups,
 		acrValues:                 c.AcrValues,
@@ -183,7 +178,6 @@ type oidcConnector struct {
 	verifier                  *oidc.IDTokenVerifier
 	cancel                    context.CancelFunc
 	logger                    log.Logger
-	hostedDomains             []string
 	insecureSkipEmailVerified bool
 	insecureEnableGroups      bool
 	acrValues                 []string
@@ -208,13 +202,6 @@ func (c *oidcConnector) LoginURL(s connector.Scopes, callbackURL, state string) 
 	}
 
 	var opts []oauth2.AuthCodeOption
-	if len(c.hostedDomains) > 0 {
-		preferredDomain := c.hostedDomains[0]
-		if len(c.hostedDomains) > 1 {
-			preferredDomain = "*"
-		}
-		opts = append(opts, oauth2.SetAuthURLParam("hd", preferredDomain))
-	}
 
 	if len(c.acrValues) > 0 {
 		acrValues := strings.Join(c.acrValues, " ")
@@ -358,21 +345,6 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 					return identity, fmt.Errorf("malformed \"%v\" claim", groupsKey)
 				}
 			}
-		}
-	}
-
-	hostedDomain, _ := claims["hd"].(string)
-	if len(c.hostedDomains) > 0 {
-		found := false
-		for _, domain := range c.hostedDomains {
-			if hostedDomain == domain {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			return identity, fmt.Errorf("oidc: unexpected hd claim %v", hostedDomain)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Anthony Brandelli <abrandel@cisco.com>

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

At some point in the evolution of dex it seems like some Google specific stuff got left in the OIDC connector, when there is now a Google specific one. 

I would like to gather feedback on this PR whether it makes sense to remove this, given that there could be users out there who are utilizing the OIDC connector but using Google as their IDP, instead of using the Google connector. I don't want to break people, but I also think this stuff is pretty 

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

Originally added in https://github.com/dexidp/dex/pull/974 which is before the Google connector was split out here https://github.com/dexidp/dex/pull/1185. I believe that this is just a miss since then, I am unaware of any other IDPs (but of course I am not aware of everyone's configuration) that use this claim. 

This is currently also referenced in the docs here https://dexidp.io/docs/connectors/oidc/, I will open a separate PR to update the docs should it be agreed we want to proceed with removing this code. 

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
The OIDC connector will no longer look for, or respect the hosted domain "hd" claim. User's who are using Google as their IDP should use the Google connector. 
```
