### PR TITLE
include granttypes in example config

### DIFF
--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -91,7 +91,16 @@ telemetry:
 
 # Default values shown below
 # oauth2:
-    # use ["code", "token", "id_token"] to enable implicit flow for web-only clients
+    # grantTypes determines the allowed set of authorization flows.
+#   grantTypes:
+#     - "authorization_code"
+#     - "refresh_token"
+#     - "implicit"
+#     - "password"
+#     - "urn:ietf:params:oauth:grant-type:device_code"
+#     - "urn:ietf:params:oauth:grant-type:token-exchange"
+    # responseTypes determines the allowed response contents of a successful authorization flow.
+    # use ["code", "token", "id_token"] to enable implicit flow for web-only clients.
 #   responseTypes: [ "code" ] # also allowed are "token" and "id_token"
     # By default, Dex will ask for approval to share data with application
     # (approval for sharing data from connected IdP to Dex is separate process on IdP)


### PR DESCRIPTION
#### Overview

Followup to #2806 with adding grantTypes to the example config

#### What this PR does / why we need it

Document the new `oauth2.grantTypes` field.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
