### PR TITLE
Add recursive LDAP parent group search (AD-style hierarchy across all LDAPs)

### DIFF
--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -62,6 +62,8 @@ import (
 type UserMatcher struct {
 	UserAttr  string `json:"userAttr"`
 	GroupAttr string `json:"groupAttr"`
+	// Look for parent groups
+	RecursionGroupAttr string `json:"recursionGroupAttr"`
 }
 
 // Config holds configuration options for LDAP logins.
@@ -144,6 +146,8 @@ type Config struct {
 		UserAttr  string `json:"userAttr"`
 		GroupAttr string `json:"groupAttr"`
 
+		RecursionGroupAttr string `json:"recursionGroupAttr"`
+
 		// Array of the field pairs used to match a user to a group.
 		// See the "UserMatcher" struct for the exact field names
 		//
@@ -197,8 +201,9 @@ func userMatchers(c *Config, logger *slog.Logger) []UserMatcher {
 	logger.Warn(`use "groupSearch.userMatchers" option instead of "userAttr/groupAttr" fields`, "deprecated", true)
 	return []UserMatcher{
 		{
-			UserAttr:  c.GroupSearch.UserAttr,
-			GroupAttr: c.GroupSearch.GroupAttr,
+			UserAttr:           c.GroupSearch.UserAttr,
+			GroupAttr:          c.GroupSearch.GroupAttr,
+			RecursionGroupAttr: c.GroupSearch.RecursionGroupAttr,
 		},
 	}
 }
@@ -591,57 +596,120 @@ func (c *ldapConnector) groups(ctx context.Context, user ldap.Entry) ([]string, 
 		return nil, nil
 	}
 
-	var groups []*ldap.Entry
+	var groupNames []string
+
 	for _, matcher := range c.GroupSearch.UserMatchers {
+		// Initial Search
+		var groups []*ldap.Entry
 		for _, attr := range c.getAttrs(user, matcher.UserAttr) {
-			filter := fmt.Sprintf("(%s=%s)", matcher.GroupAttr, ldap.EscapeFilter(attr))
-			if c.GroupSearch.Filter != "" {
-				filter = fmt.Sprintf("(&%s%s)", c.GroupSearch.Filter, filter)
-			}
-
-			req := &ldap.SearchRequest{
-				BaseDN:     c.GroupSearch.BaseDN,
-				Filter:     filter,
-				Scope:      c.groupSearchScope,
-				Attributes: []string{c.GroupSearch.NameAttr},
-			}
-
-			gotGroups := false
-			if err := c.do(ctx, func(conn *ldap.Conn) error {
-				c.logger.Info("performing ldap search",
-					"base_dn", req.BaseDN, "scope", scopeString(req.Scope), "filter", req.Filter)
-				resp, err := conn.Search(req)
-				if err != nil {
-					return fmt.Errorf("ldap: search failed: %v", err)
-				}
-				gotGroups = len(resp.Entries) != 0
-				groups = append(groups, resp.Entries...)
-				return nil
-			}); err != nil {
+			obtained, filter, err := c.queryGroups(ctx, matcher.GroupAttr, attr)
+			if err != nil {
 				return nil, err
 			}
+			gotGroups := len(obtained) != 0
 			if !gotGroups {
 				// TODO(ericchiang): Is this going to spam the logs?
-				c.logger.Error("groups search returned no groups", "filter", filter)
+				c.logger.Error("ldap: groups search returned no groups", "filter", filter)
 			}
-		}
-	}
-
-	groupNames := make([]string, 0, len(groups))
-	for _, group := range groups {
-		name := c.getAttr(*group, c.GroupSearch.NameAttr)
-		if name == "" {
-			// Be obnoxious about missing attributes. If the group entry is
-			// missing its name attribute, that indicates a misconfiguration.
-			//
-			// In the future we can add configuration options to just log these errors.
-			return nil, fmt.Errorf("ldap: group entity %q missing required attribute %q",
-				group.DN, c.GroupSearch.NameAttr)
+			groups = append(groups, obtained...)
 		}
 
-		groupNames = append(groupNames, name)
+		// If RecursionGroupAttr is not set, convert direct groups into names and return
+		if matcher.RecursionGroupAttr == "" {
+			for _, group := range groups {
+				name := c.getAttr(*group, c.GroupSearch.NameAttr)
+				if name == "" {
+					return nil, fmt.Errorf(
+						"ldap: group entity %q missing required attribute %q",
+						group.DN, c.GroupSearch.NameAttr,
+					)
+				}
+				groupNames = append(groupNames, name)
+			}
+			continue
+		}
+
+		// Recursive Search
+		c.logger.Info("Recursive group search enabled", "groupAttr", matcher.GroupAttr, "recursionAttr", matcher.RecursionGroupAttr)
+		for {
+			var nextLevel []*ldap.Entry
+			for _, group := range groups {
+				name := c.getAttr(*group, c.GroupSearch.NameAttr)
+				if name == "" {
+					return nil, fmt.Errorf("ldap: group entity %q missing required attribute %q",
+						group.DN, c.GroupSearch.NameAttr)
+				}
+
+				// Prevent duplicates and circular references.
+				duplicate := false
+				for _, existingName := range groupNames {
+					if name == existingName {
+						c.logger.Debug("Found duplicate group", "name", name)
+						duplicate = true
+						break
+					}
+				}
+				if duplicate {
+					continue
+				}
+
+				groupNames = append(groupNames, name)
+
+				// Search for parent groups using the group's DN.
+				parents, filter, err := c.queryGroups(ctx, matcher.RecursionGroupAttr, group.DN)
+				if err != nil {
+					return nil, err
+				}
+				if len(parents) == 0 {
+					c.logger.Debug("No parent groups found", "filter", filter)
+				} else {
+					nextLevel = append(nextLevel, parents...)
+				}
+			}
+			if len(nextLevel) == 0 {
+				break
+			}
+			groups = nextLevel
+		}
 	}
 	return groupNames, nil
+}
+
+func (c *ldapConnector) queryGroups(ctx context.Context, memberAttr, dn string) ([]*ldap.Entry, string, error) {
+	filter := fmt.Sprintf("(%s=%s)", memberAttr, ldap.EscapeFilter(dn))
+	if c.GroupSearch.Filter != "" {
+		filter = fmt.Sprintf("(&%s%s)", c.GroupSearch.Filter, filter)
+	}
+
+	req := &ldap.SearchRequest{
+		BaseDN:     c.GroupSearch.BaseDN,
+		Filter:     filter,
+		Scope:      c.groupSearchScope,
+		Attributes: []string{c.GroupSearch.NameAttr},
+	}
+
+	var entries []*ldap.Entry
+	if err := c.do(ctx, func(conn *ldap.Conn) error {
+		c.logger.Info(
+			"performing ldap search",
+			"base_dn", req.BaseDN,
+			"scope", scopeString(req.Scope),
+			"filter", req.Filter,
+		)
+		resp, err := conn.Search(req)
+		if err != nil {
+			if ldapErr, ok := err.(*ldap.Error); ok && ldapErr.ResultCode == ldap.LDAPResultNoSuchObject {
+				c.logger.Info("LDAP search returned no groups", "filter", filter)
+				return nil
+			}
+			return fmt.Errorf("ldap: search failed: %v", err)
+		}
+		entries = append(entries, resp.Entries...)
+		return nil
+	}); err != nil {
+		return nil, filter, err
+	}
+	return entries, filter, nil
 }
 
 func (c *ldapConnector) Prompt() string {

--- a/connector/ldap/ldap_test.go
+++ b/connector/ldap/ldap_test.go
@@ -525,6 +525,56 @@ func TestUsernamePrompt(t *testing.T) {
 	}
 }
 
+func TestNestedGroups(t *testing.T) {
+	c := &Config{}
+	c.UserSearch.BaseDN = "ou=People,ou=TestNestedGroups,dc=example,dc=org"
+	c.UserSearch.NameAttr = "cn"
+	c.UserSearch.EmailAttr = "mail"
+	c.UserSearch.IDAttr = "DN"
+	c.UserSearch.Username = "cn"
+
+	c.GroupSearch.BaseDN = "ou=TestNestedGroups,dc=example,dc=org"
+	c.GroupSearch.UserMatchers = []UserMatcher{
+		{
+			UserAttr:  "DN",
+			GroupAttr: "member",
+			// Enable Recursive Search
+			RecursionGroupAttr: "member",
+		},
+	}
+	c.GroupSearch.NameAttr = "cn"
+
+	tests := []subtest{
+		{
+			name:     "nestedgroups_jane",
+			username: "jane",
+			password: "foo",
+			groups:   true,
+			want: connector.Identity{
+				UserID:        "cn=jane,ou=People,ou=TestNestedGroups,dc=example,dc=org",
+				Username:      "jane",
+				Email:         "janedoe@example.com",
+				EmailVerified: true,
+				Groups:        []string{"childGroup", "circularGroup1", "intermediateGroup", "circularGroup2", "parentGroup"},
+			},
+		},
+		{
+			name:     "nestedgroups_john",
+			username: "john",
+			password: "bar",
+			groups:   true,
+			want: connector.Identity{
+				UserID:        "cn=john,ou=People,ou=TestNestedGroups,dc=example,dc=org",
+				Username:      "john",
+				Email:         "johndoe@example.com",
+				EmailVerified: true,
+				Groups:        []string{"circularGroup2", "intermediateGroup", "circularGroup1", "parentGroup"},
+			},
+		},
+	}
+	runTests(t, connectLDAP, c, tests)
+}
+
 func getenv(key, defaultVal string) string {
 	if val := os.Getenv(key); val != "" {
 		return val

--- a/connector/ldap/testdata/schema.ldif
+++ b/connector/ldap/testdata/schema.ldif
@@ -445,3 +445,63 @@ sn: doe
 cn: jane
 mail: janedoe@example.com
 userpassword: foo
+
+########################################################################
+
+dn: ou=TestNestedGroups,dc=example,dc=org
+objectClass: organizationalUnit
+ou: TestNestedGroups
+
+dn: ou=People,ou=TestNestedGroups,dc=example,dc=org
+objectClass: organizationalUnit
+ou: People
+
+dn: cn=jane,ou=People,ou=TestNestedGroups,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+sn: doe
+cn: jane
+mail: janedoe@example.com
+userpassword: foo
+
+dn: cn=john,ou=People,ou=TestNestedGroups,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+sn: doe
+cn: john
+mail: johndoe@example.com
+userpassword: bar
+
+# Group definitions.
+
+dn: ou=Groups,ou=TestNestedGroups,dc=example,dc=org
+objectClass: organizationalUnit
+ou: Groups
+
+dn: cn=childGroup,ou=Groups,ou=TestNestedGroups,dc=example,dc=org
+objectClass: groupOfNames
+cn: childGroup
+member: cn=jane,ou=People,ou=TestNestedGroups,dc=example,dc=org
+
+dn: cn=intermediateGroup,ou=Groups,ou=TestNestedGroups,dc=example,dc=org
+objectClass: groupOfNames
+cn: intermediateGroup
+member: cn=childGroup,ou=Groups,ou=TestNestedGroups,dc=example,dc=org
+member: cn=john,ou=People,ou=TestNestedGroups,dc=example,dc=org
+
+dn: cn=parentGroup,ou=Groups,ou=TestNestedGroups,dc=example,dc=org
+objectClass: groupOfNames
+cn: parentGroup
+member: cn=intermediateGroup,ou=Groups,ou=TestNestedGroups,dc=example,dc=org
+
+dn: cn=circularGroup1,ou=Groups,ou=TestNestedGroups,dc=example,dc=org
+objectClass: groupOfNames
+cn: circularGroup1
+member: cn=circularGroup2,ou=Groups,ou=TestNestedGroups,dc=example,dc=org
+member: cn=jane,ou=People,ou=TestNestedGroups,dc=example,dc=org
+
+dn: cn=circularGroup2,ou=Groups,ou=TestNestedGroups,dc=example,dc=org
+objectClass: groupOfNames
+cn: circularGroup2
+member: cn=circularGroup1,ou=Groups,ou=TestNestedGroups,dc=example,dc=org
+member: cn=john,ou=People,ou=TestNestedGroups,dc=example,dc=org


### PR DESCRIPTION
#### Overview

This pull request introduces improvements to Dex's LDAP connector to enable universal nested group search support across a variety of LDAP server implementations. It updates the code to allow recursive group membership discovery during user authentication and provides a more robust testing framework to validate the functionality.

This PR builds is largely based upon @paroque’s original #1058,

The groups() function in ldap.go was significantly refactored to add support for recursive nested group searching. Previously, the function directly built and executed LDAP search requests inline for each user matcher, then collected group names from the immediate search results. In the new version, the LDAP querying has been moved into a separate helper function called queryGroups(), which makes the main groups() function cleaner and easier to follow. A recursion flag and attribute have been added to the configuration. When recursion is enabled, after the initial group search, the function continues to search for parent groups using the specified recursion attribute. This process repeats until no new groups are found, allowing Dex to build a complete list of all direct and inherited group memberships. To prevent infinite loops and redundant results, the function checks for duplicate names and circular group references. If recursion is not enabled, the function simply returns the user’s direct group memberships, maintaining the original behavior.

To support per-matcher control over recursive searching, two new fields were added to the UserMatcher struct: Recursive and RecursionGroupAttr. The Recursive flag allows admins to specify whether recursion should be applied for a particular user matcher. The RecursionGroupAttr field lets them define which LDAP attribute should be used during the recursive lookup phase, allowing flexibility across different schemas. These assure that recursion is easily configurable and has broad compatibility. 

To support the new recursive nested group functionality, a new unit test called TestNestedGroups was added. Using a new LDAP config and LDIF addition, this tests basic nested structures including a multi-level nesting and circular group references. It checks that users inherit all the correct group memberships through the recursive lookup process. 

#### What this PR does / why we need it

Through extensive testing using both OpenLDAP and Apache Directory servers, we confirmed that Dex’s LDAP connector does not support nested group structures by default. While Dex could identify a user’s direct group memberships, it failed to recognize inherited group memberships through multi-level nesting, which are common in real-world LDAP environments. Although some systems like Microsoft Active Directory offer built-in nested group search (as cited in https://github.com/dexidp/dex/pull/1058#issuecomment-348106630), many LDAP implementations do not, and we wanted to create a universal solution that would work across all implementations. 

This PR introduces recursive group lookup functionality to Dex’s LDAP connector, allowing it to correctly discover and include all nested group memberships during authentication. Without this improvement for many LDAP implementations, users belonging to nested groups would not be authorized correctly, leading to access control issues for organizations relying on LDAP group hierarchies.  

![DexCITestingDiagram](https://github.com/user-attachments/assets/222b6673-e437-4161-8cfe-280ba36bd562)

Our CI testing demonstrates the functionality with a series of example groups on the left:

Without the PR:
- John’s Groups: intermediateGroup
- Jane’s Groups: childGroup

With the PR and enabling recursion:
- John’s Groups: intermediateGroup, parentGroup
- Jane’s Groups: childGroup, intermediateGroup, parentGroup

The PR makes it so that after Dex finds a user’s direct groups, it can keep searching for any parent groups they’re part of until all group memberships, direct or indirect, are found.

On the right, we’re testing a circular reference scenario to ensure that the search correctly identifies both users as members of both circular groups without introducing duplicates or causing an infinite loop. 

Finally, it is worth noting two more things:

1. We found that the AD-specific member:1.2.840.113556.1.4.1941: filter timed out after 2 minutes when searching for a 
Member’s groups in a real-world large corporate AD environment.  Searching that same corporate AD for the same Member’s groups with Dex (including this PR’s functionality) takes 7 seconds, and correctly returns 300+ groups.

2. In addition to running the CI tests with OpenLDAP, we manually tested this new Dex functionality with Apache DS, where it also performs correctly.

Overall, these changes make Dex’s LDAP connector more flexible, more reliable across different environments, and better suited for real-world deployments that depend on complex group hierarchies. 
