### PR TITLE
Add ability to override JWKS URL for OIDC connector

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -107,6 +107,9 @@ type ProviderDiscoveryOverrides struct {
 	// AuthURL provides a way to user overwrite the Auth URL
 	// from the .well-known/openid-configuration authorization_endpoint
 	AuthURL string `json:"authURL"`
+	// JWKSURL provides a way to user overwrite the JWKS URL
+	// from the .well-known/openid-configuration jwks_uri
+	JWKSURL string `json:"jwksURL"`
 }
 
 func (o *ProviderDiscoveryOverrides) Empty() bool {
@@ -150,6 +153,9 @@ func getProvider(ctx context.Context, issuer string, overrides ProviderDiscovery
 	}
 	if overrides.AuthURL != "" {
 		config.AuthURL = overrides.AuthURL
+	}
+	if overrides.JWKSURL != "" {
+		config.JWKSURL = overrides.JWKSURL
 	}
 
 	return config.NewProvider(context.Background()), nil


### PR DESCRIPTION


#### Overview

Add an option to override discovered JWKS endpoint for OIDC connector

#### What this PR does / why we need it

closes https://github.com/dexidp/dex/issues/3519

#### Special notes for your reviewer

The test to check the change would have been cumbersome if we had implemented it (because the library doesn't expose the JWKS URL).