### PR TITLE
Add support for extra claims to authproxy connector

### DIFF
--- a/connector/authproxy/authproxy.go
+++ b/connector/authproxy/authproxy.go
@@ -106,7 +106,6 @@ func (m *callback) HandleCallback(s connector.Scopes, r *http.Request) (connecto
 	}
 	return connector.Identity{
 		UserID:            remoteUserId,
-		Username:          remoteUser,
 		PreferredUsername: remoteUser,
 		Email:             remoteUserEmail,
 		EmailVerified:     true,

--- a/connector/authproxy/authproxy.go
+++ b/connector/authproxy/authproxy.go
@@ -19,7 +19,7 @@ import (
 // Headers retrieved to fetch user's email and group can be configured
 // with userHeader and groupHeader.
 type Config struct {
-	UserIdHeader string   `json:"userIdHeader"`
+	UserIDHeader string   `json:"userIDHeader"`
 	UserHeader   string   `json:"userHeader"`
 	EmailHeader  string   `json:"emailHeader"`
 	GroupHeader  string   `json:"groupHeader"`
@@ -28,9 +28,9 @@ type Config struct {
 
 // Open returns an authentication strategy which requires no user interaction.
 func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error) {
-	userIdHeader := c.UserIdHeader
-	if userIdHeader == "" {
-		userIdHeader = "X-Remote-User-Id"
+	userIDHeader := c.UserIDHeader
+	if userIDHeader == "" {
+		userIDHeader = "X-Remote-User-Id"
 	}
 	userHeader := c.UserHeader
 	if userHeader == "" {
@@ -46,7 +46,7 @@ func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error)
 	}
 
 	return &callback{
-		userIdHeader: userIdHeader,
+		userIDHeader: userIDHeader,
 		userHeader:   userHeader,
 		emailHeader:  emailHeader,
 		groupHeader:  groupHeader,
@@ -59,7 +59,7 @@ func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error)
 // Callback is a connector which returns an identity with the HTTP header
 // X-Remote-User as verified email.
 type callback struct {
-	userIdHeader string
+	userIDHeader string
 	userHeader   string
 	emailHeader  string
 	groupHeader  string
@@ -87,9 +87,9 @@ func (m *callback) HandleCallback(s connector.Scopes, r *http.Request) (connecto
 	if remoteUser == "" {
 		return connector.Identity{}, fmt.Errorf("required HTTP header %s is not set", m.userHeader)
 	}
-	remoteUserId := r.Header.Get(m.userIdHeader)
-	if remoteUserId == "" {
-		remoteUserId = remoteUser
+	remoteUserID := r.Header.Get(m.userIDHeader)
+	if remoteUserID == "" {
+		remoteUserID = remoteUser
 	}
 	remoteUserEmail := r.Header.Get(m.emailHeader)
 	if remoteUserEmail == "" {
@@ -105,7 +105,7 @@ func (m *callback) HandleCallback(s connector.Scopes, r *http.Request) (connecto
 		groups = append(splitheaderGroup, groups...)
 	}
 	return connector.Identity{
-		UserID:            remoteUserId,
+		UserID:            remoteUserID,
 		PreferredUsername: remoteUser,
 		Email:             remoteUserEmail,
 		EmailVerified:     true,

--- a/connector/authproxy/authproxy.go
+++ b/connector/authproxy/authproxy.go
@@ -19,33 +19,53 @@ import (
 // Headers retrieved to fetch user's email and group can be configured
 // with userHeader and groupHeader.
 type Config struct {
-	UserHeader  string   `json:"userHeader"`
-	GroupHeader string   `json:"groupHeader"`
-	Groups      []string `json:"staticGroups"`
+	UserIdHeader string   `json:"userIdHeader"`
+	UserHeader   string   `json:"userHeader"`
+	EmailHeader  string   `json:"emailHeader"`
+	GroupHeader  string   `json:"groupHeader"`
+	Groups       []string `json:"staticGroups"`
 }
 
 // Open returns an authentication strategy which requires no user interaction.
 func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error) {
+	userIdHeader := c.UserIdHeader
+	if userIdHeader == "" {
+		userIdHeader = "X-Remote-User-Id"
+	}
 	userHeader := c.UserHeader
 	if userHeader == "" {
 		userHeader = "X-Remote-User"
+	}
+	emailHeader := c.EmailHeader
+	if emailHeader == "" {
+		emailHeader = "X-Remote-User-Email"
 	}
 	groupHeader := c.GroupHeader
 	if groupHeader == "" {
 		groupHeader = "X-Remote-Group"
 	}
 
-	return &callback{userHeader: userHeader, groupHeader: groupHeader, logger: logger, pathSuffix: "/" + id, groups: c.Groups}, nil
+	return &callback{
+		userIdHeader: userIdHeader,
+		userHeader:   userHeader,
+		emailHeader:  emailHeader,
+		groupHeader:  groupHeader,
+		groups:       c.Groups,
+		logger:       logger,
+		pathSuffix:   "/" + id,
+	}, nil
 }
 
 // Callback is a connector which returns an identity with the HTTP header
 // X-Remote-User as verified email.
 type callback struct {
-	userHeader  string
-	groupHeader string
-	groups      []string
-	logger      log.Logger
-	pathSuffix  string
+	userIdHeader string
+	userHeader   string
+	emailHeader  string
+	groupHeader  string
+	groups       []string
+	logger       log.Logger
+	pathSuffix   string
 }
 
 // LoginURL returns the URL to redirect the user to login with.
@@ -67,6 +87,14 @@ func (m *callback) HandleCallback(s connector.Scopes, r *http.Request) (connecto
 	if remoteUser == "" {
 		return connector.Identity{}, fmt.Errorf("required HTTP header %s is not set", m.userHeader)
 	}
+	remoteUserId := r.Header.Get(m.userIdHeader)
+	if remoteUserId == "" {
+		remoteUserId = remoteUser
+	}
+	remoteUserEmail := r.Header.Get(m.emailHeader)
+	if remoteUserEmail == "" {
+		remoteUserEmail = remoteUser
+	}
 	groups := m.groups
 	headerGroup := r.Header.Get(m.groupHeader)
 	if headerGroup != "" {
@@ -77,9 +105,11 @@ func (m *callback) HandleCallback(s connector.Scopes, r *http.Request) (connecto
 		groups = append(splitheaderGroup, groups...)
 	}
 	return connector.Identity{
-		UserID:        remoteUser, // TODO: figure out if this is a bad ID value.
-		Email:         remoteUser,
-		EmailVerified: true,
-		Groups:        groups,
+		UserID:            remoteUserId,
+		Username:          remoteUser,
+		PreferredUsername: remoteUser,
+		Email:             remoteUserEmail,
+		EmailVerified:     true,
+		Groups:            groups,
 	}, nil
 }

--- a/connector/authproxy/authproxy_test.go
+++ b/connector/authproxy/authproxy_test.go
@@ -19,6 +19,8 @@ const (
 	testGroup4       = "group 4"
 	testStaticGroup1 = "static1"
 	testStaticGroup2 = "static 2"
+	testUsername     = "testuser"
+	testUserID       = "1234567890"
 )
 
 var logger = &logrus.Logger{Out: io.Discard, Formatter: &logrus.TextFormatter{}}
@@ -32,13 +34,46 @@ func TestUser(t *testing.T) {
 	req, err := http.NewRequest("GET", "/", nil)
 	expectNil(t, err)
 	req.Header = map[string][]string{
-		"X-Remote-User": {testEmail},
+		"X-Remote-User": {testUsername},
 	}
 
 	ident, err := conn.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
 	expectNil(t, err)
 
-	expectEquals(t, ident.UserID, testEmail)
+	// If not specified, the userID and email should fall back to the remote user
+	expectEquals(t, ident.UserID, testUsername)
+	expectEquals(t, ident.PreferredUsername, testUsername)
+	expectEquals(t, ident.Email, testUsername)
+	expectEquals(t, len(ident.Groups), 0)
+}
+
+func TestExtraHeaders(t *testing.T) {
+	config := Config{
+		UserIDHeader: "X-Remote-User-Id",
+		UserHeader:   "X-Remote-User",
+		EmailHeader:  "X-Remote-User-Email",
+	}
+	conn := callback{
+		userHeader:   config.UserHeader,
+		userIDHeader: config.UserIDHeader,
+		emailHeader:  config.EmailHeader,
+		logger:       logger,
+		pathSuffix:   "/test",
+	}
+
+	req, err := http.NewRequest("GET", "/", nil)
+	expectNil(t, err)
+	req.Header = map[string][]string{
+		"X-Remote-User-Id":    {testUserID},
+		"X-Remote-User":       {testUsername},
+		"X-Remote-User-Email": {testEmail},
+	}
+
+	ident, err := conn.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	expectNil(t, err)
+
+	expectEquals(t, ident.UserID, testUserID)
+	expectEquals(t, ident.PreferredUsername, testUsername)
 	expectEquals(t, ident.Email, testEmail)
 	expectEquals(t, len(ident.Groups), 0)
 }


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

This PR adds support for some additional headers to be propagated into claims in the authproxy connector.

#### What this PR does / why we need it

I am using Dex with authproxy to turn an existing IdP, whose code is not under my control, into an OIDC provider. I want to be able to propagate the user ID and email address from the underlying IdP as OIDC claims alongside the username, which is not possible with the current headers and claims supported by the authproxy connector.

This PR adds support for two extra headers that can be used to propagate the user ID and email from the underlying IdP, and sets the claims. When these additional headers are not set, it reduces to the previous mode.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
Adds support for two additional headers, for user ID and email, to the authproxy connector.
```
