### PR TITLE
chore: update nix-direnv from 1.5.0 to 3.0.5

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,7 @@
-if ! has nix_direnv_version || ! nix_direnv_version 1.5.0; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/1.5.0/direnvrc" "sha256-carKk9aUFHMuHt+IWh74hFj58nY4K3uywpZbwXX0BTI="
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.5; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.5/direnvrc" "sha256-RuwIS+QKFj/T9M2TFXScjBsLR6V3A17YVoEW/Q6AZ1w="
 fi
+
 use flake
 
 dotenv_if_exists


### PR DESCRIPTION
#### Overview

Update `nix-direnv` in the `.envrc` file to the newest version.

#### What this PR does / why we need it

The current nix-direnv version has issues on MacOS due to BSD sed differing from GNU sed. This has been fixed in nix-direnv https://github.com/nix-community/nix-direnv/issues/120 
Updating to the newest nix-direnv version fixes this issue.

#### Special notes for your reviewer
