### PR TITLE
Generate access tokens for implicit & hybrid flows only when needed

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -717,8 +717,6 @@ func (s *Server) sendCodeResponse(w http.ResponseWriter, r *http.Request, authRe
 			}
 		case responseTypeToken:
 			implicitOrHybrid = true
-		case responseTypeIDToken:
-			implicitOrHybrid = true
 			var err error
 
 			accessToken, _, err = s.newAccessToken(r.Context(), authReq.ClientID, authReq.Claims, authReq.Scopes, authReq.Nonce, authReq.ConnectorID)
@@ -727,6 +725,9 @@ func (s *Server) sendCodeResponse(w http.ResponseWriter, r *http.Request, authRe
 				s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
 				return
 			}
+		case responseTypeIDToken:
+			implicitOrHybrid = true
+			var err error
 
 			idToken, idTokenExpiry, err = s.newIDToken(r.Context(), authReq.ClientID, authReq.Claims, authReq.Scopes, authReq.Nonce, accessToken, code.ID, authReq.ConnectorID)
 			if err != nil {
@@ -739,12 +740,10 @@ func (s *Server) sendCodeResponse(w http.ResponseWriter, r *http.Request, authRe
 
 	if implicitOrHybrid {
 		v := url.Values{}
-		v.Set("access_token", accessToken)
-		v.Set("token_type", "bearer")
-		v.Set("state", authReq.State)
-		if idToken != "" {
-			v.Set("id_token", idToken)
-			// The hybrid flow with only "code token" or "code id_token" doesn't return an
+		if accessToken != "" {
+			v.Set("access_token", accessToken)
+			v.Set("token_type", "bearer")
+			// The hybrid flow with "code token" or "code id_token token" doesn't return an
 			// "expires_in" value. If "code" wasn't provided, indicating the implicit flow,
 			// don't add it.
 			//
@@ -752,6 +751,10 @@ func (s *Server) sendCodeResponse(w http.ResponseWriter, r *http.Request, authRe
 			if code.ID == "" {
 				v.Set("expires_in", strconv.Itoa(int(idTokenExpiry.Sub(s.now()).Seconds())))
 			}
+		}
+		v.Set("state", authReq.State)
+		if idToken != "" {
+			v.Set("id_token", idToken)
 		}
 		if code.ID != "" {
 			v.Set("code", code.ID)


### PR DESCRIPTION
#### Overview

Avoid access token generation when `response_type` is either `id_token` (for implicit flow) or `code id_token` (for hybrid flow).

#### What this PR does / why we need it

This PR aims to make dex better follow what is stated in the following sections of the OpenID Connect Core1.0 specification:

- [3.2.2.5. Successful Authentication Response](https://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthResponse) (for implicit flow)
- [3.3.2.5. Successful Authentication Response](https://openid.net/specs/openid-connect-core-1_0.html#HybridAuthResponse) (for hybrid flow)