### PR TITLE
Backport Go update to v2.35.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=alpine
 
-FROM golang:1.19.1-alpine3.16 AS builder
+FROM golang:1.19.2-alpine3.16 AS builder
 
 WORKDIR /usr/local/src/dex
 


### PR DESCRIPTION
#### Overview

Backport Go update to v2.35.x

