### PR TITLE
feat: Add ModifyGroupNames claimMutation to oidc connector

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -104,6 +104,7 @@ type Config struct {
 	ClaimMutations struct {
 		NewGroupFromClaims []NewGroupFromClaims `json:"newGroupFromClaims"`
 		FilterGroupClaims  FilterGroupClaims    `json:"filterGroupClaims"`
+		ModifyGroupNames   ModifyGroupNames     `json:"modifyGroupNames"`
 	} `json:"claimModifications"`
 }
 
@@ -187,6 +188,12 @@ type NewGroupFromClaims struct {
 // This is useful when the groups list is too large to fit within an HTTP header.
 type FilterGroupClaims struct {
 	GroupsFilter string `json:"groupsFilter"`
+}
+
+// ModifyGroupNames allows to modify the group claims by adding a prefix and/or suffix to each group.
+type ModifyGroupNames struct {
+	Prefix string `json:"prefix"`
+	Suffix string `json:"suffix"`
 }
 
 // Domains that don't support basic auth. golang.org/x/oauth2 has an internal
@@ -307,6 +314,8 @@ func (c *Config) Open(id string, logger *slog.Logger) (conn connector.Connector,
 		groupsKey:                 c.ClaimMapping.GroupsKey,
 		newGroupFromClaims:        c.ClaimMutations.NewGroupFromClaims,
 		groupsFilter:              groupsFilter,
+		groupsPrefix:              c.ClaimMutations.ModifyGroupNames.Prefix,
+		groupsSuffix:              c.ClaimMutations.ModifyGroupNames.Suffix,
 	}, nil
 }
 
@@ -337,6 +346,8 @@ type oidcConnector struct {
 	groupsKey                 string
 	newGroupFromClaims        []NewGroupFromClaims
 	groupsFilter              *regexp.Regexp
+	groupsPrefix              string
+	groupsSuffix              string
 }
 
 func (c *oidcConnector) Close() error {
@@ -570,6 +581,13 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 			}
 
 			groups = groupMatches
+		}
+	}
+
+	// add prefix/suffix to groups
+	if c.groupsPrefix != "" || c.groupsSuffix != "" {
+		for i, group := range groups {
+			groups[i] = c.groupsPrefix + group + c.groupsSuffix
 		}
 	}
 

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -65,6 +65,8 @@ func TestHandleCallback(t *testing.T) {
 		token                     map[string]interface{}
 		groupsRegex               string
 		newGroupFromClaims        []NewGroupFromClaims
+		groupsPrefix              string
+		groupsSuffix              string
 	}{
 		{
 			name:               "simpleCase",
@@ -397,6 +399,58 @@ func TestHandleCallback(t *testing.T) {
 			},
 		},
 		{
+			name:               "prefixGroupNames",
+			userIDKey:          "", // not configured
+			userNameKey:        "", // not configured
+			expectUserID:       "subvalue",
+			expectUserName:     "namevalue",
+			expectGroups:       []string{"prefix-group1", "prefix-group2", "prefix-groupA", "prefix-groupB"},
+			expectedEmailField: "emailvalue",
+			groupsPrefix:       "prefix-",
+			token: map[string]interface{}{
+				"sub":            "subvalue",
+				"name":           "namevalue",
+				"groups":         []string{"group1", "group2", "groupA", "groupB"},
+				"email":          "emailvalue",
+				"email_verified": true,
+			},
+		},
+		{
+			name:               "suffixGroupNames",
+			userIDKey:          "", // not configured
+			userNameKey:        "", // not configured
+			expectUserID:       "subvalue",
+			expectUserName:     "namevalue",
+			expectGroups:       []string{"group1-suffix", "group2-suffix", "groupA-suffix", "groupB-suffix"},
+			expectedEmailField: "emailvalue",
+			groupsSuffix:       "-suffix",
+			token: map[string]interface{}{
+				"sub":            "subvalue",
+				"name":           "namevalue",
+				"groups":         []string{"group1", "group2", "groupA", "groupB"},
+				"email":          "emailvalue",
+				"email_verified": true,
+			},
+		},
+		{
+			name:               "preAndSuffixGroupNames",
+			userIDKey:          "", // not configured
+			userNameKey:        "", // not configured
+			expectUserID:       "subvalue",
+			expectUserName:     "namevalue",
+			expectGroups:       []string{"prefix-group1-suffix", "prefix-group2-suffix", "prefix-groupA-suffix", "prefix-groupB-suffix"},
+			expectedEmailField: "emailvalue",
+			groupsPrefix:       "prefix-",
+			groupsSuffix:       "-suffix",
+			token: map[string]interface{}{
+				"sub":            "subvalue",
+				"name":           "namevalue",
+				"groups":         []string{"group1", "group2", "groupA", "groupB"},
+				"email":          "emailvalue",
+				"email_verified": true,
+			},
+		},
+		{
 			name:               "filterGroupClaims",
 			userIDKey:          "", // not configured
 			userNameKey:        "", // not configured
@@ -467,6 +521,8 @@ func TestHandleCallback(t *testing.T) {
 			config.ClaimMapping.GroupsKey = tc.groupsKey
 			config.ClaimMutations.NewGroupFromClaims = tc.newGroupFromClaims
 			config.ClaimMutations.FilterGroupClaims.GroupsFilter = tc.groupsRegex
+			config.ClaimMutations.ModifyGroupNames.Prefix = tc.groupsPrefix
+			config.ClaimMutations.ModifyGroupNames.Suffix = tc.groupsSuffix
 
 			conn, err := newConnector(config)
 			if err != nil {


### PR DESCRIPTION
#### Overview

This PR adds a `claimModification` to the oidc connector, to allow prefixes/suffixes of group names.
Similar things were already requested in #918 and other issues.

Since the middleware component is still pending, and in the meantime `claimModifications` were introduced in #3056 for the oidc connector, this PR just adds another modification.

This partially solves #918 but only for oidc connectors

#### Special notes for your reviewer
