### PR TITLE
supply HMACKey in test case

### DIFF
--- a/storage/conformance/transactions.go
+++ b/storage/conformance/transactions.go
@@ -75,6 +75,7 @@ func testAuthRequestConcurrentUpdate(t *testing.T, s storage.Storage) {
 			EmailVerified: true,
 			Groups:        []string{"a", "b"},
 		},
+		HMACKey: []byte("hmac_key"),
 	}
 
 	if err := s.CreateAuthRequest(a); err != nil {


### PR DESCRIPTION
commit 49471b14c8080ddb034d4855841123d378b7a634 has a failing test case due to the lack of specification of an HMACKey

https://github.com/dexidp/dex/actions/runs/3144248007/jobs/5110000846

Signed-off-by: Bob Callaway <bcallaway@google.com>