### PR TITLE
Fixed the unescaped redirect_uri issue (#2766)

### DIFF
--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -457,7 +457,8 @@ func (s *Server) parseAuthorizationRequest(r *http.Request) (*storage.AuthReques
 		return nil, newDisplayedErr(http.StatusBadRequest, "Failed to parse request.")
 	}
 	q := r.Form
-	redirectURI, err := url.QueryUnescape(q.Get("redirect_uri"))
+	redirectURI := q.Get("redirect_uri")
+	_, err := url.QueryUnescape(redirectURI)
 	if err != nil {
 		return nil, newDisplayedErr(http.StatusBadRequest, "No redirect_uri provided.")
 	}


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

This request solves the issue that happened due to an insufficient comparison processing of the redirect_uri query parameter.

#### What this PR does / why we need it

Closes #2766

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

In the dex server configuration, the "redirect_uri" must be specified by the escaped format.

```
redirectURIs:
  - http://localhost:8000/mediawiki/index.php/%E7%89%B9%E5%88%A5:PluggableAuthLogin
```