### PR TITLE
Add expiry.refreshToken settings to config.yaml.dist

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -85,6 +85,11 @@ web:
 #   deviceRequests: "5m"
 #   signingKeys: "6h"
 #   idTokens: "24h"
+#   refreshTokens:
+#     disableRotation: false
+#     reuseInterval: "3s"
+#     validIfNotUsedFor: "2160h" # 90 days
+#     absoluteLifetime: "3960h" # 165 days
 
 # OAuth2 configuration
 # oauth2:


### PR DESCRIPTION
#### Overview

Add expiry.refreshToken settings to `config.yaml.dist`

#### What this PR does / why we need it

config-dev.yaml is "deprecated" and these settings aren't mentioned anywhere else, so to ensure users know the available configuration options, these should be added to `config.yaml.dist`

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
Add expiry.refreshToken settings to config.yaml.dist
```
