### PR TITLE
Prevent double clicking of the submit button on login

### DIFF
--- a/web/static/form.js
+++ b/web/static/form.js
@@ -1,4 +1,0 @@
-document.querySelector('form').onsubmit = function(e) {
-    var el = document.querySelector('#submit-login');
-    el.setAttribute('disabled', 'disabled');
-};

--- a/web/static/form.js
+++ b/web/static/form.js
@@ -1,0 +1,4 @@
+document.querySelector('form').onsubmit = function(e) {
+    var el = document.querySelector('#submit-login');
+    el.setAttribute('disabled', 'disabled');
+};

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -32,6 +32,11 @@ body {
   outline: none;
 }
 
+.dex-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .dex-btn-icon {
   background-position: center;
   background-repeat: no-repeat;

--- a/web/templates/password.html
+++ b/web/templates/password.html
@@ -32,6 +32,12 @@
   {{ end }}
 </div>
 
-<script type="text/javascript" src="{{ url .ReqPath "/static/form.js" }}"></script>
+
+<script type="text/javascript">
+  document.querySelector('form').onsubmit = function(e) {
+    var el = document.querySelector('#submit-login');
+    el.setAttribute('disabled', 'disabled');
+  };
+</script>
 
 {{ template "footer.html" . }}

--- a/web/templates/password.html
+++ b/web/templates/password.html
@@ -32,4 +32,6 @@
   {{ end }}
 </div>
 
+<script type="text/javascript" src="{{ url .ReqPath "/static/form.js" }}"></script>
+
 {{ template "footer.html" . }}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->
Disables the submit button on login to prevent clicking multiple times while waiting for a response from the form submission on login.

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
When connecting to a very slow provider a response can take several seconds, without a visual indicator users click the submit button several times. After multiple clicks when a response is returned it's often a 500 error page within our setup. Better to prevent the user from submitting the form multiple times and indicating that by disabling the button.

We can solve this issue internally by having a custom frontend documented here https://dexidp.io/docs/guides/templates/ but this felt like a good thing to share more widely to help others.

#### Special notes for your reviewer

If necessary the following can be rewritten inline to avoid loading a unique JS file.
