### PR TITLE
verify access tokens by checking getuserinfo during a token exchange

### DIFF
--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -441,6 +441,7 @@ func TestTokenIdentity(t *testing.T) {
 		name        string
 		subjectType string
 		userInfo    bool
+		expectError bool
 	}{
 		{
 			name:        "id_token",
@@ -448,6 +449,7 @@ func TestTokenIdentity(t *testing.T) {
 		}, {
 			name:        "access_token",
 			subjectType: tokenTypeAccess,
+			expectError: true,
 		}, {
 			name:        "id_token with user info",
 			subjectType: tokenTypeID,
@@ -494,6 +496,9 @@ func TestTokenIdentity(t *testing.T) {
 			origToken := tokenResponse[long2short[tc.subjectType]].(string)
 			identity, err := conn.TokenIdentity(ctx, tc.subjectType, origToken)
 			if err != nil {
+				if tc.expectError {
+					return
+				}
 				t.Fatal("failed to get token identity", err)
 			}
 


### PR DESCRIPTION
#### Overview

Followup on #2806 for better access token handling.
verify access tokens by checking getuserinfo during a token exchange


#### What this PR does / why we need it

The provider.Verifier.Verify endpoint we were using only works with ID tokens. This isn't an issue with systems which use ID tokens as access tokens (e.g. dex), but for systems with opaque access tokens (e.g. Google / GCP), those access tokens could not be verified. Instead, check the access token against the getUserInfo endpoint.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
