### PR TITLE
Store offline sessions only if they were requested by the user

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -539,6 +539,17 @@ func (s *Server) finalizeLogin(identity connector.Identity, authReq storage.Auth
 		return returnURL, false, nil
 	}
 
+	offlineAccessRequested := false
+	for _, scope := range authReq.Scopes {
+		if scope == scopeOfflineAccess {
+			offlineAccessRequested = true
+			break
+		}
+	}
+	if !offlineAccessRequested {
+		return returnURL, false, nil
+	}
+
 	// Try to retrieve an existing OfflineSession object for the corresponding user.
 	session, err := s.storage.GetOfflineSessions(identity.UserID, authReq.ConnectorID)
 	if err != nil {


### PR DESCRIPTION
#### Overview

Create offline sessions only if they are supported by the connector and if the user requests it with the scope `offline_access`.
Extend handler tests to verify this behavior.

#### What this PR does / why we need it

This PR resolves the bug described in https://github.com/dexidp/dex/issues/3124

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
Store offline sessions only if they are supported and were requested by the user
```
