### PR TITLE
fix: return 401 if password is invalid

### DIFF
--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -280,33 +280,46 @@ func TestPasswordConnectorDataNotEmpty(t *testing.T) {
 
 	mockConnectorDataTestStorage(t, s.storage)
 
-	u, err := url.Parse(s.issuerURL.String())
-	require.NoError(t, err)
+	makeReq := func(username, password string) *httptest.ResponseRecorder {
+		u, err := url.Parse(s.issuerURL.String())
+		require.NoError(t, err)
 
-	u.Path = path.Join(u.Path, "/token")
-	v := url.Values{}
-	v.Add("scope", "openid offline_access email")
-	v.Add("grant_type", "password")
-	v.Add("username", "test")
-	v.Add("password", "test")
+		u.Path = path.Join(u.Path, "/token")
+		v := url.Values{}
+		v.Add("scope", "openid offline_access email")
+		v.Add("grant_type", "password")
+		v.Add("username", username)
+		v.Add("password", password)
 
-	req, _ := http.NewRequest("POST", u.String(), bytes.NewBufferString(v.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; param=value")
-	req.SetBasicAuth("test", "barfoo")
+		req, _ := http.NewRequest("POST", u.String(), bytes.NewBufferString(v.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded; param=value")
+		req.SetBasicAuth("test", "barfoo")
 
-	rr := httptest.NewRecorder()
-	s.ServeHTTP(rr, req)
+		rr := httptest.NewRecorder()
+		s.ServeHTTP(rr, req)
 
-	require.Equal(t, 200, rr.Code)
+		return rr
+	}
+
+	// Check unauthorized error
+	{
+		rr := makeReq("test", "invalid")
+		require.Equal(t, 401, rr.Code)
+	}
 
 	// Check that we received expected refresh token
-	var ref struct {
-		Token string `json:"refresh_token"`
-	}
-	err = json.Unmarshal(rr.Body.Bytes(), &ref)
-	require.NoError(t, err)
+	{
+		rr := makeReq("test", "test")
+		require.Equal(t, 200, rr.Code)
 
-	newSess, err := s.storage.GetOfflineSessions("0-385-28089-0", "test")
-	require.NoError(t, err)
-	require.Equal(t, `{"test": "true"}`, string(newSess.ConnectorData))
+		var ref struct {
+			Token string `json:"refresh_token"`
+		}
+		err := json.Unmarshal(rr.Body.Bytes(), &ref)
+		require.NoError(t, err)
+
+		newSess, err := s.storage.GetOfflineSessions("0-385-28089-0", "test")
+		require.NoError(t, err)
+		require.Equal(t, `{"test": "true"}`, string(newSess.ConnectorData))
+	}
 }

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -265,7 +265,7 @@ func mockConnectorDataTestStorage(t *testing.T, s storage.Storage) {
 	require.NoError(t, err)
 }
 
-func TestPasswordConnectorDataNotEmpty(t *testing.T) {
+func TestHandlePassword(t *testing.T) {
 	t0 := time.Now()
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/server/templates.go
+++ b/server/templates.go
@@ -286,6 +286,9 @@ func (t *templates) login(r *http.Request, w http.ResponseWriter, connectors []c
 }
 
 func (t *templates) password(r *http.Request, w http.ResponseWriter, postURL, lastUsername, usernamePrompt string, lastWasInvalid bool, backLink string) error {
+	if lastWasInvalid {
+		w.WriteHeader(http.StatusUnauthorized)
+	}
 	data := struct {
 		PostURL        string
 		BackLink       string


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### What this PR does / why we need it

This will help to distinguish errors and successful requests.

#### Special notes for your reviewer

Context https://github.com/dexidp/dex/pull/2454#issuecomment-1080514456

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Requests with invalid passwords are responded to with the 401 error code.
```
