### PR TITLE
fix Incorrect Group Handling in RequestContextHandler logger.go

### DIFF
--- a/cmd/dex/logger.go
+++ b/cmd/dex/logger.go
@@ -63,5 +63,5 @@ func (h requestContextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 }
 
 func (h requestContextHandler) WithGroup(name string) slog.Handler {
-	return h.handler.WithGroup(name)
+	return requestContextHandler{h.handler.WithGroup(name)}
 }


### PR DESCRIPTION
Wrap the grouped handler in requestContextHandler to preserve context attribute injection. 
fixes #4081


