### PR TITLE
Add support for the OAuth 2.0 Authorization Server Metadata Endpoint (RFC 8414)

### DIFF
--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -862,6 +862,17 @@ func setupServer(tok map[string]interface{}, idTokenDesired bool) (*httptest.Ser
 		})
 	})
 
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		url := fmt.Sprintf("http://%s", r.Host)
+
+		json.NewEncoder(w).Encode(&map[string]string{
+			"issuer":                 url,
+			"token_endpoint":         fmt.Sprintf("%s/token", url),
+			"authorization_endpoint": fmt.Sprintf("%s/authorize", url),
+			"jwks_uri":               fmt.Sprintf("%s/keys", url),
+		})
+	})
+
 	return httptest.NewServer(mux), nil
 }
 

--- a/server/api.go
+++ b/server/api.go
@@ -279,7 +279,7 @@ func (d dexAPI) GetVersion(ctx context.Context, req *api.VersionReq) (*api.Versi
 }
 
 func (d dexAPI) GetDiscovery(ctx context.Context, req *api.DiscoveryReq) (*api.DiscoveryResp, error) {
-	discoveryDoc := d.server.constructDiscovery()
+	discoveryDoc := d.server.constructDiscoveryOIDC()
 	data, err := json.Marshal(discoveryDoc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal discovery data: %v", err)

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -34,7 +34,7 @@ func TestHandleHealth(t *testing.T) {
 	}
 }
 
-func TestHandleDiscovery(t *testing.T) {
+func TestHandleDiscoveryOIDC(t *testing.T) {
 	httpServer, server := newTestServer(t, nil)
 	defer httpServer.Close()
 
@@ -44,10 +44,10 @@ func TestHandleDiscovery(t *testing.T) {
 		t.Errorf("expected 200 got %d", rr.Code)
 	}
 
-	var res discovery
+	var res discoveryOIDC
 	err := json.NewDecoder(rr.Result().Body).Decode(&res)
 	require.NoError(t, err)
-	require.Equal(t, discovery{
+	require.Equal(t, discoveryOIDC{
 		Issuer:         httpServer.URL,
 		Auth:           fmt.Sprintf("%s/auth", httpServer.URL),
 		Token:          fmt.Sprintf("%s/token", httpServer.URL),
@@ -99,6 +99,51 @@ func TestHandleDiscovery(t *testing.T) {
 			"at_hash",
 		},
 	}, res)
+}
+
+func TestHandleDiscoveryOAuth2(t *testing.T) {
+    httpServer, server := newTestServer(t, nil)
+    defer httpServer.Close()
+
+    rr := httptest.NewRecorder()
+    server.ServeHTTP(rr, httptest.NewRequest("GET", "/.well-known/oauth-authorization-server", nil))
+
+    if rr.Code != http.StatusOK {
+        t.Errorf("expected 200 got %d", rr.Code)
+    }
+
+    var res discoveryOAuth2
+    err := json.NewDecoder(rr.Result().Body).Decode(&res)
+    require.NoError(t, err)
+
+    require.Equal(t, discoveryOAuth2{
+        Issuer:         httpServer.URL,
+        Auth:           fmt.Sprintf("%s/auth", httpServer.URL),
+        Token:          fmt.Sprintf("%s/token", httpServer.URL),
+        Keys:           fmt.Sprintf("%s/keys", httpServer.URL),
+        DeviceEndpoint: fmt.Sprintf("%s/device/code", httpServer.URL),
+        Introspect:     fmt.Sprintf("%s/token/introspect", httpServer.URL),
+        GrantTypes: []string{
+            "authorization_code",
+            "refresh_token",
+            "urn:ietf:params:oauth:grant-type:device_code",
+            "urn:ietf:params:oauth:grant-type:token-exchange",
+        },
+        ResponseTypes: []string{
+            "code",
+        },
+        CodeChallengeAlgs: []string{
+            "S256",
+            "plain",
+        },
+        Scopes: []string{
+            "offline_access",
+        },
+        AuthMethods: []string{
+            "client_secret_basic",
+            "client_secret_post",
+        },
+    }, res)
 }
 
 func TestHandleHealthFailure(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -452,11 +452,17 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	}
 	r.NotFoundHandler = http.NotFoundHandler()
 
-	discoveryHandler, err := s.discoveryHandler()
+	oidcHandler, err := s.discoveryHandler(DiscoveryOIDC)
 	if err != nil {
 		return nil, err
 	}
-	handleWithCORS("/.well-known/openid-configuration", discoveryHandler)
+	handleWithCORS("/.well-known/openid-configuration", oidcHandler)
+
+	oauthHandler, err := s.discoveryHandler(DiscoveryOAuth2)
+	if err != nil {
+		return nil, err
+	}
+	handleWithCORS("/.well-known/oauth-authorization-server", oauthHandler)
 	// Handle the root path for the better user experience.
 	handleWithCORS("/", func(w http.ResponseWriter, r *http.Request) {
 		_, err := fmt.Fprintf(w, `<!DOCTYPE html>


### PR DESCRIPTION
#### Overview

This PR adds support for the OAuth 2.0 Authorization Server Metadata endpoint defined in [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414). 
Alongside the existing OIDC discovery document, this PR exposes a dedicated well‑known endpoint for OAuth 2.0 metadata.

#### What this PR does / why we need it

- Implements the endpoint /.well-known/oauth-authorization-server as specified in RFC 8414.
- Introduces separate discovery structures for OIDC and OAuth2 to ensure correct metadata for each protocol.
- Adds full test coverage for both discovery endpoints.

This feature enables better interoperability with systems and MCPs that rely on OAuth 2.0 Authorization Server Metadata, making Dex more compliant with modern standards and forward‑looking integrations.

Related issue: 

- #4444
