### PR TITLE
feat: oidc accept groups as string

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -347,6 +347,11 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 		s := ""
 		groupsKey := "groups"
 		vs, found := claims[groupsKey].([]interface{})
+
+		if !found {
+			s, found = claims[groupsKey].(string)
+		}
+
 		if (!found || c.overrideClaimMapping) && c.groupsKey != "" {
 			groupsKey = c.groupsKey
 			vs, found = claims[groupsKey].([]interface{})

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -344,14 +344,22 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 
 	var groups []string
 	if c.insecureEnableGroups {
+		s := ""
 		groupsKey := "groups"
 		vs, found := claims[groupsKey].([]interface{})
 		if (!found || c.overrideClaimMapping) && c.groupsKey != "" {
 			groupsKey = c.groupsKey
 			vs, found = claims[groupsKey].([]interface{})
+
+			if !found {
+				s, found = claims[groupsKey].(string)
+			}
 		}
 
 		if found {
+			if s != "" {
+				groups = append(groups, s)
+			}
 			for _, v := range vs {
 				if s, ok := v.(string); ok {
 					groups = append(groups, s)

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -271,6 +271,23 @@ func TestHandleCallback(t *testing.T) {
 				"cognito:groups": []string{"group3", "group4"},
 			},
 		},
+		{
+			name:                      "customGroupsString",
+			groupsKey:                 "cognito:groups",
+			expectUserID:              "subvalue",
+			expectUserName:            "namevalue",
+			expectedEmailField:        "emailvalue",
+			expectGroups:              []string{"group1"},
+			scopes:                    []string{"groups"},
+			insecureSkipEmailVerified: true,
+			token: map[string]interface{}{
+				"sub":            "subvalue",
+				"name":           "namevalue",
+				"user_name":      "username",
+				"email":          "emailvalue",
+				"cognito:groups": "group1",
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -273,7 +273,23 @@ func TestHandleCallback(t *testing.T) {
 		},
 		{
 			name:                      "customGroupsString",
-			groupsKey:                 "cognito:groups",
+			groupsKey:                 "group",
+			expectUserID:              "subvalue",
+			expectUserName:            "namevalue",
+			expectedEmailField:        "emailvalue",
+			expectGroups:              []string{"group1"},
+			scopes:                    []string{"groups"},
+			insecureSkipEmailVerified: true,
+			token: map[string]interface{}{
+				"sub":       "subvalue",
+				"name":      "namevalue",
+				"user_name": "username",
+				"email":     "emailvalue",
+				"group":     "group1",
+			},
+		},
+		{
+			name:                      "groupsString",
 			expectUserID:              "subvalue",
 			expectUserName:            "namevalue",
 			expectedEmailField:        "emailvalue",
@@ -285,7 +301,7 @@ func TestHandleCallback(t *testing.T) {
 				"name":           "namevalue",
 				"user_name":      "username",
 				"email":          "emailvalue",
-				"cognito:groups": "group1",
+				"groups": "group1",
 			},
 		},
 	}


### PR DESCRIPTION
#### Overview

The current OIDC connector only support the groups claim as an array, but if the response is a string, because the user only has one group, the groups cannot be mapped. I was configuring Dex with an OIDC provider that response a string when the user has only one group, so it's needed a way to handle this scenarios. 

#### What this PR does / why we need it

- Allows the group claim be a string and an array.
- It's need because there are some providers that response with a string when the user only have one group. 

#### Does this PR introduce a user-facing change?

NONE

```release-note
OIDC Connector: Support for groups as a string.
```
