### PR TITLE
Fix etcd device requests

### DIFF
--- a/storage/conformance/conformance.go
+++ b/storage/conformance/conformance.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/kylelemons/godebug/pretty"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 	jose "gopkg.in/square/go-jose.v2"
 
@@ -990,6 +991,13 @@ func testDeviceRequestCRUD(t *testing.T, s storage.Storage) {
 	// Attempt to create same DeviceRequest twice.
 	err := s.CreateDeviceRequest(d1)
 	mustBeErrAlreadyExists(t, "device request", err)
+
+	got, err := s.GetDeviceRequest(d1.UserCode)
+	if err != nil {
+		t.Fatalf("failed to get device request: %v", err)
+	}
+
+	require.Equal(t, d1, got)
 
 	// No manual deletes for device requests, will be handled by garbage collection routines
 	// see testGC

--- a/storage/etcd/etcd.go
+++ b/storage/etcd/etcd.go
@@ -577,8 +577,11 @@ func (c *conn) CreateDeviceRequest(d storage.DeviceRequest) error {
 func (c *conn) GetDeviceRequest(userCode string) (r storage.DeviceRequest, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultStorageTimeout)
 	defer cancel()
-	err = c.getKey(ctx, keyID(deviceRequestPrefix, userCode), &r)
-	return r, err
+	var dr DeviceRequest
+	if err = c.getKey(ctx, keyID(deviceRequestPrefix, userCode), &dr); err == nil {
+		r = toStorageDeviceRequest(dr)
+	}
+	return
 }
 
 func (c *conn) listDeviceRequests(ctx context.Context) (requests []DeviceRequest, err error) {

--- a/storage/etcd/types.go
+++ b/storage/etcd/types.go
@@ -277,6 +277,17 @@ func fromStorageDeviceRequest(d storage.DeviceRequest) DeviceRequest {
 	}
 }
 
+func toStorageDeviceRequest(d DeviceRequest) storage.DeviceRequest {
+	return storage.DeviceRequest{
+		UserCode:     d.UserCode,
+		DeviceCode:   d.DeviceCode,
+		ClientID:     d.ClientID,
+		ClientSecret: d.ClientSecret,
+		Scopes:       d.Scopes,
+		Expiry:       d.Expiry,
+	}
+}
+
 // DeviceToken is a mirrored struct from storage with JSON struct tags
 type DeviceToken struct {
 	DeviceCode          string    `json:"device_code"`


### PR DESCRIPTION
#### Overview

Add a missing type conversion while reading device requests from etcd storage and add a check for this case to the storage conformance tests.

#### What this PR does / why we need it

This PR resolves the bug described in https://github.com/dexidp/dex/issues/3118

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
Add a missing type conversion while reading device requests from etcd storage
```
