### PR TITLE
:bug: remove extra method="get" from device-code template

### DIFF
--- a/web/templates/device.html
+++ b/web/templates/device.html
@@ -2,7 +2,7 @@
 
 <div class="theme-panel">
   <h2 class="theme-heading">Enter User Code</h2>
-  <form method="post" action="{{ .PostURL }}" method="get">
+  <form method="post" action="{{ .PostURL }}">
     <div class="theme-form-row">
       {{ if( .UserCode  )}}
       <input tabindex="2" required id="user_code" name="user_code" type="text" class="theme-form-input" autocomplete="off" value="{{.UserCode}}" {{ if .Invalid }} autofocus {{ end }}/>


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

In device-code template, same form tag has method="post", then followed by method="get".. Chrome can handle that as post just fine, but in headless environments you might be using Lynx, which uses GET: it results in 400 Bad Request from Dex server.

```html
<div class="theme-panel">
  <h2 class="theme-heading">Enter User Code</h2>
  <form method="post" action="/device/auth/verify_code" method="get">
```

#### What this PR does / why we need it

Remove the extra method="get" from the form.

#### Special notes for your reviewer
