### PR TITLE
feat: allow domain names or IDs in keystone connector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.0.2
 	github.com/go-ldap/ldap/v3 v3.4.6
 	github.com/go-sql-driver/mysql v1.8.1
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
@@ -65,7 +66,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.4 // indirect
 	github.com/hashicorp/hcl/v2 v2.13.0 // indirect


### PR DESCRIPTION
OpenStack Keystone allows a user to authenticate against a domain. That domain can be specified either as the domain ID or the domain name when authenticating. The domain ID is a UUID or the special "default" domain ID so key off of that when deciding what to submit to the keystone API. Collapsed the code to share the domainKeystone struct by utilizing omitempty to skip unset fields.