### PR TITLE
Add preferredEmailDomain config option for GitHub connector

### DIFF
--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -615,7 +615,7 @@ func (c *githubConnector) userEmail(ctx context.Context, client *http.Client) (s
 		return preferredEmails[0].Email, nil
 	}
 
-	if (primaryEmail != userEmail{}) {
+	if (primaryEmail.Email != "") {
 		return primaryEmail.Email, nil
 	}
 

--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -117,6 +117,12 @@ func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error)
 		return nil, fmt.Errorf("invalid connector config: unsupported team name field value `%s`", c.TeamNameField)
 	}
 
+	if c.PreferredEmailDomain != "" {
+		if strings.HasSuffix(c.PreferredEmailDomain, "*") {
+			return nil, errors.New("invalid PreferredEmailDomain: glob pattern cannot end with \"*\"")
+		}
+	}
+
 	return &g, nil
 }
 

--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -600,7 +600,7 @@ func (c *githubConnector) userEmail(ctx context.Context, client *http.Client) (s
 				if !ok {
 					return "", errors.New("github: invalid format email is detected")
 				}
-				if email.Verified && preferredEmailDomainRegexp.Match([]byte(domainPart)) {
+				if email.Verified && preferredEmailDomainRegexp.MatchString(domainPart) {
 					preferredEmails = append(preferredEmails, email)
 				}
 			}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->
This PR is a revamped version of https://github.com/dexidp/dex/pull/1298.
It allows identifying users by verified company email without marking it as primary.

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

This PR adds new `preferredEmailDomain` config option for GitHub connector.
If set, an email address with the specified domain takes precedence over the primary email.

When a user is logged into a service that uses Dex, such as ArgoCD, via GitHub, the user is identified by the account's primary email address.

However, in a company, we have the following needs:
* Identify employees by their company domain email address
* Allow employees to use their own(not-for-only-work) GitHub account

To satisfy these, we need an option that can return a specific domain email address as the user's email address.

#### Special notes for your reviewer

N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Add new `preferredEmailDomain` config option for GitHub connector.
```
