### PR TITLE
fix for issue 2670; check for no serviceAccountFilePath and no email

### DIFF
--- a/connector/google/google.go
+++ b/connector/google/google.go
@@ -71,10 +71,13 @@ func (c *Config) Open(id string, logger log.Logger) (conn connector.Connector, e
 		scopes = append(scopes, "profile", "email")
 	}
 
-	srv, err := createDirectoryService(c.ServiceAccountFilePath, c.AdminEmail, logger)
-	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("could not create directory service: %v", err)
+	var srv *admin.Service
+	if len(c.Groups) > 0 {
+		srv, err = createDirectoryService(c.ServiceAccountFilePath, c.AdminEmail, logger)
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("could not create directory service: %v", err)
+		}
 	}
 
 	clientID := c.ClientID
@@ -283,9 +286,6 @@ func (c *googleConnector) getGroups(email string, fetchTransitiveGroupMembership
 // the google admin api. If no serviceAccountFilePath is defined, the application default credential
 // is used. if no email or serviceAccountFilePath is specified, this quietly returns without error or directory service.
 func createDirectoryService(serviceAccountFilePath, email string, logger log.Logger) (*admin.Service, error) {
-	if serviceAccountFilePath == "" && email == "" {
-		return nil, nil
-	}
 	if email == "" {
 		return nil, fmt.Errorf("directory service requires adminEmail")
 	}

--- a/connector/google/google.go
+++ b/connector/google/google.go
@@ -284,7 +284,7 @@ func (c *googleConnector) getGroups(email string, fetchTransitiveGroupMembership
 
 // createDirectoryService sets up super user impersonation and creates an admin client for calling
 // the google admin api. If no serviceAccountFilePath is defined, the application default credential
-// is used. if no email or serviceAccountFilePath is specified, this quietly returns without error or directory service.
+// is used.
 func createDirectoryService(serviceAccountFilePath, email string, logger log.Logger) (*admin.Service, error) {
 	if email == "" {
 		return nil, fmt.Errorf("directory service requires adminEmail")

--- a/connector/google/google.go
+++ b/connector/google/google.go
@@ -281,8 +281,11 @@ func (c *googleConnector) getGroups(email string, fetchTransitiveGroupMembership
 
 // createDirectoryService sets up super user impersonation and creates an admin client for calling
 // the google admin api. If no serviceAccountFilePath is defined, the application default credential
-// is used.
+// is used. if no email or serviceAccountFilePath is specified, this quietly returns without error or directory service.
 func createDirectoryService(serviceAccountFilePath, email string, logger log.Logger) (*admin.Service, error) {
+	if serviceAccountFilePath == "" && email == "" {
+		return nil, nil
+	}
 	if email == "" {
 		return nil, fmt.Errorf("directory service requires adminEmail")
 	}

--- a/connector/google/google_test.go
+++ b/connector/google/google_test.go
@@ -72,12 +72,22 @@ func TestOpen(t *testing.T) {
 	assert.Nil(t, err)
 
 	for name, reference := range map[string]testCase{
+		"not_requesting_groups": {
+			config: &Config{
+				ClientID:     "testClient",
+				ClientSecret: "testSecret",
+				RedirectURI:  ts.URL + "/callback",
+				Scopes:       []string{"openid"},
+			},
+			expectedErr: "",
+		},
 		"missing_admin_email": {
 			config: &Config{
 				ClientID:     "testClient",
 				ClientSecret: "testSecret",
 				RedirectURI:  ts.URL + "/callback",
 				Scopes:       []string{"openid", "groups"},
+				Groups:       []string{"someGroup"},
 			},
 			expectedErr: "requires adminEmail",
 		},
@@ -89,6 +99,7 @@ func TestOpen(t *testing.T) {
 				Scopes:                 []string{"openid", "groups"},
 				AdminEmail:             "foo@bar.com",
 				ServiceAccountFilePath: "not_found.json",
+				Groups:                 []string{"someGroup"},
 			},
 			expectedErr: "error reading credentials",
 		},
@@ -100,6 +111,7 @@ func TestOpen(t *testing.T) {
 				Scopes:                 []string{"openid", "groups"},
 				AdminEmail:             "foo@bar.com",
 				ServiceAccountFilePath: serviceAccountFilePath,
+				Groups:                 []string{"someGroup"},
 			},
 			expectedErr: "",
 		},
@@ -110,6 +122,7 @@ func TestOpen(t *testing.T) {
 				RedirectURI:  ts.URL + "/callback",
 				Scopes:       []string{"openid", "groups"},
 				AdminEmail:   "foo@bar.com",
+				Groups:       []string{"someGroup"},
 			},
 			adc:         serviceAccountFilePath,
 			expectedErr: "",
@@ -122,6 +135,7 @@ func TestOpen(t *testing.T) {
 				Scopes:                 []string{"openid", "groups"},
 				AdminEmail:             "foo@bar.com",
 				ServiceAccountFilePath: serviceAccountFilePath,
+				Groups:                 []string{"someGroup"},
 			},
 			adc:         "/dev/null",
 			expectedErr: "",


### PR DESCRIPTION
#### Overview

This (hopefully) reverts a bug introduced in #2530 which does not handle the case where application default credentials nor a service account file (containing credentials) are needed to operate a Google connector.

#### What this PR does / why we need it

Fixes: #2670 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
NONE

```release-note
fixes regression for Google connector when used without groups
```
Signed-off-by: Bob Callaway <bcallaway@google.com>

@ichbinfrog 