### PR TITLE
feat(connector/authproxy): support multiple groups

### DIFF
--- a/connector/authproxy/authproxy.go
+++ b/connector/authproxy/authproxy.go
@@ -70,8 +70,11 @@ func (m *callback) HandleCallback(s connector.Scopes, r *http.Request) (connecto
 	groups := m.groups
 	headerGroup := r.Header.Get(m.groupHeader)
 	if headerGroup != "" {
-		trimHeaderGroup := strings.Replace(headerGroup, " ", "", -1)
-		groups = append(strings.Split(trimHeaderGroup, ","), groups...)
+		splitheaderGroup := strings.Split(headerGroup, ",")
+		for i, v := range splitheaderGroup {
+			splitheaderGroup[i] = strings.TrimSpace(v)
+		}
+		groups = append(splitheaderGroup, groups...)
 	}
 	return connector.Identity{
 		UserID:        remoteUser, // TODO: figure out if this is a bad ID value.

--- a/connector/authproxy/authproxy.go
+++ b/connector/authproxy/authproxy.go
@@ -70,7 +70,8 @@ func (m *callback) HandleCallback(s connector.Scopes, r *http.Request) (connecto
 	groups := m.groups
 	headerGroup := r.Header.Get(m.groupHeader)
 	if headerGroup != "" {
-		groups = append(strings.Split(headerGroup, ","), groups...)
+		trimHeaderGroup := strings.Replace(headerGroup, " ", "", -1)
+		groups = append(strings.Split(trimHeaderGroup, ","), groups...)
 	}
 	return connector.Identity{
 		UserID:        remoteUser, // TODO: figure out if this is a bad ID value.

--- a/connector/authproxy/authproxy.go
+++ b/connector/authproxy/authproxy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/dexidp/dex/connector"
 	"github.com/dexidp/dex/pkg/log"
@@ -69,7 +70,7 @@ func (m *callback) HandleCallback(s connector.Scopes, r *http.Request) (connecto
 	groups := m.groups
 	headerGroup := r.Header.Get(m.groupHeader)
 	if headerGroup != "" {
-		groups = append(groups, headerGroup)
+		groups = append(strings.Split(headerGroup, ","), groups...)
 	}
 	return connector.Identity{
 		UserID:        remoteUser, // TODO: figure out if this is a bad ID value.

--- a/connector/authproxy/authproxy_test.go
+++ b/connector/authproxy/authproxy_test.go
@@ -1,0 +1,128 @@
+package authproxy
+
+import (
+	"io"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/dexidp/dex/connector"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	testUserid       = "test-user"
+	testEmail        = "testuser@example.com"
+	testGroup1       = "allUsers"
+	testGroup2       = "admins"
+	testStaticGroup1 = "static1"
+	testStaticGroup2 = "static2"
+)
+
+var logger = &logrus.Logger{Out: io.Discard, Formatter: &logrus.TextFormatter{}}
+
+func TestUser(t *testing.T) {
+	config := Config{
+		UserHeader: "X-Remote-User",
+	}
+	conn := callback{userHeader: config.UserHeader, logger: logger, pathSuffix: "/test"}
+
+	req, err := http.NewRequest("GET", "/", nil)
+	expectNil(t, err)
+	req.Header = map[string][]string{
+		"X-Remote-User": {testEmail},
+	}
+
+	ident, err := conn.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	expectNil(t, err)
+
+	expectEquals(t, ident.UserID, testEmail)
+	expectEquals(t, ident.Email, testEmail)
+	expectEquals(t, len(ident.Groups), 0)
+}
+
+func TestSingleGroup(t *testing.T) {
+	config := Config{
+		UserHeader:  "X-Remote-User",
+		GroupHeader: "X-Remote-Group",
+	}
+
+	conn := callback{userHeader: config.UserHeader, groupHeader: config.GroupHeader, logger: logger, pathSuffix: "/test"}
+
+	req, err := http.NewRequest("GET", "/", nil)
+	expectNil(t, err)
+	req.Header = map[string][]string{
+		"X-Remote-User":  {testEmail},
+		"X-Remote-Group": {testGroup1},
+	}
+
+	ident, err := conn.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	expectNil(t, err)
+
+	expectEquals(t, ident.UserID, testEmail)
+	expectEquals(t, len(ident.Groups), 1)
+	expectEquals(t, ident.Groups[0], testGroup1)
+}
+
+func TestMultipleGroup(t *testing.T) {
+	config := Config{
+		UserHeader:  "X-Remote-User",
+		GroupHeader: "X-Remote-Group",
+	}
+
+	conn := callback{userHeader: config.UserHeader, groupHeader: config.GroupHeader, logger: logger, pathSuffix: "/test"}
+
+	req, err := http.NewRequest("GET", "/", nil)
+	expectNil(t, err)
+	req.Header = map[string][]string{
+		"X-Remote-User":  {testEmail},
+		"X-Remote-Group": {testGroup1 + ", " + testGroup2},
+	}
+
+	ident, err := conn.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	expectNil(t, err)
+
+	expectEquals(t, ident.UserID, testEmail)
+	expectEquals(t, len(ident.Groups), 2)
+	expectEquals(t, ident.Groups[0], testGroup1)
+	expectEquals(t, ident.Groups[1], testGroup2)
+}
+
+func TestStaticGroup(t *testing.T) {
+	config := Config{
+		UserHeader:  "X-Remote-User",
+		GroupHeader: "X-Remote-Group",
+		Groups:      []string{"static1", "static2"},
+	}
+
+	conn := callback{userHeader: config.UserHeader, groupHeader: config.GroupHeader, groups: config.Groups, logger: logger, pathSuffix: "/test"}
+
+	req, err := http.NewRequest("GET", "/", nil)
+	expectNil(t, err)
+	req.Header = map[string][]string{
+		"X-Remote-User":  {testEmail},
+		"X-Remote-Group": {testGroup1 + ", " + testGroup2},
+	}
+
+	ident, err := conn.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	expectNil(t, err)
+
+	expectEquals(t, ident.UserID, testEmail)
+	expectEquals(t, len(ident.Groups), 4)
+	expectEquals(t, ident.Groups[0], testGroup1)
+	expectEquals(t, ident.Groups[1], testGroup2)
+	expectEquals(t, ident.Groups[2], testStaticGroup1)
+	expectEquals(t, ident.Groups[3], testStaticGroup2)
+}
+
+func expectNil(t *testing.T, a interface{}) {
+	if a != nil {
+		t.Errorf("Expected %+v to equal nil", a)
+	}
+}
+
+func expectEquals(t *testing.T, a interface{}, b interface{}) {
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("Expected %+v to equal %+v", a, b)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Added support to use multiple values for group header on authproxy connector.

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

If you use multiples values using comma-separated, the connector can't understand there are different groups.

#### Special notes for your reviewer
Definition to use comma-separated list [RFC2616 section 4.2](https://www.rfc-editor.org/rfc/rfc2616#section-4.2)
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```
NONE
```
