### PR TITLE
add config to explicitly set scopes for microsoft connector

### DIFF
--- a/connector/microsoft/microsoft.go
+++ b/connector/microsoft/microsoft.go
@@ -58,6 +58,8 @@ type Config struct {
 	// For valid values, see https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code.
 	PromptType string `json:"promptType"`
 	DomainHint string `json:"domainHint"`
+
+	Scopes []string `json:"scopes"` // defaults to scopeUser (user.read)
 }
 
 // Open returns a strategy for logging in through Microsoft.
@@ -77,6 +79,7 @@ func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error)
 		emailToLowercase:     c.EmailToLowercase,
 		promptType:           c.PromptType,
 		domainHint:           c.DomainHint,
+		scopes:               c.Scopes,
 	}
 	// By default allow logins from both personal and business/school
 	// accounts.
@@ -122,6 +125,7 @@ type microsoftConnector struct {
 	emailToLowercase     bool
 	promptType           string
 	domainHint           string
+	scopes               []string
 }
 
 func (c *microsoftConnector) isOrgTenant() bool {
@@ -133,7 +137,12 @@ func (c *microsoftConnector) groupsRequired(groupScope bool) bool {
 }
 
 func (c *microsoftConnector) oauth2Config(scopes connector.Scopes) *oauth2.Config {
-	microsoftScopes := []string{scopeUser}
+	var microsoftScopes []string
+	if len(c.scopes) > 0 {
+		microsoftScopes = c.scopes
+	} else {
+		microsoftScopes = append(microsoftScopes, scopeUser)
+	}
 	if c.groupsRequired(scopes.Groups) {
 		microsoftScopes = append(microsoftScopes, scopeGroups)
 	}


### PR DESCRIPTION

#### Overview

Adds a new configuration option for the Microsoft connector to explicitly declare the scopes to be requested in tokens

#### What this PR does / why we need it

[Users have noted](https://github.com/sigstore/fulcio/issues/157) that requesting a default scope of `user.read` (aka `profile`) vs `["openid", "email"]` may be too broad for a simple ID token. This PR allows for the Microsoft connector configuration to explicitly set the minimum scope to something other than `user.read` (per Microsoft [documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent)), which is available in other similar connectors.

#### Does this PR introduce a user-facing change?

New config option for connector

Signed-off-by: Bob Callaway <bcallaway@google.com>
