### PR TITLE
feat: also allow localhost equivalent IP addresses

### DIFF
--- a/server/oauth2_test.go
+++ b/server/oauth2_test.go
@@ -452,6 +452,27 @@ func TestValidRedirectURI(t *testing.T) {
 			redirectURI: "http://localhost",
 			wantValid:   true,
 		},
+		{
+			client: storage.Client{
+				Public: true,
+			},
+			redirectURI: "http://127.0.0.1:8080/",
+			wantValid:   true,
+		},
+		{
+			client: storage.Client{
+				Public: true,
+			},
+			redirectURI: "http://127.0.0.1:991/bar",
+			wantValid:   true,
+		},
+		{
+			client: storage.Client{
+				Public: true,
+			},
+			redirectURI: "http://127.0.0.1",
+			wantValid:   true,
+		},
 		// Both Public + RedirectURIs configured: Could e.g. be a PKCE-enabled web app.
 		{
 			client: storage.Client{


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Instead of only checking for "localhost", also validate through `net.ParseIP` + `IsLoopback` whether the host is numerically localhost

#### What this PR does / why we need it

Currently, `localhost` is already used as a special case that allows any port and http scheme if no particular redirectURIs are configured. When integrating with ownClouds desktop client, it actually sends an arbitrary `http://127.0.0.1:xyz` redirect uri. Considering that the go standard library already has the functionality to check if a given IP is a loopback address, we can extend the `== "localhost"` with also a check for `IsLoopback()` which should allow the ownCloud desktop client to be accepted.

#### Special notes for your reviewer
