### PR TITLE
k8s storage: Request only one object to check if API exists

### DIFF
--- a/storage/kubernetes/storage.go
+++ b/storage/kubernetes/storage.go
@@ -156,7 +156,7 @@ func (cli *client) registerCustomResources() (ok bool) {
 		r := definitions[i]
 		var i interface{}
 		cli.logger.Info("checking if custom resource has already been created...", "object", r.ObjectMeta.Name)
-		if err := cli.list(r.Spec.Names.Plural, &i); err == nil {
+		if err := cli.listN(r.Spec.Names.Plural, &i, 1); err == nil {
 			cli.logger.Info("the custom resource already available, skipping create", "object", r.ObjectMeta.Name)
 			continue
 		} else {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Use limit to reduce data transferred from Kubernetes API server to Dex

#### What this PR does / why we need it

Closes https://github.com/dexidp/dex/issues/4019

#### Special notes for your reviewer
