### PR TITLE
fix: device callback URL needs to handle a /

### DIFF
--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -491,7 +491,7 @@ func (s *Server) parseAuthorizationRequest(r *http.Request) (*storage.AuthReques
 		return nil, newDisplayedErr(http.StatusBadRequest, "Unregistered redirect_uri (%q).", redirectURI)
 	}
 	if redirectURI == deviceCallbackURI && client.Public {
-		redirectURI = s.issuerURL.Path + deviceCallbackURI
+		redirectURI = s.absPath(deviceCallbackURI)
 	}
 
 	// From here on out, we want to redirect back to the client with an error.


### PR DESCRIPTION
If the issuer path ends with a / the URL will be built wrong so we should instead use the helper function to ensure the path is built correctly. fixes #4242.