### PR TITLE
Do not escape password for LDAP connectors

### DIFF
--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -473,7 +473,6 @@ func (c *ldapConnector) Login(ctx context.Context, s connector.Scopes, username,
 	)
 
 	username = ldap.EscapeFilter(username)
-	password = ldap.EscapeFilter(password)
 
 	err = c.do(ctx, func(conn *ldap.Conn) error {
 		entry, found, err := c.userEntry(conn, username)


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

With the change introduced in https://github.com/dexidp/dex/pull/3372 Dex declines passwords that contain special characters. Since password is not passed to any kind of filters, it is safe to pass a password as is. No LDAP query injections are possible.

This commit is a revert of password escaping.

#### What this PR does / why we need it

Related https://github.com/dexidp/dex/issues/3433

#### Special notes for your reviewer
