### PR TITLE
Fix Google connector ADC implementation within GKE environments

### DIFF
--- a/connector/google/google_test.go
+++ b/connector/google/google_test.go
@@ -105,11 +105,12 @@ func TestOpen(t *testing.T) {
 		},
 		"adc": {
 			config: &Config{
-				ClientID:     "testClient",
-				ClientSecret: "testSecret",
-				RedirectURI:  ts.URL + "/callback",
-				Scopes:       []string{"openid", "groups"},
-				AdminEmail:   "foo@bar.com",
+				ClientID:        "testClient",
+				ClientSecret:    "testSecret",
+				RedirectURI:     ts.URL + "/callback",
+				Scopes:          []string{"openid", "groups"},
+				AdminEmail:      "foo@bar.com",
+				TargetPrincipal: "foo@prj-bar.iam.gserviceaccount.com",
 			},
 			adc:         serviceAccountFilePath,
 			expectedErr: "",
@@ -122,9 +123,21 @@ func TestOpen(t *testing.T) {
 				Scopes:                 []string{"openid", "groups"},
 				AdminEmail:             "foo@bar.com",
 				ServiceAccountFilePath: serviceAccountFilePath,
+				TargetPrincipal:        "foo@prj-bar.iam.gserviceaccount.com",
 			},
 			adc:         "/dev/null",
 			expectedErr: "",
+		},
+		"adc_no_target_principal": {
+			config: &Config{
+				ClientID:     "testClient",
+				ClientSecret: "testSecret",
+				RedirectURI:  ts.URL + "/callback",
+				Scopes:       []string{"openid", "groups"},
+				AdminEmail:   "foo@bar.com",
+			},
+			adc:         serviceAccountFilePath,
+			expectedErr: "targetPrincipal",
 		},
 	} {
 		reference := reference


### PR DESCRIPTION
#### Overview

Adapt the google connector for using application default credentials in GKE.

#### What this PR does / why we need it

Closes #2676

Upon further testing in a GKE cluster, this [line](https://github.com/dexidp/dex/blob/master/connector/google/google.go#L300) seems to return an empty JSON credential and therefore making ADC login fail. The default behavior for the [google.FindDefaultCredentials](https://pkg.go.dev/golang.org/x/oauth2/google#FindDefaultCredentials) function is the following:

> On Google Compute Engine, Google App Engine standard second generation runtimes (>= Go 1.11), and Google App Engine flexible environment, it fetches credentials from the metadata server.

The `credential.JSON` is empty in GKE environments, thus the error. In order to fetch the credentials (token) from the metadata server, the only method I found which worked did not return a `PERMISSION_DENIED` is to use the flow defined in the [impersonate package](https://pkg.go.dev/google.golang.org/api/impersonate):

- The base Application Default Credentials is used (SA1)
- That service account (SA1) is then used to impersonate the service account designated by the targetPrincipal field (SA2)
- SA2's token source is then used to impersonate the Google Workspace super user designated by adminEmail

TBH, I'm not sure if this is the canonical way of doing it and I've raised a question here https://github.com/googleapis/google-api-go-client/issues/1698.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```
