### PR TITLE
fix: ensure IPv4s parse w/ latest Go versions

### DIFF
--- a/storage/kubernetes/client.go
+++ b/storage/kubernetes/client.go
@@ -528,9 +528,10 @@ func inClusterConfig() (k8sapi.Cluster, k8sapi.AuthInfo, string, error) {
 			kubernetesServicePortENV,
 		)
 	}
-	// we need to wrap IPv6 addresses in square brackets
-	// IPv4 also works with square brackets
-	host = "[" + host + "]"
+	// Wrap IPv6 addresses in square brackets for URL formatting
+	if strings.Contains(host, ":") {
+		host = "[" + host + "]"
+	}
 	cluster := k8sapi.Cluster{
 		Server:               "https://" + host + ":" + port,
 		CertificateAuthority: serviceAccountCAPath,


### PR DESCRIPTION
#### Overview

Preemptive fix for latest changes to Go's IPv4 validation. See https://github.com/golang/go/issues/75713.

#### What this PR does / why we need it

As soon as dex bumps to Go v1.25.2, users will start seeing this error when using an API server endpoint that's an IPv4:

```
failed to initialize storage: cannot get kubernetes version: parse "https://[10.96.0.1]:443/version": invalid IPv6 host
```
