### PR TITLE
feat(connector/ldap): add indirect group membership search

### DIFF
--- a/connector/ldap/testdata/schema.ldif
+++ b/connector/ldap/testdata/schema.ldif
@@ -136,6 +136,81 @@ objectClass: groupOfNames
 cn: developers
 member: cn=jane,ou=People,ou=TestGroupQuery,dc=example,dc=org
 
+dn: cn=technical-staff,ou=Groups,ou=TestGroupQuery,dc=example,dc=org
+objectClass: groupOfNames
+cn: technical-staff
+member: cn=developers,ou=Groups,ou=TestGroupQuery,dc=example,dc=org
+
+dn: cn=admin-staff,ou=Groups,ou=TestGroupQuery,dc=example,dc=org
+objectClass: groupOfNames
+cn: admin-staff
+member: cn=admins,ou=Groups,ou=TestGroupQuery,dc=example,dc=org
+
+dn: cn=staff,ou=Groups,ou=TestGroupQuery,dc=example,dc=org
+objectClass: groupOfNames
+cn: staff
+member: cn=technical-staff,ou=Groups,ou=TestGroupQuery,dc=example,dc=org
+member: cn=admin-staff,ou=Groups,ou=TestGroupQuery,dc=example,dc=org
+
+########################################################################
+
+dn: ou=TestIndirectGroupQuery,dc=example,dc=org
+objectClass: organizationalUnit
+ou: TestIndirectGroupQuery
+
+dn: ou=People,ou=TestIndirectGroupQuery,dc=example,dc=org
+objectClass: organizationalUnit
+ou: People
+
+dn: cn=jane,ou=People,ou=TestIndirectGroupQuery,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+sn: doe
+cn: jane
+mail: janedoe@example.com
+userpassword: foo
+
+dn: cn=john,ou=People,ou=TestIndirectGroupQuery,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+sn: doe
+cn: john
+mail: johndoe@example.com
+userpassword: bar
+
+# Group definitions.
+
+dn: ou=Groups,ou=TestIndirectGroupQuery,dc=example,dc=org
+objectClass: organizationalUnit
+ou: Groups
+
+dn: cn=admins,ou=Groups,ou=TestIndirectGroupQuery,dc=example,dc=org
+objectClass: groupOfNames
+cn: admins
+member: cn=john,ou=People,ou=TestIndirectGroupQuery,dc=example,dc=org
+member: cn=jane,ou=People,ou=TestIndirectGroupQuery,dc=example,dc=org
+
+dn: cn=developers,ou=Groups,ou=TestIndirectGroupQuery,dc=example,dc=org
+objectClass: groupOfNames
+cn: developers
+member: cn=jane,ou=People,ou=TestIndirectGroupQuery,dc=example,dc=org
+
+dn: cn=technical-staff,ou=Groups,ou=TestIndirectGroupQuery,dc=example,dc=org
+objectClass: groupOfNames
+cn: technical-staff
+member: cn=developers,ou=Groups,ou=TestIndirectGroupQuery,dc=example,dc=org
+
+dn: cn=admin-staff,ou=Groups,ou=TestIndirectGroupQuery,dc=example,dc=org
+objectClass: groupOfNames
+cn: admin-staff
+member: cn=admins,ou=Groups,ou=TestIndirectGroupQuery,dc=example,dc=org
+
+dn: cn=staff,ou=Groups,ou=TestIndirectGroupQuery,dc=example,dc=org
+objectClass: groupOfNames
+cn: staff
+member: cn=technical-staff,ou=Groups,ou=TestIndirectGroupQuery,dc=example,dc=org
+member: cn=admin-staff,ou=Groups,ou=TestIndirectGroupQuery,dc=example,dc=org
+
 ########################################################################
 
 dn: ou=TestGroupsOnUserEntity,dc=example,dc=org


### PR DESCRIPTION
Signed-off-by: Yann Soubeyrand <yann.soubeyrand@gmx.fr>

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

This PR adds the ability to search indirect group membership for a user with LDAP connector.

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

Currently, LDAP connector cannot return indirect group membership for a user (indirect groups are groups which the user’s groups are member of). This is a problem when your users are placed in organizational groups and these organizational groups are then used to give access to services by placing them in turn in service groups. Currently, only the organizational groups are returned, whereas you need the service groups to authorize or not the user to access the service. This PR adds indirect group membership lookup, so that service groups are also returned.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

This PR adds a new optional `recursion` configuration section in the `groupSearch` config section.

```release-note
LDAP connector: add indirect group membership lookup
```
