### PR TITLE
refactor: simplify tests by using slog.DiscardHandler

### DIFF
--- a/connector/atlassiancrowd/atlassiancrowd_test.go
+++ b/connector/atlassiancrowd/atlassiancrowd_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -150,7 +149,7 @@ type TestServerResponse struct {
 func newTestCrowdConnector(baseURL string) crowdConnector {
 	connector := crowdConnector{}
 	connector.BaseURL = baseURL
-	connector.logger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	connector.logger = slog.New(slog.DiscardHandler)
 	return connector
 }
 

--- a/connector/authproxy/authproxy_test.go
+++ b/connector/authproxy/authproxy_test.go
@@ -1,7 +1,6 @@
 package authproxy
 
 import (
-	"io"
 	"log/slog"
 	"net/http"
 	"reflect"
@@ -23,7 +22,7 @@ const (
 	testUserID            = "1234567890"
 )
 
-var logger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+var logger = slog.New(slog.DiscardHandler)
 
 func TestUser(t *testing.T) {
 	config := Config{

--- a/connector/github/github_test.go
+++ b/connector/github/github_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -451,7 +450,7 @@ func Test_isPreferredEmailDomain(t *testing.T) {
 }
 
 func Test_Open_PreferredDomainConfig(t *testing.T) {
-	log := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	log := slog.New(slog.DiscardHandler)
 	tests := []struct {
 		preferredEmailDomain string
 		email                string

--- a/connector/google/google_test.go
+++ b/connector/google/google_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -52,7 +51,7 @@ func testSetup() *httptest.Server {
 }
 
 func newConnector(config *Config) (*googleConnector, error) {
-	log := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	log := slog.New(slog.DiscardHandler)
 	conn, err := config.Open("id", log)
 	if err != nil {
 		return nil, err

--- a/connector/ldap/ldap_test.go
+++ b/connector/ldap/ldap_test.go
@@ -3,7 +3,6 @@ package ldap
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"testing"
@@ -567,7 +566,7 @@ func runTests(t *testing.T, connMethod connectionMethod, config *Config, tests [
 	c.BindDN = "cn=admin,dc=example,dc=org"
 	c.BindPW = "admin"
 
-	l := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	l := slog.New(slog.DiscardHandler)
 
 	conn, err := c.openConnector(l)
 	if err != nil {

--- a/connector/oauth/oauth_test.go
+++ b/connector/oauth/oauth_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -271,7 +270,7 @@ func newConnector(t *testing.T, serverURL string) *oauthConnector {
 	testConfig.ClaimMapping.EmailKey = "mail"
 	testConfig.ClaimMapping.EmailVerifiedKey = "has_verified_email"
 
-	log := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	log := slog.New(slog.DiscardHandler)
 
 	conn, err := testConfig.Open("id", log)
 	if err != nil {

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -834,7 +833,7 @@ func newToken(key *jose.JSONWebKey, claims map[string]interface{}) (string, erro
 }
 
 func newConnector(config Config) (*oidcConnector, error) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 	conn, err := config.Open("id", logger)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open: %v", err)

--- a/connector/openshift/openshift_test.go
+++ b/connector/openshift/openshift_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -38,7 +37,7 @@ func TestOpen(t *testing.T) {
 		InsecureCA:   true,
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	oconfig, err := c.Open("id", logger)
 

--- a/connector/saml/saml_test.go
+++ b/connector/saml/saml_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"errors"
-	"io"
 	"log/slog"
 	"os"
 	"sort"
@@ -421,7 +420,7 @@ func (r responseTest) run(t *testing.T) {
 		t.Fatalf("parse test time: %v", err)
 	}
 
-	conn, err := c.openConnector(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})))
+	conn, err := c.openConnector(slog.New(slog.DiscardHandler))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -455,7 +454,7 @@ func (r responseTest) run(t *testing.T) {
 }
 
 func TestConfigCAData(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 	validPEM, err := os.ReadFile("testdata/ca.crt")
 	if err != nil {
 		t.Fatal(err)

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"io"
 	"log/slog"
 	"net"
 	"os"
@@ -60,7 +59,7 @@ func newAPI(s storage.Storage, logger *slog.Logger, t *testing.T) *apiClient {
 
 // Attempts to create, update and delete a test Password
 func TestPassword(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	s := memory.New(logger)
 	client := newAPI(s, logger, t)
@@ -169,7 +168,7 @@ func TestPassword(t *testing.T) {
 
 // Ensures checkCost returns expected values
 func TestCheckCost(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	s := memory.New(logger)
 	client := newAPI(s, logger, t)
@@ -222,7 +221,7 @@ func TestCheckCost(t *testing.T) {
 
 // Attempts to list and revoke an existing refresh token.
 func TestRefreshToken(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	s := memory.New(logger)
 	client := newAPI(s, logger, t)
@@ -331,7 +330,7 @@ func TestRefreshToken(t *testing.T) {
 }
 
 func TestUpdateClient(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	s := memory.New(logger)
 	client := newAPI(s, logger, t)
@@ -497,7 +496,7 @@ func TestCreateConnector(t *testing.T) {
 	os.Setenv("DEX_API_CONNECTORS_CRUD", "true")
 	defer os.Unsetenv("DEX_API_CONNECTORS_CRUD")
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	s := memory.New(logger)
 	client := newAPI(s, logger, t)
@@ -547,7 +546,7 @@ func TestUpdateConnector(t *testing.T) {
 	os.Setenv("DEX_API_CONNECTORS_CRUD", "true")
 	defer os.Unsetenv("DEX_API_CONNECTORS_CRUD")
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	s := memory.New(logger)
 	client := newAPI(s, logger, t)
@@ -615,7 +614,7 @@ func TestDeleteConnector(t *testing.T) {
 	os.Setenv("DEX_API_CONNECTORS_CRUD", "true")
 	defer os.Unsetenv("DEX_API_CONNECTORS_CRUD")
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	s := memory.New(logger)
 	client := newAPI(s, logger, t)
@@ -659,7 +658,7 @@ func TestListConnectors(t *testing.T) {
 	os.Setenv("DEX_API_CONNECTORS_CRUD", "true")
 	defer os.Unsetenv("DEX_API_CONNECTORS_CRUD")
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	s := memory.New(logger)
 	client := newAPI(s, logger, t)
@@ -699,7 +698,7 @@ func TestListConnectors(t *testing.T) {
 }
 
 func TestMissingConnectorsCRUDFeatureFlag(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	s := memory.New(logger)
 	client := newAPI(s, logger, t)

--- a/server/rotation_test.go
+++ b/server/rotation_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"io"
 	"log/slog"
 	"sort"
 	"testing"
@@ -69,7 +68,7 @@ func TestKeyRotator(t *testing.T) {
 	// Only the last 5 verification keys are expected to be kept around.
 	maxVerificationKeys := 5
 
-	l := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	l := slog.New(slog.DiscardHandler)
 
 	r := &keyRotator{
 		Storage:  memory.New(l),
@@ -101,7 +100,7 @@ func TestKeyRotator(t *testing.T) {
 
 func TestRefreshTokenPolicy(t *testing.T) {
 	lastTime := time.Now()
-	l := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	l := slog.New(slog.DiscardHandler)
 
 	r, err := NewRefreshTokenPolicy(l, true, "1m", "1m", "1m")
 	require.NoError(t, err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -76,7 +76,7 @@ FDWV28nTP9sqbtsmU8Tem2jzMvZ7C/Q0AuDoKELFUpux8shm8wfIhyaPnXUGZoAZ
 Np4vUwMSYV5mopESLWOg3loBxKyLGFtgGKVCjGiQvy6zISQ4fQo=
 -----END RSA PRIVATE KEY-----`)
 
-var logger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+var logger = slog.New(slog.DiscardHandler)
 
 func newTestServer(ctx context.Context, t *testing.T, updateConfig func(c *Config)) (*httptest.Server, *Server) {
 	var server *Server

--- a/storage/ent/mysql_test.go
+++ b/storage/ent/mysql_test.go
@@ -1,7 +1,6 @@
 package ent
 
 import (
-	"io"
 	"log/slog"
 	"os"
 	"strconv"
@@ -42,7 +41,7 @@ func mysqlTestConfig(host string, port uint64) *MySQL {
 }
 
 func newMySQLStorage(host string, port uint64) storage.Storage {
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	cfg := mysqlTestConfig(host, port)
 	s, err := cfg.Open(logger)

--- a/storage/ent/postgres_test.go
+++ b/storage/ent/postgres_test.go
@@ -1,7 +1,6 @@
 package ent
 
 import (
-	"io"
 	"log/slog"
 	"os"
 	"strconv"
@@ -37,7 +36,7 @@ func postgresTestConfig(host string, port uint64) *Postgres {
 }
 
 func newPostgresStorage(host string, port uint64) storage.Storage {
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	cfg := postgresTestConfig(host, port)
 	s, err := cfg.Open(logger)

--- a/storage/ent/sqlite_test.go
+++ b/storage/ent/sqlite_test.go
@@ -1,7 +1,6 @@
 package ent
 
 import (
-	"io"
 	"log/slog"
 	"testing"
 
@@ -10,7 +9,7 @@ import (
 )
 
 func newSQLiteStorage() storage.Storage {
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	cfg := SQLite3{File: ":memory:"}
 	s, err := cfg.Open(logger)

--- a/storage/etcd/etcd_test.go
+++ b/storage/etcd/etcd_test.go
@@ -3,7 +3,6 @@ package etcd
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"runtime"
@@ -56,7 +55,7 @@ func cleanDB(c *conn) error {
 	return nil
 }
 
-var logger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+var logger = slog.New(slog.DiscardHandler)
 
 func TestEtcd(t *testing.T) {
 	testEtcdEnv := "DEX_ETCD_ENDPOINTS"

--- a/storage/kubernetes/client_test.go
+++ b/storage/kubernetes/client_test.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"hash"
 	"hash/fnv"
-	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -53,7 +52,7 @@ func TestOfflineTokenName(t *testing.T) {
 }
 
 func TestInClusterTransport(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	user := k8sapi.AuthInfo{Token: "abc"}
 	cli, err := newClient(

--- a/storage/kubernetes/storage_test.go
+++ b/storage/kubernetes/storage_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -58,7 +57,7 @@ func (s *StorageTestSuite) SetupTest() {
 		KubeConfigFile: kubeconfigPath,
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	kubeClient, err := config.open(logger, true)
 	s.Require().NoError(err)
@@ -250,7 +249,7 @@ func newStatusCodesResponseTestClient(getResponseCode, actionResponseCode int) *
 	return &client{
 		client:  &http.Client{Transport: tr},
 		baseURL: s.URL,
-		logger:  slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})),
+		logger:  slog.New(slog.DiscardHandler),
 	}
 }
 
@@ -307,7 +306,7 @@ func TestRefreshTokenLock(t *testing.T) {
 		KubeConfigFile: kubeconfigPath,
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	kubeClient, err := config.open(logger, true)
 	require.NoError(t, err)

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -1,7 +1,6 @@
 package memory
 
 import (
-	"io"
 	"log/slog"
 	"testing"
 
@@ -10,7 +9,7 @@ import (
 )
 
 func TestStorage(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	newStorage := func() storage.Storage {
 		return New(logger)

--- a/storage/memory/static_test.go
+++ b/storage/memory/static_test.go
@@ -3,7 +3,6 @@ package memory
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"strings"
 	"testing"
@@ -13,7 +12,7 @@ import (
 
 func TestStaticClients(t *testing.T) {
 	ctx := context.Background()
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 	backing := New(logger)
 
 	c1 := storage.Client{ID: "foo", Secret: "foo_secret"}
@@ -97,7 +96,7 @@ func TestStaticClients(t *testing.T) {
 
 func TestStaticPasswords(t *testing.T) {
 	ctx := context.Background()
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 	backing := New(logger)
 
 	p1 := storage.Password{Email: "foo@example.com", Username: "foo_secret"}
@@ -206,7 +205,7 @@ func TestStaticPasswords(t *testing.T) {
 
 func TestStaticConnectors(t *testing.T) {
 	ctx := context.Background()
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 	backing := New(logger)
 
 	config1 := []byte(`{"issuer": "https://accounts.google.com"}`)

--- a/storage/sql/config_test.go
+++ b/storage/sql/config_test.go
@@ -2,7 +2,6 @@ package sql
 
 import (
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"runtime"
@@ -47,7 +46,7 @@ func cleanDB(c *conn) error {
 	return nil
 }
 
-var logger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+var logger = slog.New(slog.DiscardHandler)
 
 type opener interface {
 	open(logger *slog.Logger) (*conn, error)

--- a/storage/sql/migrate_test.go
+++ b/storage/sql/migrate_test.go
@@ -5,7 +5,6 @@ package sql
 
 import (
 	"database/sql"
-	"io"
 	"log/slog"
 	"testing"
 
@@ -19,7 +18,7 @@ func TestMigrate(t *testing.T) {
 	}
 	defer db.Close()
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	logger := slog.New(slog.DiscardHandler)
 
 	errCheck := func(err error) bool {
 		sqlErr, ok := err.(sqlite3.Error)


### PR DESCRIPTION
#### Overview

Simplify tests by using `slog.DiscardHandler` instead of `slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})`.

#### What this PR does / why we need it

It reduces number of code symbols in tests.

#### Special notes for your reviewer

The [DiscardHandler](https://pkg.go.dev/log/slog#DiscardHandler) was added in [Go 1.24](https://go.dev/doc/go1.24#logslogpkglogslog).