### PR TITLE
feat: support claim-based group name modification with separators

### DIFF
--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -65,8 +65,7 @@ func TestHandleCallback(t *testing.T) {
 		token                     map[string]interface{}
 		groupsRegex               string
 		newGroupFromClaims        []NewGroupFromClaims
-		groupsPrefix              string
-		groupsSuffix              string
+		modifyGroupNames          ModifyGroupNames
 	}{
 		{
 			name:               "simpleCase",
@@ -406,7 +405,9 @@ func TestHandleCallback(t *testing.T) {
 			expectUserName:     "namevalue",
 			expectGroups:       []string{"prefix-group1", "prefix-group2", "prefix-groupA", "prefix-groupB"},
 			expectedEmailField: "emailvalue",
-			groupsPrefix:       "prefix-",
+			modifyGroupNames: ModifyGroupNames{
+				Prefix: ValueOrClaim{Value: "prefix-"},
+			},
 			token: map[string]interface{}{
 				"sub":            "subvalue",
 				"name":           "namevalue",
@@ -423,7 +424,9 @@ func TestHandleCallback(t *testing.T) {
 			expectUserName:     "namevalue",
 			expectGroups:       []string{"group1-suffix", "group2-suffix", "groupA-suffix", "groupB-suffix"},
 			expectedEmailField: "emailvalue",
-			groupsSuffix:       "-suffix",
+			modifyGroupNames: ModifyGroupNames{
+				Suffix: ValueOrClaim{Value: "-suffix"},
+			},
 			token: map[string]interface{}{
 				"sub":            "subvalue",
 				"name":           "namevalue",
@@ -440,8 +443,10 @@ func TestHandleCallback(t *testing.T) {
 			expectUserName:     "namevalue",
 			expectGroups:       []string{"prefix-group1-suffix", "prefix-group2-suffix", "prefix-groupA-suffix", "prefix-groupB-suffix"},
 			expectedEmailField: "emailvalue",
-			groupsPrefix:       "prefix-",
-			groupsSuffix:       "-suffix",
+			modifyGroupNames: ModifyGroupNames{
+				Prefix: ValueOrClaim{Value: "prefix-"},
+				Suffix: ValueOrClaim{Value: "-suffix"},
+			},
 			token: map[string]interface{}{
 				"sub":            "subvalue",
 				"name":           "namevalue",
@@ -521,8 +526,7 @@ func TestHandleCallback(t *testing.T) {
 			config.ClaimMapping.GroupsKey = tc.groupsKey
 			config.ClaimMutations.NewGroupFromClaims = tc.newGroupFromClaims
 			config.ClaimMutations.FilterGroupClaims.GroupsFilter = tc.groupsRegex
-			config.ClaimMutations.ModifyGroupNames.Prefix = tc.groupsPrefix
-			config.ClaimMutations.ModifyGroupNames.Suffix = tc.groupsSuffix
+			config.ClaimMutations.ModifyGroupNames = tc.modifyGroupNames
 
 			conn, err := newConnector(config)
 			if err != nil {


### PR DESCRIPTION
**Overview**
This PR adds the ability to reference OIDC claims when modifying group names as prefixes and suffixes, moving beyond static string values. This enables more dynamic group naming strategies based on claim data.

**Problem**
Previously, group name prefixes and suffixes could only be static strings. Organizations need the ability to incorporate claim values (e.g., organization name, environment) dynamically into group names.

**Solution**
Introduces a new ValueOrClaim union type that allows specifying either:

- A literal string (Value field)
- A reference to an OIDC claim (Claim field)
- An optional separator (Separator field) applied directionally
- This replaces the previous string-based approach with a more flexible, extensible pattern.

This basically extends the functionality of #4144 to allow to use other claims as prefix & suffix.

**Special notes for your reviewer**