### PR TITLE
chore: check for prompt=none in authentication requests

### DIFF
--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -77,6 +77,10 @@ func (err *redirectedAuthErr) Handler() http.Handler {
 	return http.HandlerFunc(hf)
 }
 
+func newRedirectedAuthErr(authReq *storage.AuthRequest, typ, format string, a ...interface{}) *redirectedAuthErr {
+	return &redirectedAuthErr{authReq.State, authReq.RedirectURI, typ, fmt.Sprintf(format, a...)}
+}
+
 func tokenErr(w http.ResponseWriter, typ, description string, statusCode int) error {
 	data := struct {
 		Error       string `json:"error"`
@@ -612,6 +616,7 @@ func (s *Server) parseAuthorizationRequest(r *http.Request) (*storage.AuthReques
 		State:               state,
 		Nonce:               nonce,
 		ForceApprovalPrompt: q.Get("approval_prompt") == "force",
+		Prompt:              q.Get("prompt"),
 		Scopes:              scopes,
 		RedirectURI:         redirectURI,
 		ResponseTypes:       responseTypes,

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -211,6 +211,7 @@ type AuthRequest struct {
 	// on all requests. The server cannot cache their initial action for subsequent
 	// attempts.
 	ForceApprovalPrompt bool
+	Prompt              string
 
 	Expiry time.Time
 


### PR DESCRIPTION
#### Overview

This PR adds support for `prompt=none` as described in the [specs section 3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).

#### What this PR does / why we need it

Currently dex lacks support for the `prompt=none` parameter. Though `prompt` is an optional parameter in the request, if it is set to `none` the IdP must not show any login mask or other UIs. Instead it should either return a new token if the session is still valid or return an error (which is always the case for dex, as there are no sessions).
This PR adds support for `prompt=none` in a way which will check for the existence of the parameter and the value and if that is the case, it always returns a `login_required` error.