### PR TITLE
Add domainHint parameter to Microsoft Connector

### DIFF
--- a/connector/microsoft/microsoft.go
+++ b/connector/microsoft/microsoft.go
@@ -57,6 +57,7 @@ type Config struct {
 	// PromptType is used for the prompt query parameter.
 	// For valid values, see https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code.
 	PromptType string `json:"promptType"`
+	DomainHint string `json:"domainHint"`
 }
 
 // Open returns a strategy for logging in through Microsoft.
@@ -75,6 +76,7 @@ func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error)
 		logger:               logger,
 		emailToLowercase:     c.EmailToLowercase,
 		promptType:           c.PromptType,
+		domainHint:			  c.DomainHint,
 	}
 	// By default allow logins from both personal and business/school
 	// accounts.
@@ -119,6 +121,7 @@ type microsoftConnector struct {
 	logger               log.Logger
 	emailToLowercase     bool
 	promptType           string
+	domainHint			 string
 }
 
 func (c *microsoftConnector) isOrgTenant() bool {
@@ -159,6 +162,9 @@ func (c *microsoftConnector) LoginURL(scopes connector.Scopes, callbackURL, stat
 	var options []oauth2.AuthCodeOption
 	if c.promptType != "" {
 		options = append(options, oauth2.SetAuthURLParam("prompt", c.promptType))
+	}
+	if c.domainHint != "" {
+		options = append(options, oauth2.SetAuthURLParam("domain_hint", c.domainHint))
 	}
 
 	return c.oauth2Config(scopes).AuthCodeURL(state, options...), nil

--- a/connector/microsoft/microsoft.go
+++ b/connector/microsoft/microsoft.go
@@ -76,7 +76,7 @@ func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error)
 		logger:               logger,
 		emailToLowercase:     c.EmailToLowercase,
 		promptType:           c.PromptType,
-		domainHint:			  c.DomainHint,
+		domainHint:           c.DomainHint,
 	}
 	// By default allow logins from both personal and business/school
 	// accounts.
@@ -121,7 +121,7 @@ type microsoftConnector struct {
 	logger               log.Logger
 	emailToLowercase     bool
 	promptType           string
-	domainHint			 string
+	domainHint           string
 }
 
 func (c *microsoftConnector) isOrgTenant() bool {

--- a/connector/microsoft/microsoft_test.go
+++ b/connector/microsoft/microsoft_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"reflect"
 	"testing"
-	"net/url"
 
 	"github.com/dexidp/dex/connector"
 )
@@ -17,8 +17,10 @@ type testResponse struct {
 	data interface{}
 }
 
-const tenant = "9b1c3439-a67e-4e92-bb0d-0571d44ca965"
-const clientId = "a115ebf3-6020-4384-8eb1-c0c42e667b6f"
+const (
+	tenant   = "9b1c3439-a67e-4e92-bb0d-0571d44ca965"
+	clientID = "a115ebf3-6020-4384-8eb1-c0c42e667b6f"
+)
 
 var dummyToken = testResponse{data: map[string]interface{}{
 	"access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9",
@@ -30,11 +32,11 @@ func TestLoginURL(t *testing.T) {
 	testState := "some-state"
 
 	conn := microsoftConnector{
-		apiURL: testURL,
-		graphURL: testURL,
+		apiURL:      testURL,
+		graphURL:    testURL,
 		redirectURI: testURL,
-		clientID: clientId,
-		tenant: tenant,
+		clientID:    clientID,
+		tenant:      tenant,
 	}
 
 	loginURL, _ := conn.LoginURL(connector.Scopes{}, conn.redirectURI, testState)
@@ -42,8 +44,8 @@ func TestLoginURL(t *testing.T) {
 	parsedLoginURL, _ := url.Parse(loginURL)
 	queryParams := parsedLoginURL.Query()
 
-	expectEquals(t, parsedLoginURL.Path,  "/" + tenant + "/oauth2/v2.0/authorize")
-	expectEquals(t, queryParams.Get("client_id"), clientId)
+	expectEquals(t, parsedLoginURL.Path, "/"+tenant+"/oauth2/v2.0/authorize")
+	expectEquals(t, queryParams.Get("client_id"), clientID)
 	expectEquals(t, queryParams.Get("redirect_uri"), testURL)
 	expectEquals(t, queryParams.Get("response_type"), "code")
 	expectEquals(t, queryParams.Get("scope"), "user.read")
@@ -58,11 +60,11 @@ func TestLoginURLWithOptions(t *testing.T) {
 	domainHint := "domain.hint"
 
 	conn := microsoftConnector{
-		apiURL: testURL,
-		graphURL: testURL,
+		apiURL:      testURL,
+		graphURL:    testURL,
 		redirectURI: testURL,
-		clientID: clientId,
-		tenant: tenant,
+		clientID:    clientID,
+		tenant:      tenant,
 
 		promptType: promptType,
 		domainHint: domainHint,


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

This PR implements the solution proposed in https://github.com/dexidp/dex/issues/2585 to accelerate users logins using the Microsoft Connector when multiple sessions are present.

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

Closes #2585

Adds optional `domainHint` string configuration parameter to the Microsoft Connector
When `domainHint` is configured, the Microsoft Connector will encode the string as `domain_hint` in the Authorization Code URL.

#### Special notes for your reviewer

Added 2 new tests to cover the `TestLoginURL` function in the Microsoft Connector.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Adds optional `domainHint` configuration parameter to the Microsoft connector to streamline logins for single-tenant deployments.
```
