### PR TITLE
Sign container images

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -62,6 +62,11 @@ jobs:
       - name: Set up Syft
         uses: anchore/sbom-action/download-syft@c7f031d9249a826a082ea14c79d3b686a51d485a # v0.15.3
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@1fc5bd396d372bee37d608f955b336615edf79c8 # v3.2.0
+        with:
+          cosign-release: 'v2.2.1'
+
       - name: Set image name
         id: image-name
         run: echo "value=ghcr.io/${{ github.repository }}" >> "$GITHUB_OUTPUT"
@@ -129,6 +134,11 @@ jobs:
           # cache-to: type=gha,mode=max
           outputs: ${{ steps.build-output.outputs.value }}
           # push: ${{ inputs.publish }}
+
+      - name: Sign the images with GitHub OIDC Token
+        run: |
+          cosign sign --yes ${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }}
+        if: inputs.publish
 
       - name: Set image ref
         id: image-ref


### PR DESCRIPTION
#### Overview

Use cosign to sign container images (simple keyless method).

Signing container images enhances security by ensuring the integrity and authenticity of deployed images, reducing the risk of tampering and unauthorized modifications. It establishes a trust chain, confirming that the deployed image aligns with the developer's intent, thereby bolstering the security of your containerized applications.

#### What this PR does / why we need it

Related https://github.com/dexidp/dex/issues/2865

#### Special notes for your reviewer
