### PR TITLE
Add allowedDomains to Microsoft connector.

### DIFF
--- a/connector/microsoft/microsoft.go
+++ b/connector/microsoft/microsoft.go
@@ -71,6 +71,8 @@ type Config struct {
 	// following values: "name", "email", "mailNickname" or "onPremisesSamAccountName".
 	// If unset, the preferred_username field will remain empty.
 	PreferredUsernameField string `json:"preferredUsernameField"`
+
+	AllowedDomains []string `json:"allowedDomains"`
 }
 
 // Open returns a strategy for logging in through Microsoft.
@@ -93,6 +95,7 @@ func (c *Config) Open(id string, logger *slog.Logger) (connector.Connector, erro
 		domainHint:             c.DomainHint,
 		scopes:                 c.Scopes,
 		preferredUsernameField: c.PreferredUsernameField,
+		allowedDomains:         c.AllowedDomains,
 	}
 
 	if m.apiURL == "" {
@@ -150,6 +153,7 @@ type microsoftConnector struct {
 	domainHint             string
 	scopes                 []string
 	preferredUsernameField string
+	allowedDomains         []string
 }
 
 func (c *microsoftConnector) isOrgTenant() bool {
@@ -293,6 +297,11 @@ func (c *microsoftConnector) HandleCallback(s connector.Scopes, connData []byte,
 
 	if c.emailToLowercase {
 		user.Email = strings.ToLower(user.Email)
+	}
+
+	// Check if the email's domain is in the allowed list
+	if !c.isAllowedDomain(user.Email) {
+		return identity, fmt.Errorf("email (%s) domain not allowed", user.Email)
 	}
 
 	identity = connector.Identity{
@@ -660,4 +669,23 @@ func (e *oauth2Error) Error() string {
 		return e.error
 	}
 	return e.error + ": " + e.errorDescription
+}
+
+func (c *microsoftConnector) isAllowedDomain(email string) bool {
+
+	if len(c.allowedDomains) == 0 {
+		return true
+	}
+
+	parts := strings.Split(email, "@")
+	if len(parts) != 2 {
+		return false
+	}
+	domain := parts[1]
+	for _, d := range c.allowedDomains {
+		if d == domain {
+			return true
+		}
+	}
+	return false
 }

--- a/connector/microsoft/microsoft_test.go
+++ b/connector/microsoft/microsoft_test.go
@@ -13,6 +13,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dexidp/dex/connector"
 )
 
@@ -240,6 +242,66 @@ func TestClientAssertionTokenExchange(t *testing.T) {
 	}
 	if receivedAuthorization != "" {
 		t.Errorf("Expected Authorization header to be empty, got %q", receivedAuthorization)
+	}
+}
+
+func TestDomainNotAllowed(t *testing.T) {
+	s := newTestServer(map[string]testResponse{
+		"/v1.0/me?$select=id,displayName,userPrincipalName,mailNickname,onPremisesSamAccountName": {
+			data: user{ID: "S56767889", Name: "Jane Doe", Email: "jane.doe@example.com"},
+		},
+		"/" + tenant + "/oauth2/v2.0/token": dummyToken,
+	})
+	defer s.Close()
+
+	req, _ := http.NewRequest("GET", s.URL, nil)
+
+	c := microsoftConnector{apiURL: s.URL, graphURL: s.URL, tenant: tenant, allowedDomains: []string{"dcode.tech"}}
+	identity, err := c.HandleCallback(connector.Scopes{Groups: false}, nil, req)
+
+	assert.Error(t, err, "email (jane.doe@example.com) domain not allowed")
+	assert.Equal(t, connector.Identity{}, identity)
+}
+
+func TestDomainListAllowed(t *testing.T) {
+	testCases := []struct {
+		email   string
+		allowed bool
+		domain  string
+	}{
+		{"jane.doe@dcode.tech", true, "dcode.tech"},              // Allowed domain
+		{"joe.bloggs@example.com", true, "example.com"},          // Allowed domain
+		{"john.smith@otherdomain.com", false, "otherdomain.com"}, // Not allowed domain
+	}
+
+	for _, tc := range testCases {
+		s := newTestServer(map[string]testResponse{
+			"/v1.0/me?$select=id,displayName,userPrincipalName,mailNickname,onPremisesSamAccountName": {
+				data: user{ID: "S56767889", Name: "John Doe", Email: tc.email},
+			},
+			"/" + tenant + "/oauth2/v2.0/token": dummyToken,
+		})
+		defer s.Close()
+
+		req, _ := http.NewRequest("GET", s.URL, nil)
+
+		// Setup the microsoftConnector with allowed domains
+		c := microsoftConnector{
+			apiURL:         s.URL,
+			graphURL:       s.URL,
+			tenant:         tenant,
+			allowedDomains: []string{"dcode.tech", "example.com"},
+		}
+
+		identity, err := c.HandleCallback(connector.Scopes{Groups: false}, nil, req)
+
+		if tc.allowed {
+			assert.NoError(t, err, "Expected no error for allowed domain: "+tc.domain)
+			assert.NotEqual(t, connector.Identity{}, identity, "Expected a non-empty identity struct")
+		} else {
+			assert.Error(t, err, "Expected error for non-allowed domain: "+tc.email)
+			assert.Equal(t, connector.Identity{}, identity, "Expected an empty identity struct")
+		}
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dexidp/dex
 
-go 1.25.8
+go 1.25.12
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0


### PR DESCRIPTION
The existing Microsoft connector does not support allowedDomains like Google connector or other connectors allows.

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

The existing Microsoft connector does not support allowedDomains like Google connector or other connectors.


#### What this PR does / why we need it

Microsoft connector supports too-open or too-close scenarios (either all organizations/schools or all users or on the other hand only one specific tenant). Our organization needs to approve a list of domains like Google connector supports.
This PR adds the logic to verify the specific domain is approved to receive a token from Dex. 

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
