### PR TITLE
Backport #2705 to v2.35.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
 
-ENV GOMPLATE_VERSION=v3.11.2
+ENV GOMPLATE_VERSION=v3.11.3
 
 RUN wget -O /usr/local/bin/gomplate \
     "https://github.com/hairyhenderson/gomplate/releases/download/${GOMPLATE_VERSION}/gomplate_${TARGETOS:-linux}-${TARGETARCH:-amd64}${TARGETVARIANT}" \


### PR DESCRIPTION
### Overview
Backport https://github.com/dexidp/dex/pull/2705 to v2.35.x