### PR TITLE
Add logic for collect user project for Gitlab connector

### DIFF
--- a/connector/gitlab/gitlab.go
+++ b/connector/gitlab/gitlab.go
@@ -111,7 +111,7 @@ func (c *gitlabConnector) oauth2Config(scopes connector.Scopes) *oauth2.Config {
 		gitlabScopes = []string{scopeUser, scopeOpenID}
 	}
 	if c.getProjects {
-		gitlabScopes = append(gitlabScopes, scopeReadApi)
+		gitlabScopes = append(gitlabScopes, scopeReadAPI)
 	}
 
 	gitlabEndpoint := oauth2.Endpoint{AuthURL: c.baseURL + "/oauth/authorize", TokenURL: c.baseURL + "/oauth/token"}


### PR DESCRIPTION
This PR is a logical continuation of [that one](https://github.com/dexidp/dex/pull/2941).

In this PR I add new flag for Gitlab connector - `getProjects`. If this flag set to true, and Gitlab Application have API access (`read_api scope`) - all user project with permission more than 30 (developer), will be added to user Group


```release-note
GitLab connector: add user projects to user groups
```