### PR TITLE
fix(storage/kubernetes): Only wrap IPv6 addresses in brackets

### DIFF
--- a/storage/kubernetes/client.go
+++ b/storage/kubernetes/client.go
@@ -528,16 +528,8 @@ func getInClusterConnectOptions(host, port string) (k8sapi.Cluster, error) {
 		)
 	}
 
-	// we need to wrap IPv6 addresses in square brackets
-	// IPv4 used to work with square brackets, but it was fixed in the latest Go versions
-	// https://github.com/golang/go/issues/75712
-	ipAddr := net.ParseIP(host)
-	if ipAddr != nil && ipAddr.To4() == nil {
-		host = "[" + host + "]"
-	}
-
 	cluster := k8sapi.Cluster{
-		Server:               "https://" + host + ":" + port,
+		Server:               "https://" + net.JoinHostPort(host, port),
 		CertificateAuthority: serviceAccountCAPath,
 	}
 	return cluster, nil


### PR DESCRIPTION
#### Overview

The Kubernetes client code was wrapping all IP addresses (both IPv4 and IPv6) in square brackets when constructing the API server URL. This was based on an incorrect assumption that IPv4 addresses in brackets are valid in a URL.

As a result, the container crashes immediately when built with newer versions of golang.

Recent versions of Go (1.25.2 and later) have stricter URL parsing that conforms to RFC 3986. This causes a failure when running Dex in a Kubernetes environment where the KUBERNETES_SERVICE_HOST is an IPv4 address, leading to the error "invalid IPv6 host".

This commit changes the logic to only wrap IPv6 addresses in square brackets. It uses `net.JoinHostPort`, which is a convenience function made for this specific purpose. This ensures that URLs are correctly formatted for both IPv4 and IPv6 addresses (and even if KUBERNETES_SERVICE_HOST would be a dns name), fixing the incompatibility with newer Go versions.

#### What this PR does / why we need it

- It fixes https://github.com/dexidp/dex/issues/4382 which was issued by @JGuinegagne 

#### Special notes for your reviewer
