### PR TITLE
fix: remove redundant scope check from Google connector

### DIFF
--- a/connector/google/google.go
+++ b/connector/google/google.go
@@ -226,7 +226,7 @@ func (c *googleConnector) createIdentity(ctx context.Context, identity connector
 	}
 
 	var groups []string
-	if s.Groups && c.adminSrv != nil {
+	if c.adminSrv != nil {
 		checkedGroups := make(map[string]struct{})
 		groups, err = c.getGroups(claims.Email, c.fetchTransitiveGroupMembership, checkedGroups)
 		if err != nil {


### PR DESCRIPTION
#### Overview

Remove redundant scope check from Google connector to fetching groups available.

#### What this PR does / why we need it

Since `groups` are not considered a valid scope by Google, we cannot pass to the `scope`. Although @damieva introduced `claimMapping` in https://github.com/dexidp/dex/issues/2653 to address this issue, it does not seem to work with the current implementation of the Google connector.

This commit resolves the issue by removing the unnecessary `group` scope check, as `adminSrv` is only initialized when the user wants to retrieve groups.

#### Special notes for your reviewer

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
