### PR TITLE
Allow compilation without CGO

### DIFF
--- a/storage/sql/sqlite_no_cgo.go
+++ b/storage/sql/sqlite_no_cgo.go
@@ -15,5 +15,5 @@ import (
 type SQLite3 struct{}
 
 func (s *SQLite3) Open(logger *slog.Logger) (storage.Storage, error) {
-	return nil, fmt.Errorf("Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work")
+	return nil, fmt.Errorf("SQLite storage is not available: binary compiled without CGO support. Recompile with CGO_ENABLED=1 or use a different storage backend.")
 }

--- a/storage/sql/sqlite_no_cgo.go
+++ b/storage/sql/sqlite_no_cgo.go
@@ -1,0 +1,19 @@
+//go:build !cgo
+// +build !cgo
+
+// This is a stub for the no CGO compilation (CGO_ENABLED=0)
+
+package sql
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/dexidp/dex/storage"
+)
+
+type SQLite3 struct{}
+
+func (s *SQLite3) Open(logger *slog.Logger) (storage.Storage, error) {
+	return nil, fmt.Errorf("Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work")
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

`ent` driver gives a normal error if the binary is compiled without CGO, but with our custom SQL driver Dex just fails to compile.

```
# github.com/dexidp/dex/cmd/dex
cmd/dex/config.go:273:26: undefined: sql.SQLite3
cmd/dex/config.go:315:43: undefined: sql.SQLite3
```

#### What this PR does / why we need it

Somebody rised this once, but I didn't mange to find it quickly. With this PR it is now possible to compile Dex without CGO in case if the sqlite driver is not required in runtime. 

#### Special notes for your reviewer
