### PR TITLE
Update max length of kubernetes object to fit kubernetes policy

### DIFF
--- a/storage/kubernetes/client.go
+++ b/storage/kubernetes/client.go
@@ -84,7 +84,8 @@ func offlineTokenName(userID string, connID string, h func() hash.Hash) string {
 	return strings.TrimRight(encoding.EncodeToString(hash.Sum(nil)), "=")
 }
 
-const kubeResourceMaxLen = 63
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+const kubeResourceMaxLen = 253 
 
 var kubeResourceNameRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
 

--- a/storage/kubernetes/client.go
+++ b/storage/kubernetes/client.go
@@ -85,7 +85,7 @@ func offlineTokenName(userID string, connID string, h func() hash.Hash) string {
 }
 
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
-const kubeResourceMaxLen = 253 
+const kubeResourceMaxLen = 253
 
 var kubeResourceNameRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
 


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->

Update max length of kubernetes object to fit kubernetes policy.
#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
We faced an errror with oauth2 clients with id longer than 63 symbols (77 in particular).
#### Special notes for your reviewer
```
{"level":"error","msg":"Failed to get client: invalid kubernetes resource name: must match the pattern ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and be no longer than 63 characters","time":"2024-03-28T19:20:09Z"}
{"level":"error","msg":"Failed to parse authorization request: Database error.","time":"2024-03-28T19:20:09Z"}
```