### PR TITLE
Add a SAML connector option to allows SAML request to be sent using RedirectBinding

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -81,7 +81,7 @@ type SAMLConnector interface {
 	//
 	// POSTData should encode the provided request ID in the returned serialized
 	// SAML request.
-	POSTData(s Scopes, requestID string) (ssoURL, samlRequest string, err error)
+	POSTData(s Scopes, requestID string) (ssoURL, samlRequest string, bindingType string, err error)
 
 	// HandlePOST decodes, verifies, and maps attributes from the SAML response.
 	// It passes the expected value of the "InResponseTo" response field, which

--- a/connector/saml/saml.go
+++ b/connector/saml/saml.go
@@ -399,7 +399,6 @@ func (p *provider) HandlePOST(s connector.Scopes, samlResponse, inResponseTo str
 		return ident, fmt.Errorf("subject does not contain an NameID element")
 	}
 
-
 	// After verifying the assertion, map data in the attribute statements to
 	// various user info.
 	attributes := assertion.AttributeStatement

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -311,7 +311,7 @@ func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 				</body>
 				</html>`, action, value, authReq.ID)
 			} else {
-				s.renderError(r, w, http.StatusInternalServerError, "Invalid binding type")
+				s.renderError(r, w, http.StatusInternalServerError, fmt.Sprintf("Invalid binding type: %s", bindingType))
 				return
 			}
 		default:

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -287,24 +287,8 @@ func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 				s.renderError(r, w, http.StatusInternalServerError, "Connector Login Error")
 				return
 			}
-
-			// TODO(ericchiang): Don't inline this.
-			fmt.Fprintf(w, `<!DOCTYPE html>
-			  <html lang="en">
-			  <head>
-			    <meta http-equiv="content-type" content="text/html; charset=utf-8">
-			    <title>SAML login</title>
-			  </head>
-			  <body>
-			    <form method="post" action="%s" >
-				    <input type="hidden" name="SAMLRequest" value="%s" />
-				    <input type="hidden" name="RelayState" value="%s" />
-			    </form>
-				<script>
-				    document.forms[0].submit();
-				</script>
-			  </body>
-			  </html>`, action, value, authReq.ID)
+			escaped_saml_request := url.QueryEscape(value)
+			http.Redirect(w, r, action+"/saml?SAMLRequest="+escaped_saml_request+"&RelayState="+authReq.ID, http.StatusFound)
 		default:
 			s.renderError(r, w, http.StatusBadRequest, "Requested resource does not exist.")
 		}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Some IDP ( like Canonical's SSO ) systematically drops incoming POST requests. This PR adds the option for Dex to use HTTP redirect to send its SAML request, providing more flexibility.

#### What this PR does / why we need it

This PR adds a new attribute `bindingType` to the SAML connector configuration, the default value is `post` so this won't change the behavior of existing configs. Updating this value to `redirect` will prompt Dex to send the SAML request via a HTTP Get redirect instead.
