### PR TITLE
fix: Only wrap IPv6 addresses in square brackets per RFC 3986

### DIFF
--- a/storage/kubernetes/client.go
+++ b/storage/kubernetes/client.go
@@ -528,9 +528,11 @@ func inClusterConfig() (k8sapi.Cluster, k8sapi.AuthInfo, string, error) {
 			kubernetesServicePortENV,
 		)
 	}
-	// we need to wrap IPv6 addresses in square brackets
-	// IPv4 also works with square brackets
-	host = "[" + host + "]"
+	// Wrap IPv6 addresses in square brackets per RFC 3986.
+	// IPv4 addresses must not be wrapped in brackets.
+	if parsedIP := net.ParseIP(host); parsedIP != nil && parsedIP.To4() == nil {
+		host = "[" + host + "]"
+	}
 	cluster := k8sapi.Cluster{
 		Server:               "https://" + host + ":" + port,
 		CertificateAuthority: serviceAccountCAPath,


### PR DESCRIPTION
Fixes #4389

## Summary

This PR fixes a bug where Dex fails to initialize Kubernetes storage when the API server uses an IPv4 address. The issue occurs in Go 1.25.2+ and 1.24.8+ due to stricter RFC 3986 enforcement introduced as part of CVE-2025-47912.

## Problem

The `inClusterConfig()` function unconditionally wrapped all IP addresses in square brackets when constructing the Kubernetes API server URL:

```go
host = "[" + host + "]"
cluster.Server = "https://" + host + ":" + port
```

This violated RFC 3986, which specifies that only IPv6 addresses should be enclosed in brackets. While older Go versions accepted this, newer versions (1.25.2+, 1.24.8+) now correctly reject it:

```
parse "https://[172.20.0.1]:443/version": invalid IPv6 host
```

## Solution

Use `net.ParseIP()` to detect the address type and only wrap IPv6 addresses:

```go
if parsedIP := net.ParseIP(host); parsedIP != nil && parsedIP.To4() == nil {
    host = "[" + host + "]"
}
```

**Results:**
- IPv4: `https://172.20.0.1:443` (unwrapped, RFC compliant)
- IPv6: `https://[2001:db8::1]:443` (wrapped, RFC compliant)

## Changes

- ✅ Fixed bracket wrapping logic in `storage/kubernetes/client.go`
- ✅ Added comprehensive test coverage for IPv4, IPv6, and edge cases
- ✅ All existing tests pass

## Testing

Added `TestInClusterConfigIPv4IPv6` covering:
- IPv4 addresses (not wrapped)
- IPv6 addresses (wrapped)
- IPv6 loopback (wrapped)
- IPv4 loopback (not wrapped)
- IPv4-mapped IPv6 addresses (not wrapped, treated as IPv4)
- Error cases

## Backward Compatibility

- ✅ IPv6 clusters: No change (still wrapped)
- ✅ IPv4 clusters: Now works with Go 1.25.2+/1.24.8+
- ✅ Older Go versions: Still works correctly

## Related

- Original commit that introduced unconditional wrapping: 3a3a2bcc (2020)
- CVE-2025-47912: Go URL parsing security fix
- RFC 3986 Section 3.2.2: Host component specification