### PR TITLE
feat: Add configurable CORS Headers

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -150,6 +150,7 @@ type Web struct {
 	TLSCert        string   `json:"tlsCert"`
 	TLSKey         string   `json:"tlsKey"`
 	AllowedOrigins []string `json:"allowedOrigins"`
+    AllowedHeaders []string `json:"allowedHeaders"`
 }
 
 // Telemetry is the config format for telemetry including the HTTP server config.

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -265,6 +265,7 @@ func runServe(options serveOptions) error {
 		AlwaysShowLoginScreen:  c.OAuth2.AlwaysShowLoginScreen,
 		PasswordConnector:      c.OAuth2.PasswordConnector,
 		AllowedOrigins:         c.Web.AllowedOrigins,
+        AllowedHeaders:         c.Web.AllowedHeaders,
 		Issuer:                 c.Issuer,
 		Storage:                s,
 		Web:                    c.Frontend,

--- a/server/server.go
+++ b/server/server.go
@@ -77,6 +77,9 @@ type Config struct {
 	// domain.
 	AllowedOrigins []string
 
+    // List of allowed headers for CORS requests on discovery, token, and keys endpoint.
+    AllowedHeaders []string
+
 	// If enabled, the server won't prompt the user to approve authorization requests.
 	// Logging in implies approval.
 	SkipApprovalScreen bool
@@ -214,6 +217,9 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	if len(c.SupportedResponseTypes) == 0 {
 		c.SupportedResponseTypes = []string{responseTypeCode}
 	}
+    if len(c.AllowedHeaders) == 0 {
+        c.AllowedHeaders = []string{"Authorization"}
+    }
 
 	allSupportedGrants := map[string]bool{
 		grantTypeAuthorizationCode: true,
@@ -353,12 +359,9 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	handleWithCORS := func(p string, h http.HandlerFunc) {
 		var handler http.Handler = h
 		if len(c.AllowedOrigins) > 0 {
-			allowedHeaders := []string{
-				"Authorization",
-			}
 			cors := handlers.CORS(
 				handlers.AllowedOrigins(c.AllowedOrigins),
-				handlers.AllowedHeaders(allowedHeaders),
+				handlers.AllowedHeaders(c.AllowedHeaders),
 			)
 			handler = cors(handler)
 		}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview
The CORS enforced endpoints only allow the `Authorization` header by default, and this behavior is not configurable.  For some environments, it is desirable to allow configuration of which headers should be accepted (e.g. when using Swagger UI with a Dex IDP, which for instance inserts a `x-requested-with` header to the CORS preflight check).

#### What this PR does / why we need it
This PR allows the `AllowedHeaders` for CORS endpoints to be configurable, so that the host can decide if headers should be rejected or not.  By default, the `Authorization` header will be accepted to not interfere with any existing setups of Dex if no `allowedHeaders` are defined in the `config.yaml` file.

#### Does this PR introduce a user-facing change?
Yes


```release-note
Adds a configuration option `allowedHeaders` in the `web` section of `config.yaml` to change which headers are accepted on CORS requests.
```
