### PR TITLE
Fail if OIDC config contains hosted domains

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -35,6 +35,13 @@ type Config struct {
 
 	Scopes []string `json:"scopes"` // defaults to "profile" and "email"
 
+	// Previously it was an optional list of whitelisted domains when using Google.
+	// Only users from a listed domain will be allowed to log in.
+	// Now this option does nothing. To work with Google, users should migrate to using the Google connector.
+	//
+	// Deprecated: will be removed in feature releases.
+	HostedDomains []string `json:"hostedDomains"`
+
 	// Certificates for SSL validation
 	RootCAs []string `json:"rootCAs"`
 
@@ -112,6 +119,10 @@ func knownBrokenAuthHeaderProvider(issuerURL string) bool {
 // Open returns a connector which can be used to login users through an upstream
 // OpenID Connect provider.
 func (c *Config) Open(id string, logger log.Logger) (conn connector.Connector, err error) {
+	if len(c.HostedDomains) > 0 {
+		return nil, fmt.Errorf("hostedDomains option does not work anymore, consider switching to the Google connector")
+	}
+
 	httpClient, err := httpclient.NewHTTPClient(c.RootCAs, c.InsecureSkipVerify)
 	if err != nil {
 		return nil, err

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -35,11 +35,12 @@ type Config struct {
 
 	Scopes []string `json:"scopes"` // defaults to "profile" and "email"
 
-	// Previously it was an optional list of whitelisted domains when using Google.
-	// Only users from a listed domain will be allowed to log in.
-	// Now this option does nothing. To work with Google, users should migrate to using the Google connector.
+	// HostedDomains was an optional list of whitelisted domains when using the OIDC connector with Google.
+	// Only users from a whitelisted domain were allowed to log in.
+	// Support for this option was removed from the OIDC connector.
+	// Consider switching to the Google connector which supports this option.
 	//
-	// Deprecated: will be removed in feature releases.
+	// Deprecated: will be removed in future releases.
 	HostedDomains []string `json:"hostedDomains"`
 
 	// Certificates for SSL validation
@@ -120,7 +121,7 @@ func knownBrokenAuthHeaderProvider(issuerURL string) bool {
 // OpenID Connect provider.
 func (c *Config) Open(id string, logger log.Logger) (conn connector.Connector, err error) {
 	if len(c.HostedDomains) > 0 {
-		return nil, fmt.Errorf("hostedDomains option does not work anymore, consider switching to the Google connector")
+		return nil, fmt.Errorf("support for the Hosted domains option had been deprecated and removed, consider switching to the Google connector")
 	}
 
 	httpClient, err := httpclient.NewHTTPClient(c.RootCAs, c.InsecureSkipVerify)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Fail if the hostedDomains option is specified in an OIDC connector config

#### What this PR does / why we need it

The option was removed. After the upgrade, users still using OIDC connectors for their Google providers may accidentally open access to more people than before.

#### Special notes for your reviewer

