### PR TITLE
introduce Provenance Attestation

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -39,10 +39,12 @@ jobs:
           - distroless
 
     permissions:
+      attestations: write
       contents: read
       packages: write
       id-token: write
       security-events: write
+
 
     outputs:
       name: ${{ steps.image-name.outputs.value }}
@@ -174,6 +176,22 @@ jobs:
       #     name: "[${{ github.job }}] SBOM"
       #     path: sbom-spdx.json
       #     retention-days: 5
+
+      # TODO: uncomment when the action is working for non ghcr.io pushes. GH Issue: https://github.com/actions/attest-build-provenance/issues/80
+      # - name: Generate build provenance attestation
+      #   uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+      #   with:
+      #     subject-name: dexidp/dex
+      #     subject-digest: ${{ steps.build.outputs.digest }}
+      #     push-to-registry: true
+
+      - name: Generate build provenance attestation
+        uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+        with:
+          subject-name: ghcr.io/dexidp/dex
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+        if: inputs.publish
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@b2933f565dbc598b29947660e66259e3c7bc8561 # 0.20.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,6 +159,7 @@ jobs:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     permissions:
+      attestations: write
       contents: read
       packages: write
       id-token: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,7 @@ jobs:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     permissions:
+      attestations: write
       contents: read
       packages: write
       id-token: write


### PR DESCRIPTION
#### Overview

Add Provenance Attestation using GitHub Action and sigstore (https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/)

#### What this PR does / why we need it

This adds the provenance attestation and push the attestation to the same registry as the image.
- per a limitation for the action it only pushes to `ghcr.io` and not to docker.io 


Rehearsal: 
job: https://github.com/cpanato/dex/actions/runs/9252829376/job/25451249054

attestation: https://github.com/cpanato/dex/attestations/921641 and attestation image: `ghcr.io/cpanato/dex@sha256:8e5d24d7a0f0fe95bbdf6722e1c724075d5d4c15cfa8d0ef4959f25103e12bac ` 

to verify
```
$ gh attestation verify oci://ghcr.io/cpanato/dex@sha256:8e5d24d7a0f0fe95bbdf6722e1c724075d5d4c15cfa8d0ef4959f25103e12bac --owner cpanato
Loaded digest sha256:8e5d24d7a0f0fe95bbdf6722e1c724075d5d4c15cfa8d0ef4959f25103e12bac for oci://ghcr.io/cpanato/dex@sha256:8e5d24d7a0f0fe95bbdf6722e1c724075d5d4c15cfa8d0ef4959f25103e12bac
Loaded 1 attestation from GitHub API
✓ Verification succeeded!

sha256:8e5d24d7a0f0fe95bbdf6722e1c724075d5d4c15cfa8d0ef4959f25103e12bac was attested by:
REPO         PREDICATE_TYPE                  WORKFLOW
cpanato/dex  https://slsa.dev/provenance/v1  .github/workflows/artifacts.yaml@refs/tags/v9.9.1
```

xref: https://github.com/dexidp/dex/issues/2865

#### Special notes for your reviewer

cc @justaugustus @sagikazarmark 