### PR TITLE
fix: propagate http client to userInfo requests for OIDC connector

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -260,7 +260,7 @@ func (c *oidcConnector) HandleCallback(s connector.Scopes, r *http.Request) (ide
 	if err != nil {
 		return identity, fmt.Errorf("oidc: failed to get token: %v", err)
 	}
-	return c.createIdentity(r.Context(), identity, token, createCaller)
+	return c.createIdentity(ctx, identity, token, createCaller)
 }
 
 // Refresh is used to refresh a session with the refresh token provided by the IdP
@@ -270,6 +270,8 @@ func (c *oidcConnector) Refresh(ctx context.Context, s connector.Scopes, identit
 	if err != nil {
 		return identity, fmt.Errorf("oidc: failed to unmarshal connector data: %v", err)
 	}
+
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, c.httpClient)
 
 	t := &oauth2.Token{
 		RefreshToken: string(cd.RefreshToken),


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

#### Overview

Fix for an error (it occurs when the `getUserInfo` is set to true and a custom ca is used)

![image](https://user-images.githubusercontent.com/32434187/211685542-87cfdab9-c2f0-4c07-b4cd-2aeea40b4af9.png)

#### What this PR does / why we need it

A fix for https://github.com/dexidp/dex/pull/1632

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

This is a fix for the feature that is not released.
```release-note
NONE
```
