### PR TITLE
chore: test docker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,18 @@ FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.3.0@sha256:904fe94f236d36d65aeb5a
 
 FROM --platform=$BUILDPLATFORM golang:1.21.6-alpine3.18 AS builder
 
+RUN apk add --update make
+
+ARG VERSION
+
+WORKDIR /usr/local/src/dex
+
+COPY . .
+
+RUN make release-binary && exit 1
+
+RUN exit 1
+
 COPY --from=xx / /
 
 RUN apk add --update alpine-sdk ca-certificates openssl clang lld
@@ -47,8 +59,8 @@ ARG TARGETVARIANT
 ENV GOMPLATE_VERSION=v3.11.6
 
 RUN wget -O /usr/local/bin/gomplate \
-  "https://github.com/hairyhenderson/gomplate/releases/download/${GOMPLATE_VERSION}/gomplate_${TARGETOS:-linux}-${TARGETARCH:-amd64}${TARGETVARIANT}" \
-  && chmod +x /usr/local/bin/gomplate
+    "https://github.com/hairyhenderson/gomplate/releases/download/${GOMPLATE_VERSION}/gomplate_${TARGETOS:-linux}-${TARGETARCH:-amd64}${TARGETVARIANT}" \
+    && chmod +x /usr/local/bin/gomplate
 
 # For Dependabot to detect base image versions
 FROM alpine:3.19.0 AS alpine

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,10 @@ examples: bin/grpc-client bin/example-app ## Build example app.
 .PHONY: release-binary
 release-binary: LD_FLAGS = "-w -X main.version=$(VERSION) -extldflags \"-static\""
 release-binary: ## Build release binaries (used to build a final container image).
-	@go build -o /go/bin/dex -v -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/dex
-	@go build -o /go/bin/docker-entrypoint -v -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/docker-entrypoint
+	@echo $(VERSION)
+	@echo $(LD_FLAGS)
+	# @go build -o /go/bin/dex -v -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/dex
+	# @go build -o /go/bin/docker-entrypoint -v -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/docker-entrypoint
 
 bin/dex:
 	@mkdir -p bin/


### PR DESCRIPTION
Test that build args work as env vars.

```
docker build --build-arg VERSION=test-version .
```