### PR TITLE
feat(connector/microsoft): support custom api and graph URLs

### DIFF
--- a/connector/microsoft/microsoft.go
+++ b/connector/microsoft/microsoft.go
@@ -54,6 +54,9 @@ type Config struct {
 	UseGroupsAsWhitelist bool            `json:"useGroupsAsWhitelist"`
 	EmailToLowercase     bool            `json:"emailToLowercase"`
 
+	APIURL   string `json:"apiURL"`
+	GraphURL string `json:"graphURL"`
+
 	// PromptType is used for the prompt query parameter.
 	// For valid values, see https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code.
 	PromptType string `json:"promptType"`
@@ -65,8 +68,8 @@ type Config struct {
 // Open returns a strategy for logging in through Microsoft.
 func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error) {
 	m := microsoftConnector{
-		apiURL:               "https://login.microsoftonline.com",
-		graphURL:             "https://graph.microsoft.com",
+		apiURL:               strings.TrimSuffix(c.APIURL, "/"),
+		graphURL:             strings.TrimSuffix(c.GraphURL, "/"),
 		redirectURI:          c.RedirectURI,
 		clientID:             c.ClientID,
 		clientSecret:         c.ClientSecret,
@@ -81,6 +84,15 @@ func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error)
 		domainHint:           c.DomainHint,
 		scopes:               c.Scopes,
 	}
+
+	if m.apiURL == "" {
+		m.apiURL = "https://login.microsoftonline.com"
+	}
+
+	if m.graphURL == "" {
+		m.graphURL = "https://graph.microsoft.com"
+	}
+
 	// By default allow logins from both personal and business/school
 	// accounts.
 	if m.tenant == "" {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Support custom API and graph URLs in Microsoft/Azure connector.

From #2459

> This change makes the Azure endpoints configurable.  For most users, the default 
> https://login.microsoftonline.com/ and https://graph.microsoft.com/ values 
> will remain the correct choice, but this allows users of Azure in special 
> regions, such as Government Cloud Services for export-controlled workloads, 
> to use the Microsoft connector to get group membership.


#### What this PR does / why we need it

Fixes #2457
Fixes #2459

#### Special notes for your reviewer

I was not able to test this change as I don't have access to such environments.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Support custom api and graph URLs in Microsoft/Azure connector
```
