### PR TITLE
authproxy connector: add support for specifying group header separator

### DIFF
--- a/connector/authproxy/authproxy.go
+++ b/connector/authproxy/authproxy.go
@@ -19,11 +19,12 @@ import (
 // Headers retrieved to fetch user's email and group can be configured
 // with userHeader and groupHeader.
 type Config struct {
-	UserIDHeader string   `json:"userIDHeader"`
-	UserHeader   string   `json:"userHeader"`
-	EmailHeader  string   `json:"emailHeader"`
-	GroupHeader  string   `json:"groupHeader"`
-	Groups       []string `json:"staticGroups"`
+	UserIDHeader         string   `json:"userIDHeader"`
+	UserHeader           string   `json:"userHeader"`
+	EmailHeader          string   `json:"emailHeader"`
+	GroupHeader          string   `json:"groupHeader"`
+	GroupHeaderSeparator string   `json:"groupHeaderSeparator"`
+	Groups               []string `json:"staticGroups"`
 }
 
 // Open returns an authentication strategy which requires no user interaction.
@@ -44,28 +45,34 @@ func (c *Config) Open(id string, logger *slog.Logger) (connector.Connector, erro
 	if groupHeader == "" {
 		groupHeader = "X-Remote-Group"
 	}
+	groupHeaderSeparator := c.GroupHeaderSeparator
+	if groupHeaderSeparator == "" {
+		groupHeaderSeparator = ","
+	}
 
 	return &callback{
-		userIDHeader: userIDHeader,
-		userHeader:   userHeader,
-		emailHeader:  emailHeader,
-		groupHeader:  groupHeader,
-		groups:       c.Groups,
-		logger:       logger.With(slog.Group("connector", "type", "authproxy", "id", id)),
-		pathSuffix:   "/" + id,
+		userIDHeader:         userIDHeader,
+		userHeader:           userHeader,
+		emailHeader:          emailHeader,
+		groupHeader:          groupHeader,
+		groupHeaderSeparator: groupHeaderSeparator,
+		groups:               c.Groups,
+		logger:               logger.With(slog.Group("connector", "type", "authproxy", "id", id)),
+		pathSuffix:           "/" + id,
 	}, nil
 }
 
 // Callback is a connector which returns an identity with the HTTP header
 // X-Remote-User as verified email.
 type callback struct {
-	userIDHeader string
-	userHeader   string
-	emailHeader  string
-	groupHeader  string
-	groups       []string
-	logger       *slog.Logger
-	pathSuffix   string
+	userIDHeader         string
+	userHeader           string
+	emailHeader          string
+	groupHeader          string
+	groupHeaderSeparator string
+	groups               []string
+	logger               *slog.Logger
+	pathSuffix           string
 }
 
 // LoginURL returns the URL to redirect the user to login with.
@@ -98,7 +105,7 @@ func (m *callback) HandleCallback(s connector.Scopes, r *http.Request) (connecto
 	groups := m.groups
 	headerGroup := r.Header.Get(m.groupHeader)
 	if headerGroup != "" {
-		splitheaderGroup := strings.Split(headerGroup, ",")
+		splitheaderGroup := strings.Split(headerGroup, m.groupHeaderSeparator)
 		for i, v := range splitheaderGroup {
 			splitheaderGroup[i] = strings.TrimSpace(v)
 		}

--- a/connector/authproxy/authproxy_test.go
+++ b/connector/authproxy/authproxy_test.go
@@ -25,10 +25,10 @@ const (
 var logger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
 
 func TestUser(t *testing.T) {
-	config := Config{
-		UserHeader: "X-Remote-User",
-	}
-	conn := callback{userHeader: config.UserHeader, logger: logger, pathSuffix: "/test"}
+	config := Config{}
+
+	conn, _ := config.Open("test", logger)
+	callback := conn.(*callback)
 
 	req, err := http.NewRequest("GET", "/", nil)
 	expectNil(t, err)
@@ -36,7 +36,7 @@ func TestUser(t *testing.T) {
 		"X-Remote-User": {testUsername},
 	}
 
-	ident, err := conn.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
 	expectNil(t, err)
 
 	// If not specified, the userID and email should fall back to the remote user
@@ -48,18 +48,10 @@ func TestUser(t *testing.T) {
 }
 
 func TestExtraHeaders(t *testing.T) {
-	config := Config{
-		UserIDHeader: "X-Remote-User-Id",
-		UserHeader:   "X-Remote-User",
-		EmailHeader:  "X-Remote-User-Email",
-	}
-	conn := callback{
-		userHeader:   config.UserHeader,
-		userIDHeader: config.UserIDHeader,
-		emailHeader:  config.EmailHeader,
-		logger:       logger,
-		pathSuffix:   "/test",
-	}
+	config := Config{}
+
+	conn, _ := config.Open("test", logger)
+	callback := conn.(*callback)
 
 	req, err := http.NewRequest("GET", "/", nil)
 	expectNil(t, err)
@@ -69,7 +61,7 @@ func TestExtraHeaders(t *testing.T) {
 		"X-Remote-User-Email": {testEmail},
 	}
 
-	ident, err := conn.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
 	expectNil(t, err)
 
 	expectEquals(t, ident.UserID, testUserID)
@@ -80,12 +72,10 @@ func TestExtraHeaders(t *testing.T) {
 }
 
 func TestSingleGroup(t *testing.T) {
-	config := Config{
-		UserHeader:  "X-Remote-User",
-		GroupHeader: "X-Remote-Group",
-	}
+	config := Config{}
 
-	conn := callback{userHeader: config.UserHeader, groupHeader: config.GroupHeader, logger: logger, pathSuffix: "/test"}
+	conn, _ := config.Open("test", logger)
+	callback := conn.(*callback)
 
 	req, err := http.NewRequest("GET", "/", nil)
 	expectNil(t, err)
@@ -94,7 +84,7 @@ func TestSingleGroup(t *testing.T) {
 		"X-Remote-Group": {testGroup1},
 	}
 
-	ident, err := conn.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
 	expectNil(t, err)
 
 	expectEquals(t, ident.UserID, testEmail)
@@ -103,12 +93,10 @@ func TestSingleGroup(t *testing.T) {
 }
 
 func TestMultipleGroup(t *testing.T) {
-	config := Config{
-		UserHeader:  "X-Remote-User",
-		GroupHeader: "X-Remote-Group",
-	}
+	config := Config{}
 
-	conn := callback{userHeader: config.UserHeader, groupHeader: config.GroupHeader, logger: logger, pathSuffix: "/test"}
+	conn, _ := config.Open("test", logger)
+	callback := conn.(*callback)
 
 	req, err := http.NewRequest("GET", "/", nil)
 	expectNil(t, err)
@@ -117,7 +105,33 @@ func TestMultipleGroup(t *testing.T) {
 		"X-Remote-Group": {testGroup1 + ", " + testGroup2 + ", " + testGroup3 + ", " + testGroup4},
 	}
 
-	ident, err := conn.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	expectNil(t, err)
+
+	expectEquals(t, ident.UserID, testEmail)
+	expectEquals(t, len(ident.Groups), 4)
+	expectEquals(t, ident.Groups[0], testGroup1)
+	expectEquals(t, ident.Groups[1], testGroup2)
+	expectEquals(t, ident.Groups[2], testGroup3)
+	expectEquals(t, ident.Groups[3], testGroup4)
+}
+
+func TestMultipleGroupWithCustomSeparator(t *testing.T) {
+	config := Config{
+		GroupHeaderSeparator: ";",
+	}
+
+	conn, _ := config.Open("test", logger)
+	callback := conn.(*callback)
+
+	req, err := http.NewRequest("GET", "/", nil)
+	expectNil(t, err)
+	req.Header = map[string][]string{
+		"X-Remote-User":  {testEmail},
+		"X-Remote-Group": {testGroup1 + ";" + testGroup2 + ";" + testGroup3 + ";" + testGroup4},
+	}
+
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
 	expectNil(t, err)
 
 	expectEquals(t, ident.UserID, testEmail)
@@ -130,12 +144,11 @@ func TestMultipleGroup(t *testing.T) {
 
 func TestStaticGroup(t *testing.T) {
 	config := Config{
-		UserHeader:  "X-Remote-User",
-		GroupHeader: "X-Remote-Group",
-		Groups:      []string{"static1", "static 2"},
+		Groups: []string{"static1", "static 2"},
 	}
 
-	conn := callback{userHeader: config.UserHeader, groupHeader: config.GroupHeader, groups: config.Groups, logger: logger, pathSuffix: "/test"}
+	conn, _ := config.Open("test", logger)
+	callback := conn.(*callback)
 
 	req, err := http.NewRequest("GET", "/", nil)
 	expectNil(t, err)
@@ -144,7 +157,7 @@ func TestStaticGroup(t *testing.T) {
 		"X-Remote-Group": {testGroup1 + ", " + testGroup2 + ", " + testGroup3 + ", " + testGroup4},
 	}
 
-	ident, err := conn.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
 	expectNil(t, err)
 
 	expectEquals(t, ident.UserID, testEmail)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

This change proposes making the group header splitter configurable so a value other than `,` can be used. 

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

Motivated as the groups header is not universally a `,`. For example the default group separator in mod_auth_mellon is `;`.

This change intends to be fully backwards compatible. I also refactored the tests slightly to exercise more of the production code and reduce duplication.

Please let me know if you have any feedback, more than happy to address any items.

