### PR TITLE
Add support to PKCE in OIDC connector

### DIFF
--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -66,6 +66,7 @@ func TestHandleCallback(t *testing.T) {
 		token                     map[string]interface{}
 		groupsRegex               string
 		newGroupFromClaims        []NewGroupFromClaims
+		pkceChallenge             string
 	}{
 		{
 			name:               "simpleCase",
@@ -382,6 +383,40 @@ func TestHandleCallback(t *testing.T) {
 				"email_verified": true,
 			},
 		},
+		{
+			name:               "S256PKCEChallenge",
+			userIDKey:          "", // not configured
+			userNameKey:        "", // not configured
+			pkceChallenge:      "S256",
+			expectUserID:       "subvalue",
+			expectUserName:     "namevalue",
+			expectGroups:       []string{"group1", "group2"},
+			expectedEmailField: "emailvalue",
+			token: map[string]interface{}{
+				"sub":            "subvalue",
+				"name":           "namevalue",
+				"groups":         []string{"group1", "group2"},
+				"email":          "emailvalue",
+				"email_verified": true,
+			},
+		},
+		{
+			name:               "plainPKCEChallenge",
+			userIDKey:          "", // not configured
+			userNameKey:        "", // not configured
+			pkceChallenge:      "plain",
+			expectUserID:       "subvalue",
+			expectUserName:     "namevalue",
+			expectGroups:       []string{"group1", "group2"},
+			expectedEmailField: "emailvalue",
+			token: map[string]interface{}{
+				"sub":            "subvalue",
+				"name":           "namevalue",
+				"groups":         []string{"group1", "group2"},
+				"email":          "emailvalue",
+				"email_verified": true,
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -413,6 +448,7 @@ func TestHandleCallback(t *testing.T) {
 				InsecureEnableGroups:      true,
 				BasicAuthUnsupported:      &basicAuth,
 				OverrideClaimMapping:      tc.overrideClaimMapping,
+				PKCEChallenge:             tc.pkceChallenge,
 			}
 			config.ClaimMapping.PreferredUsernameKey = tc.preferredUsernameKey
 			config.ClaimMapping.EmailKey = tc.emailKey


### PR DESCRIPTION
#### Overview

This PR adds support to PKCE in the OIDC connector.

#### What this PR does / why we need it

Dex currently does't supports PKCE for upstream OIDC providers.
The PKCE flow requires a code challenge to be passed to the authorization_endpoint and a code verifier.
* It uses dynamic configuration using the OAuth2 discovery metadata (supports S256 and plain).
* It's possibile (but optional) to specify an algorithm to use in the PKCEChallenge key of the connector's config.
* The generated code changes with each login session, so it supports multiple login sessions at the same time.

#### Does this PR introduce a user-facing change?
* Adds the OIDC connector configuration optional option `PKCEChallenge` to specify an algorithm to use in the PKCE flow.

#### Special notes for your reviewer

Related PRs: 

- #3188 
- #3195 
- #3162 

Related discussions:

- #2253 
- #3741