### PR TITLE
fix: device code pending HTTP response

### DIFF
--- a/server/deviceflowhandlers.go
+++ b/server/deviceflowhandlers.go
@@ -249,7 +249,7 @@ func (s *Server) handleDeviceToken(w http.ResponseWriter, r *http.Request) {
 		if slowDown {
 			s.tokenErrHelper(w, deviceTokenSlowDown, "", http.StatusBadRequest)
 		} else {
-			s.tokenErrHelper(w, deviceTokenPending, "", http.StatusUnauthorized)
+			s.tokenErrHelper(w, deviceTokenPending, "", http.StatusBadRequest)
 		}
 	case deviceTokenComplete:
 		codeChallengeFromStorage := deviceToken.PKCE.CodeChallenge

--- a/server/deviceflowhandlers_test.go
+++ b/server/deviceflowhandlers_test.go
@@ -459,7 +459,7 @@ func TestDeviceTokenResponse(t *testing.T) {
 			},
 			testDeviceCode:         "f00bar",
 			expectedServerResponse: deviceTokenPending,
-			expectedResponseCode:   http.StatusUnauthorized,
+			expectedResponseCode:   http.StatusBadRequest,
 		},
 		{
 			testName:          "Invalid Grant Type",


### PR DESCRIPTION
#### Overview

As per RFC8628 section 3.5, https://datatracker.ietf.org/doc/html/rfc8628#section-3.5 the authorization_pending response should extend RFC6749 section 5.2, https://datatracker.ietf.org/doc/html/rfc6749#section-5.2 which specifies that the HTTP response code should be 400, Bad Request.

#### What this PR does / why we need it

RFC8628 compliance.

Partially fixes #4240 