### PR TITLE
feat: Add support for configurable prompt type for Google connector

### DIFF
--- a/connector/google/google_test.go
+++ b/connector/google/google_test.go
@@ -10,11 +10,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dexidp/dex/connector"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	admin "google.golang.org/api/admin/directory/v1"
 	"google.golang.org/api/option"
+
+	"github.com/dexidp/dex/connector"
 )
 
 var (

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -75,7 +75,7 @@ type Config struct {
 
 	UserNameKey string `json:"userNameKey"`
 
-	// PromptType will be used fot the prompt parameter (when offline_access, by default prompt=consent)
+	// PromptType will be used for the prompt parameter (when offline_access, by default prompt=consent)
 	PromptType *string `json:"promptType"`
 
 	// OverrideClaimMapping will be used to override the options defined in claimMappings.


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Add support for configurable prompt type for Google Connector. Reference https://github.com/dexidp/dex/issues/3450

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

- Allows the user to explicitly configure the value of `prompt` parameter in login URL generated by Google connector

#### Special notes for your reviewer

Ref https://github.com/dexidp/dex/issues/3450

The original ask was to avoid the user experience of consent screen every time authentication flow goes through `dex` into Google by skipping `prompt=consent` flag. As per OIDC specification, there is no valid value for `prompt` param to achieve this. So this PR just allows the ability to set the value of `prompt` parameter through configuration. Setting an explicit `""` (empty) value for prompt should be functionally equivalent for skipping it for Google connector
