### PR TITLE
chore: run release note label ci only in dexidp/dex repo not in forks

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -12,6 +12,8 @@ jobs:
     name: Release note label
     runs-on: ubuntu-latest
 
+    if: github.repository == 'dexidp/dex'
+
     steps:
       - name: Check minimum labels
         uses: mheap/github-action-required-labels@80a96a4863886addcbc9f681b5b295ba7f5424e1 # v5.3.0


### PR DESCRIPTION

#### Overview

- run release note label ci only in dexidp/dex repo not in forks

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
