### PR TITLE
OIDC connector option to override jwksURI

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -109,7 +109,7 @@ type ProviderDiscoveryOverrides struct {
 	AuthURL string `json:"authURL"`
 	// JWKSURL provides a way to user overwrite the JWKS URL
 	// from the .well-known/openid-configuration jwks_uri
-	JWKSURL string `json:"jwksURL"
+	JWKSURL string `json:"jwksURL"`
 }
 
 func (o *ProviderDiscoveryOverrides) Empty() bool {

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -107,10 +107,13 @@ type ProviderDiscoveryOverrides struct {
 	// AuthURL provides a way to user overwrite the Auth URL
 	// from the .well-known/openid-configuration authorization_endpoint
 	AuthURL string `json:"authURL"`
+	// JWKSURL provides a way to user overwrite the JWKS URL
+	// from the .well-known/openid-configuration jwks_uri
+	JWKSURL string `json:"jwksURL"
 }
 
 func (o *ProviderDiscoveryOverrides) Empty() bool {
-	return o.TokenURL == "" && o.AuthURL == ""
+	return o.TokenURL == "" && o.AuthURL == "" && o.JWKSURL == ""
 }
 
 func getProvider(ctx context.Context, issuer string, overrides ProviderDiscoveryOverrides) (*oidc.Provider, error) {
@@ -151,7 +154,9 @@ func getProvider(ctx context.Context, issuer string, overrides ProviderDiscovery
 	if overrides.AuthURL != "" {
 		config.AuthURL = overrides.AuthURL
 	}
-
+	if overrides.JWKSURL != "" {
+		config.JWKSURL = overrides.JWKSURL
+	}
 	return config.NewProvider(context.Background()), nil
 }
 

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -652,7 +652,7 @@ func TestProviderOverride(t *testing.T) {
 		conn, err := newConnector(Config{
 			Issuer:                     testServer.URL,
 			Scopes:                     []string{"openid", "groups"},
-			ProviderDiscoveryOverrides: ProviderDiscoveryOverrides{TokenURL: "/test1", AuthURL: "/test2", JWKSURL:"/test3"},
+			ProviderDiscoveryOverrides: ProviderDiscoveryOverrides{TokenURL: "/test1", AuthURL: "/test2"},
 		})
 		if err != nil {
 			t.Fatal("failed to create new connector", err)
@@ -666,11 +666,6 @@ func TestProviderOverride(t *testing.T) {
 		expToken := "/test1"
 		if conn.provider.Endpoint().TokenURL != expToken {
 			t.Fatalf("unexpected token URL: %s, expected: %s\n", conn.provider.Endpoint().TokenURL, expToken)
-		}
-
-		expJWKS := "/test3"
-		if conn.provider.Endpoint().JWKSURL != expJWKS {
-			t.Fatalf("unexpected JWKS URL: %s, expected: %s\n", conn.provider.Endpoint().JWKSURL, expJWKS)
 		}
 	})
 }

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -652,7 +652,7 @@ func TestProviderOverride(t *testing.T) {
 		conn, err := newConnector(Config{
 			Issuer:                     testServer.URL,
 			Scopes:                     []string{"openid", "groups"},
-			ProviderDiscoveryOverrides: ProviderDiscoveryOverrides{TokenURL: "/test1", AuthURL: "/test2"},
+			ProviderDiscoveryOverrides: ProviderDiscoveryOverrides{TokenURL: "/test1", AuthURL: "/test2", JWKSURL:"/test3"},
 		})
 		if err != nil {
 			t.Fatal("failed to create new connector", err)
@@ -666,6 +666,11 @@ func TestProviderOverride(t *testing.T) {
 		expToken := "/test1"
 		if conn.provider.Endpoint().TokenURL != expToken {
 			t.Fatalf("unexpected token URL: %s, expected: %s\n", conn.provider.Endpoint().TokenURL, expToken)
+		}
+
+		expJWKS := "/test3"
+		if conn.provider.Endpoint().JWKSURL != expJWKS {
+			t.Fatalf("unexpected JWKS URL: %s, expected: %s\n", conn.provider.Endpoint().JWKSURL, expJWKS)
 		}
 	})
 }


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

- It gives option to override the value of jwks_uri received from .well-known/openid-configurations and allows to use user supplied custom url. 
  Usage:  "Closes (#3519)"


#### Special notes for your reviewer

