### PR TITLE
fix: add sanitizer to ldap account and password

### DIFF
--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -9,9 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"regexp"
 	"strings"
-	"errors"
 
 	"github.com/go-ldap/ldap/v3"
 
@@ -463,21 +461,6 @@ func (c *ldapConnector) userEntry(conn *ldap.Conn, username string) (user ldap.E
 func (c *ldapConnector) Login(ctx context.Context, s connector.Scopes, username, password string) (ident connector.Identity, validPass bool, err error) {
 	// make this check to avoid unauthenticated bind to the LDAP server.
 
-	matched, err := regexp.MatchString(`[\w\s\*]+`, username)
-	if err != nil {
-		return connector.Identity{}, false, err
-	}
-	if matched {
-		return connector.Identity{}, false, errors.New("invalid input")
-	}
-	matched, err = regexp.MatchString(`[\w\*]+`, password)
-	if err != nil {
-		return connector.Identity{}, false, err
-	}
-	if matched {
-		return connector.Identity{}, false, errors.New("invalid input")
-	}
-
 	if password == "" {
 		return connector.Identity{}, false, nil
 	}
@@ -488,6 +471,9 @@ func (c *ldapConnector) Login(ctx context.Context, s connector.Scopes, username,
 		incorrectPass = false
 		user          ldap.Entry
 	)
+
+	username = ldap.EscapeFilter(username)
+	password = ldap.EscapeFilter(password)
 
 	err = c.do(ctx, func(conn *ldap.Conn) error {
 		entry, found, err := c.userEntry(conn, username)

--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"regexp"
 	"strings"
+	"errors"
 
 	"github.com/go-ldap/ldap/v3"
 
@@ -460,6 +462,22 @@ func (c *ldapConnector) userEntry(conn *ldap.Conn, username string) (user ldap.E
 
 func (c *ldapConnector) Login(ctx context.Context, s connector.Scopes, username, password string) (ident connector.Identity, validPass bool, err error) {
 	// make this check to avoid unauthenticated bind to the LDAP server.
+
+	matched, err := regexp.MatchString(`[\w\s\*]+`, username)
+	if err != nil {
+		return connector.Identity{}, false, err
+	}
+	if matched {
+		return connector.Identity{}, false, errors.New("invalid input")
+	}
+	matched, err = regexp.MatchString(`[\w\*]+`, password)
+	if err != nil {
+		return connector.Identity{}, false, err
+	}
+	if matched {
+		return connector.Identity{}, false, errors.New("invalid input")
+	}
+
 	if password == "" {
 		return connector.Identity{}, false, nil
 	}

--- a/connector/ldap/ldap_test.go
+++ b/connector/ldap/ldap_test.go
@@ -92,7 +92,7 @@ func TestQuery(t *testing.T) {
 		{
 			name:      "invalid wildcard password",
 			username:  "john",
-			password:  "*",  //wildcard password is not allowed
+			password:  "*",  // wildcard password is not allowed
 			wantBadPW: true, // Want invalid password, not a query error.
 		},
 	}

--- a/connector/ldap/ldap_test.go
+++ b/connector/ldap/ldap_test.go
@@ -83,6 +83,18 @@ func TestQuery(t *testing.T) {
 			password:  "foo",
 			wantBadPW: true, // Want invalid password, not a query error.
 		},
+		{
+			name:     "invalid wildcard username",
+			username: "a*", // wildcard query is not allowed
+			password: "foo",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid wildcard password",
+			username: "john",
+			password: "*", //wildcard password is not allowed
+			wantErr:  true,
+		},
 	}
 
 	runTests(t, connectLDAP, c, tests)

--- a/connector/ldap/ldap_test.go
+++ b/connector/ldap/ldap_test.go
@@ -84,16 +84,16 @@ func TestQuery(t *testing.T) {
 			wantBadPW: true, // Want invalid password, not a query error.
 		},
 		{
-			name:     "invalid wildcard username",
-			username: "a*", // wildcard query is not allowed
-			password: "foo",
-			wantErr:  true,
+			name:      "invalid wildcard username",
+			username:  "a*", // wildcard query is not allowed
+			password:  "foo",
+			wantBadPW: true, // Want invalid password, not a query error.
 		},
 		{
-			name:     "invalid wildcard password",
-			username: "john",
-			password: "*", //wildcard password is not allowed
-			wantErr:  true,
+			name:      "invalid wildcard password",
+			username:  "john",
+			password:  "*",  //wildcard password is not allowed
+			wantBadPW: true, // Want invalid password, not a query error.
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

this patch draws error when queys (i.e. account / password) against ldap contain wildcard. 


#### What this PR does / why we need it

fixes #3354 

#### Special notes for your reviewer

not sure whether it would impact the existing usecases or not, but I an open to accept additional switcher to on/off.
