### PR TITLE
Fixes https://github.com/dexidp/dex/issues/2537

### DIFF
--- a/server/deviceflowhandlers.go
+++ b/server/deviceflowhandlers.go
@@ -141,6 +141,10 @@ func (s *Server) handleDeviceCode(w http.ResponseWriter, r *http.Request) {
 		// https://tools.ietf.org/html/rfc8628#section-3.2
 		w.Header().Set("Cache-Control", "no-store")
 
+		// Response type should be application/json according to
+		// https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
+		w.Header().Set("Content-Type", "application/json")
+
 		enc := json.NewEncoder(w)
 		enc.SetEscapeHTML(false)
 		enc.SetIndent("", "   ")

--- a/server/deviceflowhandlers_test.go
+++ b/server/deviceflowhandlers_test.go
@@ -52,6 +52,7 @@ func TestHandleDeviceCode(t *testing.T) {
 		requestType            string
 		scopes                 []string
 		expectedResponseCode   int
+		expectedContentType    string
 		expectedServerResponse string
 	}{
 		{
@@ -60,6 +61,7 @@ func TestHandleDeviceCode(t *testing.T) {
 			requestType:          "POST",
 			scopes:               []string{"openid", "profile", "email"},
 			expectedResponseCode: http.StatusOK,
+			expectedContentType:  "application/json",
 		},
 		{
 			testName:             "Invalid request Type (GET)",
@@ -67,6 +69,7 @@ func TestHandleDeviceCode(t *testing.T) {
 			requestType:          "GET",
 			scopes:               []string{"openid", "profile", "email"},
 			expectedResponseCode: http.StatusBadRequest,
+			expectedContentType:  "application/json",
 		},
 	}
 	for _, tc := range tests {
@@ -99,6 +102,10 @@ func TestHandleDeviceCode(t *testing.T) {
 			s.ServeHTTP(rr, req)
 			if rr.Code != tc.expectedResponseCode {
 				t.Errorf("Unexpected Response Type.  Expected %v got %v", tc.expectedResponseCode, rr.Code)
+			}
+
+			if rr.Header().Get("content-type") != tc.expectedContentType {
+				t.Errorf("Unexpected Response Content Type.  Expected %v got %v", tc.expectedContentType, rr.Header().Get("content-type"))
 			}
 
 			body, err := io.ReadAll(rr.Body)


### PR DESCRIPTION
Signed-off-by: Shivansh Vij <shivanshvij@outlook.com>

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

Closes https://github.com/dexidp/dex/issues/2537

This is a bug that was introduced in [this PR](https://github.com/dexidp/dex/pull/1706), and is where the `handleDeviceCode` handler does not set the `content-type` header in the response to `application/json` - because of this, the flow does not conform to the RFC (https://datatracker.ietf.org/doc/html/rfc8628#section-3.3 and https://datatracker.ietf.org/doc/html/rfc6749#section-5.1). 

I've also added a test case to check for this exact bug. 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
