### PR TITLE
Also set the username in authproxy connector

### DIFF
--- a/connector/authproxy/authproxy.go
+++ b/connector/authproxy/authproxy.go
@@ -106,6 +106,7 @@ func (m *callback) HandleCallback(s connector.Scopes, r *http.Request) (connecto
 	}
 	return connector.Identity{
 		UserID:            remoteUserID,
+		Username:          remoteUser,
 		PreferredUsername: remoteUser,
 		Email:             remoteUserEmail,
 		EmailVerified:     true,

--- a/connector/authproxy/authproxy_test.go
+++ b/connector/authproxy/authproxy_test.go
@@ -43,6 +43,7 @@ func TestUser(t *testing.T) {
 	// If not specified, the userID and email should fall back to the remote user
 	expectEquals(t, ident.UserID, testUsername)
 	expectEquals(t, ident.PreferredUsername, testUsername)
+	expectEquals(t, ident.Username, testUsername)
 	expectEquals(t, ident.Email, testUsername)
 	expectEquals(t, len(ident.Groups), 0)
 }
@@ -74,6 +75,7 @@ func TestExtraHeaders(t *testing.T) {
 
 	expectEquals(t, ident.UserID, testUserID)
 	expectEquals(t, ident.PreferredUsername, testUsername)
+	expectEquals(t, ident.Username, testUsername)
 	expectEquals(t, ident.Email, testEmail)
 	expectEquals(t, len(ident.Groups), 0)
 }


### PR DESCRIPTION
#### Overview

The `authproxy` connector only sets the `preferred_username` but not `username`. This causes issues with some OIDC clients that don't fallback to `preferred_username`.

One example here is `rallly` but I also noticed that there's no username when using dex with WikiJS.

#### What this PR does / why we need it

In addition to `preferred_username`, the authproxy connector now also set's the `Username` field on the `connector.Identity`
