### PR TITLE
fix: Add ability to get groups dn from memberof attribute.

### DIFF
--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -62,6 +62,8 @@ import (
 type UserMatcher struct {
 	UserAttr  string `json:"userAttr"`
 	GroupAttr string `json:"groupAttr"`
+	// Work only if UserAttr is 'memberOf' and GroupAttr is dn
+	GroupPrefix string `json:"groupPrefix"`
 }
 
 // Config holds configuration options for LDAP logins.
@@ -593,6 +595,49 @@ func (c *ldapConnector) groups(ctx context.Context, user ldap.Entry) ([]string, 
 
 	var groups []*ldap.Entry
 	for _, matcher := range c.GroupSearch.UserMatchers {
+		// When we get groups from memberof user.s entity attribute, we may
+		// don.t want (Or don.t need) to perform extra search query for each group.
+		// Also when groupattr is dn (which implies memberof freeipa), we cannot use
+		// ldapsearch to retrieve group by DN (LDAP restriction)
+		if strings.ToLower(matcher.UserAttr) == "memberof" &&
+			strings.ToLower(matcher.GroupAttr) == "dn" {
+			for _, attr := range c.getAttrs(user, matcher.UserAttr) {
+				// If group dn has no ends with group search base dn - ignore it.
+				// In FreeIPA case, it also can contain hbac, sudo rules, etc...
+				if !strings.HasSuffix(attr, c.GroupSearch.BaseDN) {
+					continue
+				}
+
+				// Trim {NameAttr}= prefix and baseDN suffix to get group name.
+				// For NameAttr=cn and BaseDN=cn=groups,dc=example,dc=com :
+				// cn=groupname,cn=groups,dc=example,dc=com -> groupname
+				groupName := strings.TrimSuffix(
+					strings.TrimPrefix(attr,
+						fmt.Sprintf("%s=", c.GroupSearch.NameAttr)),
+					fmt.Sprintf(",%s", c.GroupSearch.BaseDN))
+
+				// Is it needed compability with GroupSearch.Filter? (r9odt)
+				if !strings.HasPrefix(groupName, matcher.GroupPrefix) {
+					continue
+				}
+
+				// Append result to group list as ldap.Entry to process it next wihtout
+				// extra changes in code.
+				groups = append(groups, &ldap.Entry{
+					DN: attr,
+					Attributes: []*ldap.EntryAttribute{
+						{
+							Name: c.GroupSearch.NameAttr,
+							Values: []string{
+								groupName,
+							},
+						},
+					},
+				})
+			}
+			continue
+		}
+
 		for _, attr := range c.getAttrs(user, matcher.UserAttr) {
 			filter := fmt.Sprintf("(%s=%s)", matcher.GroupAttr, ldap.EscapeFilter(attr))
 			if c.GroupSearch.Filter != "" {


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

In the case of using FreeIPA, the user has a set of memberOf attributes that contain the DNs of groups, sudo rules, and HBAC. The ability to use the memberof-dn combination in UserMatchers has been added to directly retrieve groups from the user entity without additional group queries. Additionally, memberOf values that do not have the suffix defined as BaseDN or do not start with the NameAttr ({NameAttr}=groupname,{BaseDN}) are discarded

#### What this PR does / why we need it

When ldap user like this

```txt
dn: uid=test,cn=users,cn=accounts,dc=example,dc=com
uid: test
displayName: Test User
gecos: Test User
loginShell: /bin/bash
memberOf: cn=ipausers,cn=groups,cn=accounts,dc=example,dc=com
memberOf: cn=admins,cn=groups,cn=accounts,dc=example,dc=com
memberOf: ipaUniqueID=UUIDPLACEHOLDER,cn=hbac,dc=example,dc=com
memberOf: ipaUniqueID=UUIDPLACEHOLDER,cn=sudorules,cn=sudo,dc=example,dc=com
memberOf: cn=wazuh-users,cn=groups,cn=accounts,dc=example,dc=com
memberOf: cn=dex-admins,cn=groups,cn=accounts,dc=example,dc=com
sn: User
givenName: Test
cn: Test User
mail: test@example.com
```

and use

```yaml
groupSearch:
  baseDN: cn=groups,cn=accounts,dc=example,dc=com
  nameAttr: cn
  userMatchers:
    - userAttr: memberOf
      groupAttr: dn
      groupPrefix: dex # work only if userattr is 'memberOf' and groupAttr is dn
```

It allow to get groups of user from user.s entity. For this example expected groups: `dex-admins`
If we use standart functional, it returned no groups, because (i guess), ldapsearch cannot be performed with filter like (dn=ENTITYDN).
Also we can't use `member` properties of groups because nested groups are mapped the same as users and more queries need to be made

#### Special notes for your reviewer
 