### PR TITLE
Enable `ContinueOnConnectorFailure` feature flag

### DIFF
--- a/pkg/featureflags/set.go
+++ b/pkg/featureflags/set.go
@@ -13,5 +13,5 @@ var (
 	APIConnectorsCRUD = newFlag("api_connectors_crud", false)
 
 	// ContinueOnConnectorFailure allows the server to start even if some connectors fail to initialize.
-	ContinueOnConnectorFailure = newFlag("continue_on_connector_failure", false)
+	ContinueOnConnectorFailure = newFlag("continue_on_connector_failure", true)
 )


### PR DESCRIPTION
#### Overview

Following up on [this comment](https://github.com/dexidp/dex/pull/4159#discussion_r2145398108) here to enable the `continue_on_connector_failure` feature flag by default. 

cc: @nabokihms