### PR TITLE
Introducing Dex Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/dexidp/dex/badge?style=flat-square)](https://api.securityscorecards.dev/projects/github.com/dexidp/dex)
 [![Go Report Card](https://goreportcard.com/badge/github.com/dexidp/dex?style=flat-square)](https://goreportcard.com/report/github.com/dexidp/dex)
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod&style=flat-square)](https://gitpod.io/#https://github.com/dexidp/dex)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Dex%20Guru-006BFF?style=flat-square)](https://gurubase.io/g/dex)
 
 ![logo](docs/logos/dex-horizontal-color.png)
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Dex Guru](https://gurubase.io/g/dex) to Gurubase. Dex Guru uses the data from this repo and data from the [docs](https://dexidp.io/docs/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Dex Guru", which highlights that Dex now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Dex Guru in Gurubase, just let me know that's totally fine.
