### PR TITLE
chore: Upgrade golangci-lint to v1.50.1 from v1.46.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,6 @@ linters:
     disable-all: true
     enable:
         - bodyclose
-        - deadcode
         - depguard
         - dogsled
         - exhaustive
@@ -42,13 +41,11 @@ linters:
         - rowserrcheck
         - sqlclosecheck
         - staticcheck
-        - structcheck
         - stylecheck
         - tparallel
         - unconvert
         - unparam
         - unused
-        - varcheck
         - whitespace
 
         # Disable temporarily until everything works with Go 1.18

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,7 +49,7 @@ linters:
         - whitespace
 
         # Disable temporarily until everything works with Go 1.18
-        # - typecheck
+        - typecheck
 
         # TODO: fix linter errors before enabling
         # - exhaustivestruct

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ proto-internal:
 	@protoc --go_out=paths=source_relative:. server/internal/*.proto
 
 # Dependency versions
-GOLANGCI_VERSION = 1.46.0
+GOLANGCI_VERSION = 1.50.1
 GOTESTSUM_VERSION ?= 1.7.0
 PROTOC_VERSION = 3.15.6
 PROTOC_GEN_GO_VERSION = 1.26.0

--- a/connector/atlassiancrowd/atlassiancrowd.go
+++ b/connector/atlassiancrowd/atlassiancrowd.go
@@ -24,18 +24,17 @@ import (
 //
 // An example config:
 //
-//     type: atlassian-crowd
-//     config:
-//       baseURL: https://crowd.example.com/context
-//       clientID: applogin
-//       clientSecret: appP4$$w0rd
-//       # users can be restricted by a list of groups
-//       groups:
-//       - admin
-//       # Prompt for username field
-//       usernamePrompt: Login
-//		 preferredUsernameField: name
-//
+//	    type: atlassian-crowd
+//	    config:
+//	      baseURL: https://crowd.example.com/context
+//	      clientID: applogin
+//	      clientSecret: appP4$$w0rd
+//	      # users can be restricted by a list of groups
+//	      groups:
+//	      - admin
+//	      # Prompt for username field
+//	      usernamePrompt: Login
+//			 preferredUsernameField: name
 type Config struct {
 	BaseURL      string   `json:"baseURL"`
 	ClientID     string   `json:"clientID"`

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -70,7 +70,8 @@ type CallbackConnector interface {
 }
 
 // SAMLConnector represents SAML connectors which implement the HTTP POST binding.
-//  RelayState is handled by the server.
+//
+//	RelayState is handled by the server.
 //
 // See: https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf
 // "3.5 HTTP POST Binding"

--- a/connector/google/google_test.go
+++ b/connector/google/google_test.go
@@ -46,7 +46,7 @@ func testSetup() *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
-func newConnector(config *Config, serverURL string) (*googleConnector, error) {
+func newConnector(config *Config) (*googleConnector, error) {
 	log := logrus.New()
 	conn, err := config.Open("id", log)
 	if err != nil {
@@ -155,7 +155,7 @@ func TestOpen(t *testing.T) {
 			assert := assert.New(t)
 
 			os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", reference.adc)
-			conn, err := newConnector(reference.config, ts.URL)
+			conn, err := newConnector(reference.config)
 
 			if reference.expectedErr == "" {
 				assert.Nil(err)
@@ -181,7 +181,7 @@ func TestGetGroups(t *testing.T) {
 		RedirectURI:  ts.URL + "/callback",
 		Scopes:       []string{"openid", "groups"},
 		AdminEmail:   "admin@dexidp.com",
-	}, ts.URL)
+	})
 	assert.Nil(t, err)
 
 	conn.adminSrv, err = admin.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(ts.URL))

--- a/connector/google/google_test.go
+++ b/connector/google/google_test.go
@@ -31,7 +31,7 @@ var (
 	callCounter = make(map[string]int)
 )
 
-func testSetup(t *testing.T) *httptest.Server {
+func testSetup() *httptest.Server {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/admin/directory/v1/groups/", func(w http.ResponseWriter, r *http.Request) {
@@ -78,7 +78,7 @@ func tempServiceAccountKey() (string, error) {
 }
 
 func TestOpen(t *testing.T) {
-	ts := testSetup(t)
+	ts := testSetup()
 	defer ts.Close()
 
 	type testCase struct {
@@ -168,7 +168,7 @@ func TestOpen(t *testing.T) {
 }
 
 func TestGetGroups(t *testing.T) {
-	ts := testSetup(t)
+	ts := testSetup()
 	defer ts.Close()
 
 	serviceAccountFilePath, err := tempServiceAccountKey()

--- a/connector/microsoft/microsoft.go
+++ b/connector/microsoft/microsoft.go
@@ -316,22 +316,27 @@ func (c *microsoftConnector) Refresh(ctx context.Context, s connector.Scopes, id
 
 // https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/user
 // id                - The unique identifier for the user. Inherited from
-//                     directoryObject. Key. Not nullable. Read-only.
+//
+//	directoryObject. Key. Not nullable. Read-only.
+//
 // displayName       - The name displayed in the address book for the user.
-//                     This is usually the combination of the user's first name,
-//                     middle initial and last name. This property is required
-//                     when a user is created and it cannot be cleared during
-//                     updates. Supports $filter and $orderby.
+//
+//	This is usually the combination of the user's first name,
+//	middle initial and last name. This property is required
+//	when a user is created and it cannot be cleared during
+//	updates. Supports $filter and $orderby.
+//
 // userPrincipalName - The user principal name (UPN) of the user.
-//                     The UPN is an Internet-style login name for the user
-//                     based on the Internet standard RFC 822. By convention,
-//                     this should map to the user's email name. The general
-//                     format is alias@domain, where domain must be present in
-//                     the tenant’s collection of verified domains. This
-//                     property is required when a user is created. The
-//                     verified domains for the tenant can be accessed from the
-//                     verifiedDomains property of organization. Supports
-//                     $filter and $orderby.
+//
+//	The UPN is an Internet-style login name for the user
+//	based on the Internet standard RFC 822. By convention,
+//	this should map to the user's email name. The general
+//	format is alias@domain, where domain must be present in
+//	the tenant’s collection of verified domains. This
+//	property is required when a user is created. The
+//	verified domains for the tenant can be accessed from the
+//	verifiedDomains property of organization. Supports
+//	$filter and $orderby.
 type user struct {
 	ID    string `json:"id"`
 	Name  string `json:"displayName"`
@@ -364,8 +369,9 @@ func (c *microsoftConnector) user(ctx context.Context, client *http.Client) (u u
 
 // https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/group
 // displayName - The display name for the group. This property is required when
-//               a group is created and it cannot be cleared during updates.
-//               Supports $filter and $orderby.
+//
+//	a group is created and it cannot be cleared during updates.
+//	Supports $filter and $orderby.
 type group struct {
 	Name string `json:"displayName"`
 }

--- a/connector/saml/saml.go
+++ b/connector/saml/saml.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dexidp/dex/pkg/log"
 )
 
-// nolint
+//nolint
 const (
 	bindingRedirect = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
 	bindingPOST     = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
@@ -292,7 +292,6 @@ func (p *provider) POSTData(s connector.Scopes, id string) (action, value string
 // * Verify signature on XML document (or verify sig on assertion elements).
 // * Verify various parts of the Assertion element. Conditions, audience, etc.
 // * Map the Assertion's attribute elements to user info.
-//
 func (p *provider) HandlePOST(s connector.Scopes, samlResponse, inResponseTo string) (ident connector.Identity, err error) {
 	rawResp, err := base64.StdEncoding.DecodeString(samlResponse)
 	if err != nil {

--- a/connector/saml/saml_test.go
+++ b/connector/saml/saml_test.go
@@ -24,19 +24,18 @@ import (
 // To add a new test, define a new, unsigned SAML 2.0 response that exercises some
 // case, then sign it using the "testdata/gen.sh" script.
 //
-//     cp testdata/good-resp.tmpl testdata/( testname ).tmpl
-//     vim ( testname ).tmpl # Modify your template for your test case.
-//     vim testdata/gen.sh   # Add a xmlsec1 command to the generation script.
-//     ./testdata/gen.sh     # Sign your template.
+//	cp testdata/good-resp.tmpl testdata/( testname ).tmpl
+//	vim ( testname ).tmpl # Modify your template for your test case.
+//	vim testdata/gen.sh   # Add a xmlsec1 command to the generation script.
+//	./testdata/gen.sh     # Sign your template.
 //
 // To install xmlsec1 on Fedora run:
 //
-//     sudo dnf install xmlsec1 xmlsec1-openssl
+//	sudo dnf install xmlsec1 xmlsec1-openssl
 //
 // On mac:
 //
-//     brew install Libxmlsec1
-//
+//	brew install Libxmlsec1
 type responseTest struct {
 	// CA file and XML file of the response.
 	caFile   string

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -93,7 +93,7 @@ func tokenErr(w http.ResponseWriter, typ, description string, statusCode int) er
 	return nil
 }
 
-// nolint
+//nolint
 const (
 	errInvalidRequest          = "invalid_request"
 	errUnauthorizedClient      = "unauthorized_client"
@@ -211,9 +211,9 @@ func signPayload(key *jose.JSONWebKey, alg jose.SignatureAlgorithm, payload []by
 // The hash algorithm for the at_hash is determined by the signing
 // algorithm used for the id_token. From the spec:
 //
-//    ...the hash algorithm used is the hash algorithm used in the alg Header
-//    Parameter of the ID Token's JOSE Header. For instance, if the alg is RS256,
-//    hash the access_token value with SHA-256
+//	...the hash algorithm used is the hash algorithm used in the alg Header
+//	Parameter of the ID Token's JOSE Header. For instance, if the alg is RS256,
+//	hash the access_token value with SHA-256
 //
 // https://openid.net/specs/openid-connect-core-1_0.html#ImplicitIDToken
 var hashForSigAlg = map[jose.SignatureAlgorithm]func() hash.Hash{

--- a/server/templates.go
+++ b/server/templates.go
@@ -83,12 +83,11 @@ func getFuncMap(c webConfig) (template.FuncMap, error) {
 //
 // The directory layout is expected to be:
 //
-//    ( web directory )
-//    |- static
-//    |- themes
-//    |  |- (theme name)
-//    |- templates
-//
+//	( web directory )
+//	|- static
+//	|- themes
+//	|  |- (theme name)
+//	|- templates
 func loadWebConfig(c webConfig) (http.Handler, http.Handler, *templates, error) {
 	// fallback to the default theme if the legacy theme name is provided
 	if c.theme == "coreos" || c.theme == "tectonic" {

--- a/storage/ent/postgres.go
+++ b/storage/ent/postgres.go
@@ -20,7 +20,7 @@ import (
 	"github.com/dexidp/dex/storage/ent/db"
 )
 
-// nolint
+//nolint
 const (
 	// postgres SSL modes
 	pgSSLDisable    = "disable"

--- a/storage/kubernetes/client.go
+++ b/storage/kubernetes/client.go
@@ -211,7 +211,7 @@ func (cli *client) getResource(apiVersion, namespace, resource, name string, v i
 	return cli.getURL(u, v)
 }
 
-func (cli *client) listN(resource string, v interface{}, n int) error {
+func (cli *client) listN(resource string, v interface{}, n int) error { //nolint:unparam // In practice, n is the gcResultLimit constant.
 	params := url.Values{}
 	params.Add("limit", fmt.Sprintf("%d", n))
 	u, err := cli.urlForWithParams(cli.apiVersion, cli.namespace, resource, "", params)

--- a/storage/kubernetes/lock.go
+++ b/storage/kubernetes/lock.go
@@ -19,9 +19,9 @@ var (
 //
 // Refresh token contains data to refresh identity in external authentication system.
 // There is a requirement that refresh should be called only once because of several reasons:
-// * Some of OIDC providers could use the refresh token rotation feature which requires calling refresh only once.
-// * Providers can limit the rate of requests to the token endpoint, which will lead to the error
-//   in case of many concurrent requests.
+//   - Some of OIDC providers could use the refresh token rotation feature which requires calling refresh only once.
+//   - Providers can limit the rate of requests to the token endpoint, which will lead to the error
+//     in case of many concurrent requests.
 type refreshTokenLock struct {
 	cli          *client
 	waitingState bool

--- a/storage/kubernetes/transport.go
+++ b/storage/kubernetes/transport.go
@@ -62,15 +62,17 @@ func wrapRoundTripper(base http.RoundTripper, user k8sapi.AuthInfo, inCluster bo
 }
 
 // renewTokenPeriod is the interval after which dex will read the token from a well-known file.
-//   By Kubernetes documentation, this interval should be at least one minute long.
-//   Kubernetes client-go v0.15+ uses 10 seconds long interval.
-//   Dex uses the reasonable value between these two.
+//
+//	By Kubernetes documentation, this interval should be at least one minute long.
+//	Kubernetes client-go v0.15+ uses 10 seconds long interval.
+//	Dex uses the reasonable value between these two.
 const renewTokenPeriod = 30 * time.Second
 
 // inClusterTransportHelper is capable of safely updating the user token.
-//   BoundServiceAccountTokenVolume feature is enabled in Kubernetes >=1.21 by default.
-//   With this feature, the service account token in the pod becomes periodically updated.
-//   Therefore, Dex needs to re-read the token from the disk after some time to be sure that it uses the valid token.
+//
+//	BoundServiceAccountTokenVolume feature is enabled in Kubernetes >=1.21 by default.
+//	With this feature, the service account token in the pod becomes periodically updated.
+//	Therefore, Dex needs to re-read the token from the disk after some time to be sure that it uses the valid token.
 type inClusterTransportHelper struct {
 	mu   sync.RWMutex
 	info k8sapi.AuthInfo

--- a/storage/sql/config.go
+++ b/storage/sql/config.go
@@ -31,7 +31,7 @@ const (
 	mysqlErrUnknownSysVar       = 1193
 )
 
-// nolint
+//nolint
 const (
 	// postgres SSL modes
 	pgSSLDisable    = "disable"
@@ -40,7 +40,7 @@ const (
 	pgSSLVerifyFull = "verify-full"
 )
 
-// nolint
+//nolint
 const (
 	// MySQL SSL modes
 	mysqlSSLTrue       = "true"

--- a/storage/sql/crud.go
+++ b/storage/sql/crud.go
@@ -21,19 +21,18 @@ const keysRowID = "keys"
 // encoder wraps the underlying value in a JSON marshaler which is automatically
 // called by the database/sql package.
 //
-//		s := []string{"planes", "bears"}
-//		err := db.Exec(`insert into t1 (id, things) values (1, $1)`, encoder(s))
-//		if err != nil {
-//			// handle error
-//		}
+//	s := []string{"planes", "bears"}
+//	err := db.Exec(`insert into t1 (id, things) values (1, $1)`, encoder(s))
+//	if err != nil {
+//		// handle error
+//	}
 //
-//		var r []byte
-//		err = db.QueryRow(`select things from t1 where id = 1;`).Scan(&r)
-//		if err != nil {
-//			// handle error
-//		}
-//		fmt.Printf("%s\n", r) // ["planes","bears"]
-//
+//	var r []byte
+//	err = db.QueryRow(`select things from t1 where id = 1;`).Scan(&r)
+//	if err != nil {
+//		// handle error
+//	}
+//	fmt.Printf("%s\n", r) // ["planes","bears"]
 func encoder(i interface{}) driver.Valuer {
 	return jsonEncoder{i}
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -144,8 +144,8 @@ type Storage interface {
 // Client represents an OAuth2 client.
 //
 // For further reading see:
-//   * Trusted peers: https://developers.google.com/identity/protocols/CrossClientAuth
-//   * Public clients: https://developers.google.com/api-client-library/python/auth/installed-app
+//   - Trusted peers: https://developers.google.com/identity/protocols/CrossClientAuth
+//   - Public clients: https://developers.google.com/api-client-library/python/auth/installed-app
 type Client struct {
 	// Client ID and secret used to identify the client.
 	ID        string `json:"id" yaml:"id"`


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Updates the version of golangci-lint defined in the Makefile.

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

Versions prior to v1.48.0 are incompatible with go v1.19, which is in use since d33e9948059abe45257cc6b734870b2c4f3c4ea5.

Linting fails:

```console
❯ go version
go version go1.19.2 linux/amd64

❯ make bin/golangci-lint
curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | BINARY=golangci-lint bash -s -- v1.46.0
golangci/golangci-lint info checking GitHub for tag 'v1.46.0'
golangci/golangci-lint info found version: 1.46.0 for v1.46.0/linux/amd64
bgolangci/golangci-lint info installed ./bin/golangci-lint

❯ bin/golangci-lint run
panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt

goroutine 1 [running]:
github.com/go-critic/go-critic/checkers.init.22()
	github.com/go-critic/go-critic@v0.6.3/checkers/embedded_rules.go:47 +0x4b4
```

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
