### PR TITLE
fix: handle url fragments for redirects

### DIFF
--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -16,4 +16,13 @@
   </div>
 </div>
 
+<script type="text/javascript">
+  if (window.location.hash) {
+    var buttons = document.querySelectorAll('div.theme-form-row a');
+    buttons.forEach(function(button) {
+      button.href = button.href + window.location.hash;
+    });
+  }
+</script>
+
 {{ template "footer.html" . }}

--- a/web/templates/password.html
+++ b/web/templates/password.html
@@ -38,6 +38,11 @@
     var el = document.querySelector('#submit-login');
     el.setAttribute('disabled', 'disabled');
   };
+
+  if (window.location.hash) {
+    var form = document.querySelector('form');
+    form.action = (form.action || '') + window.location.hash;
+  }
 </script>
 
 {{ template "footer.html" . }}


### PR DESCRIPTION
#### Overview

Includes original URL fragment throughout auth process to keep it in the original redirect. 

#### What this PR does / why we need it

Closes #4462

Including the URL fragment on the pages that do form posts to different URL (not to self) and anchor links to providers.  

#### Special notes for your reviewer

What are implications of adding the hash to the URLs on the login.html page. Do some providers use the hash and if so this will mess up the url fragment. Maybe we should only add it to the password.html page.  

Tested manually using the following flow:
1. Run dex `./bin/dex serve examples/config-dev.yaml`
2. Run example app `cd examples && go run ./example-app`
3. Go to `http://127.0.0.1:5555/` click login
4. Add `#foobar` to the URL and force refresh
5. Click "Login with email" and observe the fragment is still there
6. Add `#foobar` to the URL and force refresh
7. Login using static user credentials `admin@example.com` and `password` and observe the fragment is still there after being redirected.