### PR TITLE
feat: new Prometheus metrics build_info

### DIFF
--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -58,7 +58,7 @@ var (
 			Namespace: "dex",
 			Help:      "A metric with a constant '1' value labeled by version from which Dex was built.",
 		},
-		[]string{"version", "goversion", "goarch"},
+		[]string{"version", "go_version", "platform"},
 	)
 )
 
@@ -725,5 +725,5 @@ func loadTLSConfig(certFile, keyFile, caFile string, baseConfig *tls.Config) (*t
 
 // recordBuildInfo publishes information about Dex version and runtime info through an info metric (gauge).
 func recordBuildInfo() {
-	buildInfo.WithLabelValues(version, runtime.Version(), runtime.GOARCH).Set(1)
+	buildInfo.WithLabelValues(version, runtime.Version(), fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)).Set(1)
 }

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -54,8 +54,9 @@ type serveOptions struct {
 var (
 	buildInfo = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "build_info",
-			Help: "A metric with a constant '1' value labeled by version from which Dex was built.",
+			Name:      "build_info",
+			Namespace: "dex",
+			Help:      "A metric with a constant '1' value labeled by version from which Dex was built.",
 		},
 		[]string{"version", "goversion", "goarch"},
 	)
@@ -126,7 +127,7 @@ func runServe(options serveOptions) error {
 	logger.Infof("config issuer: %s", c.Issuer)
 
 	prometheusRegistry := prometheus.NewRegistry()
-	
+
 	prometheusRegistry.MustRegister(buildInfo)
 	recordBuildInfo()
 

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -51,15 +51,13 @@ type serveOptions struct {
 	grpcAddr      string
 }
 
-var (
-	buildInfo = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name:      "build_info",
-			Namespace: "dex",
-			Help:      "A metric with a constant '1' value labeled by version from which Dex was built.",
-		},
-		[]string{"version", "go_version", "platform"},
-	)
+var buildInfo = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name:      "build_info",
+		Namespace: "dex",
+		Help:      "A metric with a constant '1' value labeled by version from which Dex was built.",
+	},
+	[]string{"version", "go_version", "platform"},
 )
 
 func commandServe() *cobra.Command {

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -727,11 +727,3 @@ func loadTLSConfig(certFile, keyFile, caFile string, baseConfig *tls.Config) (*t
 func recordBuildInfo() {
 	buildInfo.WithLabelValues(version, runtime.Version(), runtime.GOARCH).Set(1)
 }
-
-// logger.Infof(
-// 	"Dex Version: %s, Go Version: %s, Go OS/ARCH: %s %s",
-// 	version,
-// 	runtime.Version(),
-// 	runtime.GOOS,
-// 	runtime.GOARCH,
-// )


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->

Add a new metric `dex_build_info`, with `version` which will be set to the Git tag version.

```
$ curl -s http://127.0.0.1:5558/metrics | grep build
# HELP dex_build_info A metric with a constant '1' value labeled by version from which Dex was built.
# TYPE dex_build_info gauge
dex_build_info{goarch="arm64",goversion="go1.22.2",version="43a9a144a710803b6a3036368cec3bec9f6f02de-dirty"} 1 
```

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
