### PR TITLE
fix: always retrieve github emails when `preferredEmailDomain` is set

### DIFF
--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -531,9 +531,10 @@ func (c *githubConnector) user(ctx context.Context, client *http.Client) (user, 
 		return u, err
 	}
 
-	// Only public user emails are returned by 'GET /user'. u.Email will be empty
-	// if a users' email is private. We must retrieve private emails explicitly.
-	if u.Email == "" {
+	// Only public user emails are returned by 'GET /user'.
+	// If a user has no public email, we must retrieve private emails explicitly.
+	// If preferredEmailDomain is set, we always need to retrieve all emails.
+	if u.Email == "" || c.preferredEmailDomain != "" {
 		var err error
 		if u.Email, err = c.userEmail(ctx, client); err != nil {
 			return u, err


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

As discussed in https://github.com/dexidp/website/pull/176, even when `preferredEmailDomain` (which was added by https://github.com/dexidp/dex/pull/2740) is set on the GitHub connector, if the user has a __public__ email on their GitHub profile, it will take precedence over any private one which might match the `preferredEmailDomain` selector.

This is problematic for organizations which want to use the email filter to assign permissions to employees based on their corporate email, as they must tell users to remove any public emails from their profile.

## What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

Simply makes it so that we always preform an email check when `preferredEmailDomain` is non empty.

## Special notes for your reviewer

N/A