### PR TITLE
fix: propagate http.Client to JWT verifier for OIDC connector

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -263,7 +263,8 @@ func (c *Config) Open(id string, logger *slog.Logger) (conn connector.Connector,
 			Scopes:       scopes,
 			RedirectURL:  c.RedirectURI,
 		},
-		verifier: provider.Verifier(
+		verifier: provider.VerifierContext(
+			ctx, // Pass our ctx with customized http.Client
 			&oidc.Config{ClientID: clientID},
 		),
 		logger:                    logger.With(slog.Group("connector", "type", "oidc", "id", id)),


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

The OIDC connector has two options that directly customize the http.Client used for requests: [`rootCAs`](https://github.com/dexidp/dex/blob/23a53a80f664649ff77be9a21eb279b0ecf01678/connector/oidc/oidc.go#L52) and [`insecureSkipVerify`](https://github.com/dexidp/dex/blob/23a53a80f664649ff77be9a21eb279b0ecf01678/connector/oidc/oidc.go#L67) (passed [here](https://github.com/dexidp/dex/blob/23a53a80f664649ff77be9a21eb279b0ecf01678/connector/oidc/oidc.go#L214) to http.Client [here](https://github.com/dexidp/dex/blob/23a53a80f664649ff77be9a21eb279b0ecf01678/pkg/httpclient/httpclient.go#L19)).

That customized http.Client isn't currently propagated through to the JWT verifier. This means that the verifier's requests to the JWKS endpoint can unexpectedly fail with certificate issues.

<details>
<summary>Example of an error caused by this inconsistency</summary>

Truncated sample configuration describing our setup:

```
connectors:
  - type: oidc
    # omitting other config
    issuer: https://<in-cluster-hostname>.svc.cluster.local
    insecureSkipVerify: true
    providerDiscoveryOverrides:
      authURL: https://<public-hostname-behind-auth-proxy>.org
```

Dex's communication with the provider should be inside the Kubernetes cluster so Dex doesn't need to worry about the authenticating proxy in front of the public URLs. Dex logs the following error upon attempted login:

```
Failed to authenticate: oidc: failed to verify ID Token: failed to verify signature: fetching keys oidc: get keys failed Get \"https://<in-cluster-hostname>.svc.cluster.local/keys\": tls: failed to verify certificate: x509: certificate is valid for <public-hostname-behind-auth-proxy>.org, not <in-cluster-hostname>.svc.cluster.local
```

Even if we were to self-sign certificates for in-cluster hostnames, we wouldn't be able to use the `rootCAs` option to make the verifier respect that either.

</details>

#### What this PR does / why we need it

- Call coreos/go-oidc's [Provider.VerifierContext](https://pkg.go.dev/github.com/coreos/go-oidc/v3/oidc@v3.11.0#Provider.VerifierContext) instead of [Provider.Verifier](https://pkg.go.dev/github.com/coreos/go-oidc/v3/oidc@v3.11.0#Provider.Verifier), so we can pass the same ctx-with-customized-http.Client that's used elsewhere.
  - The docs for those functions specifically say to use VerifierContext to configure how requests are made.
  - The call chain for those interested is [1](https://github.com/coreos/go-oidc/blob/v3.11.0/oidc/verify.go#L126), [2](https://github.com/coreos/go-oidc/blob/v3/oidc/jwks.go#L60), [3](https://github.com/coreos/go-oidc/blob/v3/oidc/jwks.go#L76), [4](https://github.com/coreos/go-oidc/blob/v3/oidc/jwks.go#L248), [5](https://github.com/coreos/go-oidc/blob/v3/oidc/oidc.go#L89), [6](https://github.com/coreos/go-oidc/blob/v3/oidc/oidc.go#L62), and the client is set in the ctx [here](https://github.com/dexidp/dex/blob/master/connector/oidc/oidc.go#L220).

#### Special notes for your reviewer

This PR closely follows prior art from #2781.

It doesn't appear that there's a great way to test this sort of TLS behavior here; #2781 didn't include tests either. **We're currently running this patch in production and it's solved the issue.** I suppose it'd be possible to reach into the JWT verifier with reflection to check that the ctx has the expected value set... but that seems brittle to me. Happy for suggestions.