### PR TITLE
fix: exit serve with cascaded errors

### DIFF
--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -57,7 +57,7 @@ func commandServe() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			cmd.SilenceErrors = true
+			cmd.SilenceErrors = false
 
 			options.config = args[0]
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->
Cascade `runServe` errors to cobra CLI and exit 1.

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
When running in Kubernetes, we encountered `failed to initialize server: server: Failed to open connector google: failed to open connector: failed to create connector google: failed to get provider: Get "https://accounts.google.com/.well-known/openid-configuration": dial tcp: lookup accounts.google.com: i/o timeout` that did not triggered a restart. As there is no retry mecanism, IMHO, the dex server should exit so kubernetes (systemd/you name it) can restart it. 

#### Special notes for your reviewer

I believe this was changed by https://github.com/dexidp/dex/pull/1921

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
fix: exit serve with cascaded errors
```
