### PR TITLE
fix(tokenExchange): use correct token type for userInfo requests

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -433,7 +433,10 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 	// We immediately want to run getUserInfo if configured before we validate the claims.
 	// For token exchanges with access tokens, this is how we verify the token.
 	if c.getUserInfo {
-		userInfo, err := c.provider.UserInfo(ctx, oauth2.StaticTokenSource(token))
+		userInfo, err := c.provider.UserInfo(ctx, oauth2.StaticTokenSource(&oauth2.Token{
+			AccessToken: token.AccessToken,
+			TokenType:   "Bearer", // The UserInfo endpoint requires a bearer token as per RFC6750
+		}))
 		if err != nil {
 			return identity, fmt.Errorf("oidc: error loading userinfo: %v", err)
 		}


### PR DESCRIPTION
#### Overview

This small changes fixes an issue in the token exchange flow. It explicitly sets the tokenType used for `GET /userinfo` to `Bearer` to be conform with the OIDC spec.

#### What this PR does / why we need it

Without this change the tokenType would be set to either `urn:ietf:params:oauth:token-type:access_token` or `urn:ietf:params:oauth:token-type:id_token`, which doesn't satisfy the OIDC spec.

> The Access Token obtained from an OpenID Connect Authentication Request MUST be sent as a Bearer Token, per Section 2 of [OAuth 2.0 Bearer Token Usage](https://openid.net/specs/openid-connect-core-1_0.html#RFC6750) [RFC6750].

https://openid.net/specs/openid-connect-core-1_0.html#UserInfo (5.3.1)


Closes https://github.com/dexidp/dex/issues/3335

