### PR TITLE
fix: Do not evaluate skipApproval on approval page

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -613,12 +613,6 @@ func (s *Server) handleApproval(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodGet:
-		// TODO: `finalizeLogin()` now sends code directly to client without going through this endpoint,
-		//		 the `if skipApproval { ... }` block needs to be removed after a grace period.
-		if s.skipApproval {
-			s.sendCodeResponse(w, r, authReq)
-			return
-		}
 		client, err := s.storage.GetClient(authReq.ClientID)
 		if err != nil {
 			s.logger.Errorf("Failed to get client %q: %v", authReq.ClientID, err)


### PR DESCRIPTION
#### Overview

Remove evaluation of skipApproval on approval page

#### What this PR does / why we need it

The Pull Request https://github.com/dexidp/dex/pull/2897 caused a bug when using `oauth2.skipApprovalScreen: true` together with a client setting `approval_prompt=force` during the request. The tests validated correctly that the user gets redirected to `/approval` in this case, but the handler of the approval page contains some code which immediately returns the auth code if `oauth2.skipApprovalScreen: true` is set and ignores the `approval_prompt` parameter. Since there is a TODO comment to remove this check after some time, I guess it can be removed now to fix that issue.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
Fix a bug that Dex ignores approval_prompt=force when skipping approval screen is enabled as default behavior
```
