### PR TITLE
feat: Update response_types_supported to allow multiple-valued response type combinations

### DIFF
--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -135,12 +135,12 @@ const (
 )
 
 const (
-	responseTypeCode    = "code"     // "Regular" flow
-	responseTypeToken   = "token"    // Implicit flow for frontend apps.
-	responseTypeIDToken = "id_token" // ID Token in url fragment
-	responseTypeCodeToken = "code token" // "Regular" flow + Implicit flow
-	responseTypeCodeIDToken = "code id_token" // "Regular" flow + ID Token
-	responseTypeIDTokenToken = "id_token token" // ID Token + Implicit flow
+	responseTypeCode             = "code"                // "Regular" flow
+	responseTypeToken            = "token"               // Implicit flow for frontend apps.
+	responseTypeIDToken          = "id_token"            // ID Token in url fragment
+	responseTypeCodeToken        = "code token"          // "Regular" flow + Implicit flow
+	responseTypeCodeIDToken      = "code id_token"       // "Regular" flow + ID Token
+	responseTypeIDTokenToken     = "id_token token"      // ID Token + Implicit flow
 	responseTypeCodeIDTokenToken = "code id_token token" // "Regular" flow + ID Token + Implicit flow
 )
 

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -138,6 +138,10 @@ const (
 	responseTypeCode    = "code"     // "Regular" flow
 	responseTypeToken   = "token"    // Implicit flow for frontend apps.
 	responseTypeIDToken = "id_token" // ID Token in url fragment
+	responseTypeCodeToken = "code token" // "Regular" flow + Implicit flow
+	responseTypeCodeIDToken = "code id_token" // "Regular" flow + ID Token
+	responseTypeIDTokenToken = "id_token token" // ID Token + Implicit flow
+	responseTypeCodeIDTokenToken = "code id_token token" // "Regular" flow + ID Token + Implicit flow
 )
 
 const (

--- a/server/server.go
+++ b/server/server.go
@@ -218,9 +218,9 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 
 	for _, respType := range c.SupportedResponseTypes {
 		switch respType {
-		case responseTypeCode, responseTypeIDToken:
+		case responseTypeCode, responseTypeIDToken, responseTypeCodeIDToken:
 			// continue
-		case responseTypeToken:
+		case responseTypeToken, responseTypeCodeToken, responseTypeIDTokenToken, responseTypeCodeIDTokenToken:
 			// response_type=token is an implicit flow, let's add it to the discovery info
 			// https://datatracker.ietf.org/doc/html/rfc6749#section-4.2.1
 			supportedGrant = append(supportedGrant, grantTypeImplicit)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->

DEX can support multiple-valued response type combinations ([spec](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#Combinations)) but doesn't display it on the server endpoint :
[https://<idp_url>/.well-known/openid-configuration](https://<idp_url>/.well-known/openid-configuration)

This PR fixes this issue.

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

Some applications will check the ``response_types_supported`` retrieved from the following URL : [https://<idp_url>/.well-known/openid-configuration](https://<idp_url>/.well-known/openid-configuration) before performing any flow.

DEX servers will only display the following supported response types :
```json
"response_types_supported": [
  "code",
  "id_token",
  "token"
]
```

Since DEX can support multiple-valued response type combinations, this field should display :
```json
"response_types_supported": [
  "code",
  "id_token",
  "token",
  "code token",
  "code id_token",
  "token id_token",
  "code token id_token"
]
```

Closes #1449 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
