### PR TITLE
Update handlers.go

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -813,7 +813,7 @@ func (s *Server) withClientFromStorage(w http.ResponseWriter, r *http.Request, h
 		return
 	}
 
-	if subtle.ConstantTimeCompare([]byte(client.Secret), []byte(clientSecret)) != 1 {
+	if !client.Public && subtle.ConstantTimeCompare([]byte(client.Secret), []byte(clientSecret)) != 1 {
 		if clientSecret == "" {
 			s.logger.Infof("missing client_secret on token request for client: %s", client.ID)
 		} else {


### PR DESCRIPTION
Compare secrets just on not public clients

#### Overview

<!-- Describe your changes briefly here. -->

Removed client.Secret verification for public clients, maintaining the same behavior for private clients.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

This PR addresses a specific need in our custom connector. Our custom connector relies on the secret as an authentication header. In the case of public clients, this header is also necessary for proper authentication. With this small change, the connector now functions seamlessly for both public and private clients. It's worth noting that this adjustment doesn't appear to impact code coverage or the expected behavior of the system.

#### Special notes for your reviewer
