### PR TITLE
Minimalistic support for group filtering in oidc connector

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -15,9 +15,9 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/dexidp/dex/connector"
+	groups_pkg "github.com/dexidp/dex/pkg/groups"
 	"github.com/dexidp/dex/pkg/httpclient"
 	"github.com/dexidp/dex/pkg/log"
-	groups_pkg "github.com/dexidp/dex/pkg/groups"
 )
 
 // Config holds configuration options for OpenID Connect logins.

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/exp/slices"
 	"golang.org/x/oauth2"
 
 	"github.com/dexidp/dex/connector"
@@ -50,7 +51,8 @@ type Config struct {
 	InsecureSkipEmailVerified bool `json:"insecureSkipEmailVerified"`
 
 	// InsecureEnableGroups enables groups claims. This is disabled by default until https://github.com/dexidp/dex/issues/1065 is resolved
-	InsecureEnableGroups bool `json:"insecureEnableGroups"`
+	InsecureEnableGroups bool     `json:"insecureEnableGroups"`
+	AllowedGroups        []string `json:"allowedGroups"`
 
 	// AcrValues (Authentication Context Class Reference Values) that specifies the Authentication Context Class Values
 	// within the Authentication Request that the Authorization Server is being requested to use for
@@ -180,6 +182,7 @@ func (c *Config) Open(id string, logger log.Logger) (conn connector.Connector, e
 		httpClient:                httpClient,
 		insecureSkipEmailVerified: c.InsecureSkipEmailVerified,
 		insecureEnableGroups:      c.InsecureEnableGroups,
+		allowedGroups:             c.AllowedGroups,
 		acrValues:                 c.AcrValues,
 		getUserInfo:               c.GetUserInfo,
 		promptType:                c.PromptType,
@@ -207,6 +210,7 @@ type oidcConnector struct {
 	httpClient                *http.Client
 	insecureSkipEmailVerified bool
 	insecureEnableGroups      bool
+	allowedGroups             []string
 	acrValues                 []string
 	getUserInfo               bool
 	promptType                string
@@ -424,6 +428,25 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 					return identity, fmt.Errorf("malformed \"%v\" claim", groupsKey)
 				}
 			}
+		}
+
+		// Validate that the user is part of allowedGroups
+		accessAllowed := false
+		if len(c.allowedGroups) > 0 {
+			for _, group := range c.allowedGroups {
+				groupPresent := slices.Contains(groups, group)
+				if groupPresent {
+					accessAllowed = true
+					break
+				}
+			}
+		} else {
+			// don't check for groups if allowedGroups is not configured
+			accessAllowed = true
+		}
+
+		if !accessAllowed {
+			return identity, errors.New("user is not in the allowed group(s)")
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Filter users based on groups in OIDC connector.

#### What this PR does / why we need it
Currently it is not possible to filter users based on groups like it is done with the `google` connector. This PR is an attempt to support group filtering in the `oidc` connector. The connector configuration takes an additional configuration as below to specify what the allowed groups are. If the user's groups belong to at least one of the `allowedGroups`, then authentication will be successful. The other change is to indicate that the user does not belong to allowed groups if authentication fails because the user does not belong to any of the allowed groups.

```
{
            "name": "My-oidc",
            "config": {
                "issuer": "<ISSUER>",
                "clientID": "12345678",
                "redirectURI": "<Dex Callback>",
                "clientSecret": "12345678",
                "insecureSkipEmailVerified": true,
                "insecureEnableGroups": true,
                "getUserInfo": true,
                "allowedGroups": ["XYZ", "ABC"],
                "scopes": ....
            },
            "id": "myoidc",
            "type": "oidc"
        }
```
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
