### PR TITLE
chore: remove api/v2 replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,6 +124,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/dexidp/dex/api/v2 => ./api/v2
-
 tool entgo.io/ent/cmd/ent


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

This PR gets rid of the replace directive in the `go.mod` for the `github.com/dexidp/dex` module.

Doing so has the benefit of making it possible to `go install github.com/dexidp/dex/cmd/dex`, which at least slightly addresses the underlying need from https://github.com/dexidp/dex/issues/827, though an officially provided binary release would of course be better.

#### What this PR does / why we need it

This change addresses the error message you'll receive if you try to `go install github.com/dexidp/dex/cmd/dex`:
```shell
$ go install --tags '!cgo' github.com/dexidp/dex/cmd/dex@2dce75009acfcd9df77d57f2d144aae999a4c569
go: github.com/dexidp/dex/cmd/dex@2dce75009acfcd9df77d57f2d144aae999a4c569 (in github.com/dexidp/dex@v0.0.0-20250829100637-2dce75009acf):
        The go.mod file for the module providing named packages contains one or
        more replace directives. It must not contain directives that would cause
        it to be interpreted differently than if it were the main module.
```

It also bumps the `github.com/dexidp/dex/api/v2` dependency to `v2.4.0` since parts of the code rely on types introduced in the `github.com/dexidp/dex/api/v2` release `v2.4.0`.

This has been previously brought up in [a discussion](https://github.com/dexidp/dex/discussions/3102).

#### Special notes for your reviewer
