### PR TITLE
fix: Do not use connector data from the refresh token field

### DIFF
--- a/server/refreshhandlers.go
+++ b/server/refreshhandlers.go
@@ -186,6 +186,8 @@ func (s *Server) refreshWithConnector(ctx context.Context, rCtx *refreshContext,
 	// TODO(ericchiang): We may want a strict mode where connectors that don't implement
 	// this interface can't perform refreshing.
 	if refreshConn, ok := rCtx.connector.Connector.(connector.RefreshConnector); ok {
+		// Set connector data to the one received from an offline session
+		ident.ConnectorData = rCtx.connectorData
 		s.logger.Debugf("connector data before refresh: %s", ident.ConnectorData)
 
 		newIdent, err := refreshConn.Refresh(ctx, parseScopes(rCtx.scopes), ident)
@@ -245,7 +247,6 @@ func (s *Server) updateRefreshToken(ctx context.Context, rCtx *refreshContext) (
 		Email:             rCtx.storageToken.Claims.Email,
 		EmailVerified:     rCtx.storageToken.Claims.EmailVerified,
 		Groups:            rCtx.storageToken.Claims.Groups,
-		ConnectorData:     rCtx.connectorData,
 	}
 
 	refreshTokenUpdater := func(old storage.RefreshToken) (storage.RefreshToken, error) {
@@ -255,6 +256,7 @@ func (s *Server) updateRefreshToken(ctx context.Context, rCtx *refreshContext) (
 		switch {
 		case !rotationEnabled && reusingAllowed:
 			// If rotation is disabled and the offline session was updated not so long ago - skip further actions.
+			old.ConnectorData = nil
 			return old, nil
 
 		case rotationEnabled && reusingAllowed:
@@ -269,7 +271,7 @@ func (s *Server) updateRefreshToken(ctx context.Context, rCtx *refreshContext) (
 
 			// Do not update last used time for offline session if token is allowed to be reused
 			lastUsed = old.LastUsed
-			ident.ConnectorData = nil
+			old.ConnectorData = nil
 			return old, nil
 
 		case rotationEnabled && !reusingAllowed:
@@ -286,7 +288,7 @@ func (s *Server) updateRefreshToken(ctx context.Context, rCtx *refreshContext) (
 		old.LastUsed = lastUsed
 
 		// ConnectorData has been moved to OfflineSession
-		old.ConnectorData = []byte{}
+		old.ConnectorData = nil
 
 		// Call  only once if there is a request which is not in the reuse interval.
 		// This is required to avoid multiple calls to the external IdP for concurrent requests.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -871,6 +871,17 @@ func TestOAuth2CodeFlow(t *testing.T) {
 			if respDump, err = httputil.DumpResponse(resp, true); err != nil {
 				t.Fatal(err)
 			}
+
+			tokens, err := s.storage.ListRefreshTokens()
+			if err != nil {
+				t.Fatalf("failed to get existed refresh token: %v", err)
+			}
+
+			for _, token := range tokens {
+				if /* token was updated */ token.ObsoleteToken != "" && token.ConnectorData != nil {
+					t.Fatalf("token connectorDatawith id %q field is not nil: %s", token.ID, token.ConnectorData)
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### What this PR does / why we need it

There is a possibility that connector data will be saved to refresh token, which can lead to refresh tokens invalidation.


#### Special notes for your reviewer

The flow of connectorData is too complicated. I opened an issue to think about it in the future.
See https://github.com/dexidp/dex/issues/2728

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Do not use connector data from the refresh token field.
```
