### PR TITLE
feat: Support PKCE in OIDC connector

### DIFF
--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -55,6 +55,7 @@ func TestHandleCallback(t *testing.T) {
 		emailKey                  string
 		groupsKey                 string
 		insecureSkipEmailVerified bool
+		enablePKCE                bool
 		scopes                    []string
 		expectUserID              string
 		expectUserName            string
@@ -122,6 +123,23 @@ func TestHandleCallback(t *testing.T) {
 				"sub":   "subvalue",
 				"name":  "namevalue",
 				"email": "emailvalue",
+			},
+		},
+		{
+			name:               "withEnablePKCE",
+			userIDKey:          "", // not configured
+			userNameKey:        "", // not configured
+			enablePKCE:         true,
+			expectUserID:       "subvalue",
+			expectUserName:     "namevalue",
+			expectGroups:       []string{"group1", "group2"},
+			expectedEmailField: "emailvalue",
+			token: map[string]interface{}{
+				"sub":            "subvalue",
+				"name":           "namevalue",
+				"groups":         []string{"group1", "group2"},
+				"email":          "emailvalue",
+				"email_verified": true,
 			},
 		},
 		{
@@ -390,6 +408,7 @@ func TestHandleCallback(t *testing.T) {
 				UserIDKey:                 tc.userIDKey,
 				UserNameKey:               tc.userNameKey,
 				InsecureSkipEmailVerified: tc.insecureSkipEmailVerified,
+				EnablePKCE:                tc.enablePKCE,
 				InsecureEnableGroups:      true,
 				BasicAuthUnsupported:      &basicAuth,
 				OverrideClaimMapping:      tc.overrideClaimMapping,


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->
This adds a configuration option `enablePKCE` to the OIDC connector to send code challenge and verifier parameters as required for PKCE.

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
Some OIDC providers require the PKCE flow, so a code challenge must be passed to the authorize endpoint, and a code verifier must be sent on the subsequent authorization token exchange.

Dex currently supports PKCE for downstream clients, but not for upstream OIDC providers.
Dynamic configuration using the OAuth2 discovery metadata isn't possible as the `coreos/go-oidc` library currently doesn't expose `code_challenge_methods_supported` in the `Provider`.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
* Adds the OIDC connector configuration option `enablePKCE` to send code
  challenge and verifier parameters to upstream OIDC providers as required for
  PKCE.
```
