### PR TITLE
Gracefully handle no args being passed to entrypoint

### DIFF
--- a/cmd/docker-entrypoint/main.go
+++ b/cmd/docker-entrypoint/main.go
@@ -17,6 +17,10 @@ func main() {
 	// Note that this docker-entrypoint program is args[0], and it is provided with the true process
 	// args.
 	args := os.Args[1:]
+	if len(args) == 0 {
+		fmt.Println("error: no args passed to entrypoint")
+		os.Exit(1)
+	}
 
 	if err := run(args, realExec, realWhich); err != nil {
 		fmt.Println("error:", err.Error())


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

This is a minor change to prevent a panic in an admittedly niche edge case.

#### What this PR does / why we need it

This PR gracefully handles no args being passed to the entrypoint binary.
```sh
# before
./docker-entrypoint
panic: runtime error: index out of range [0] with length 0
goroutine 1 [running]:
main.run({0xc000014140?, 0xc00006e740?, 0x0?}, 0x60?, 0x0?)
/usr/local/src/dex/cmd/docker-entrypoint/main.go:56 +0x5c5
main.main()
/usr/local/src/dex/cmd/docker-entrypoint/main.go:21 +0x65

# after
./docker-entrypoint 
error: no args passed to entrypoint
```

This can occur if someone builds upon the upstream dex image (e.g., adding internal company certificates) and inadvertently breaks the entrypoint/cmd.

#### Special notes for your reviewer
