### PR TITLE
chore: do not use caching for docker build

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -71,8 +71,8 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm/v7,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -76,8 +76,8 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm/v7,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Try to build dex without using cache and see the impact

#### What this PR does / why we need it

There are a lot of failed docker builds, and their nature is unknown. Most of the time job freezes after preparing the cache
```
2022-05-06T04:34:03.2162689Z 
2022-05-06T04:34:03.2162791Z #79 exporting cache
2022-05-06T04:34:03.2163057Z #79 preparing build cache for export
2022-05-06T04:35:07.8469443Z #79 preparing build cache for export 64.7s done
2022-05-06T10:06:23.6107579Z ##[error]The operation was canceled.
2022-05-06T10:06:23.6170814Z Post job cleanup.
2022-05-06T10:06:23.7425906Z ##[group]Removing temp folder /tmp/docker-build-push-x2GXuu
2022-05-06T10:06:23.7426866Z ##[endgroup]
```
I would like to build Dex images without caching and see how it affects building time (and the consistency of building results).
 
#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
