### PR TITLE
[oidc] pass httpClient to the TokenIdentity context

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -420,6 +420,9 @@ func (c *oidcConnector) Refresh(ctx context.Context, s connector.Scopes, identit
 
 func (c *oidcConnector) TokenIdentity(ctx context.Context, subjectTokenType, subjectToken string) (connector.Identity, error) {
 	var identity connector.Identity
+
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, c.httpClient)
+
 	token := &oauth2.Token{
 		AccessToken: subjectToken,
 		TokenType:   subjectTokenType,


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

OIDC options `insecureSkipVerify` and `rootCAs` does not work now, we getting `x509: certificate signed by unknown authority` errors with this config:

```
  connectors:
    - type: oidc
      id: "my-oidc"
      name: "My OIDC"
      config:
        issuer: "https://dex.company.my/"
        clientID: REDACTED
        clientSecret: REDACTED
        redirectURI: https://dex-client.company.my/callback
        insecureEnableGroups: true
        getUserInfo: true
        userIDKey: "sub"
        userNameKey: "email"
        scopes:
        - "openid"
        - "email"
        - "profile"
        - "offline_access"
        - "groups"
        - "federated:id"
        - "offline_access"
        - "audience:server:client_id:kubernetes"
        promptType: "consent"
        rootCAs:
        - |
          -----BEGIN CERTIFICATE-----
          -----END CERTIFICATE-----
        insecureSkipVerify: true
```

```
{"time":"2025-07-17T18:34:03.235594098Z","level":"ERROR","msg":"failed to verify subject token","err":"oidc: error loading userinfo: Get \"https://dex.company.my/userinfo\": tls: failed to verify certificate: x509: certificate signed by unknown authority","client_remote_addr":"10.111.0.38","request_id":"0256ef74-5dca-4241-b71d-c556cdd03058"}
```

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

We need to pass OIDC connector's `httpClient` to all requests to make `insecureSkipVerify` and `rootCAs` options work

#### Special notes for your reviewer
