### PR TITLE
feat: Disallow unknown config fields

### DIFF
--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -96,8 +96,14 @@ func runServe(options serveOptions) error {
 	}
 
 	var c Config
-	if err := yaml.Unmarshal(configData, &c); err != nil {
+
+	jsonConfigData, err := yaml.YAMLToJSON(configData)
+	if err != nil {
 		return fmt.Errorf("error parse config file %s: %v", configFile, err)
+	}
+
+	if err := configUnmarshaller(jsonConfigData, &c); err != nil {
+		return fmt.Errorf("error unmarshalling config file %s: %v", configFile, err)
 	}
 
 	applyConfigOverrides(options, &c)

--- a/pkg/featureflags/set.go
+++ b/pkg/featureflags/set.go
@@ -14,4 +14,7 @@ var (
 
 	// ContinueOnConnectorFailure allows the server to start even if some connectors fail to initialize.
 	ContinueOnConnectorFailure = newFlag("continue_on_connector_failure", true)
+
+	// ConfigDisallowUnknownFields enables to forbid unknown fields in the config while unmarshaling.
+	ConfigDisallowUnknownFields = newFlag("config_disallow_unknown_fields", false)
 )

--- a/storage/etcd/config.go
+++ b/storage/etcd/config.go
@@ -15,10 +15,10 @@ var defaultDialTimeout = 2 * time.Second
 
 // SSL represents SSL options for etcd databases.
 type SSL struct {
-	ServerName string `json:"serverName" yaml:"serverName"`
-	CAFile     string `json:"caFile" yaml:"caFile"`
-	KeyFile    string `json:"keyFile" yaml:"keyFile"`
-	CertFile   string `json:"certFile" yaml:"certFile"`
+	ServerName string `json:"serverName"`
+	CAFile     string `json:"caFile"`
+	KeyFile    string `json:"keyFile"`
+	CertFile   string `json:"certFile"`
 }
 
 // Etcd options for connecting to etcd databases.
@@ -26,11 +26,11 @@ type SSL struct {
 // configure an etcd namespace either via Namespace field or using `etcd grpc-proxy
 // --namespace=<prefix>`
 type Etcd struct {
-	Endpoints []string `json:"endpoints" yaml:"endpoints"`
-	Namespace string   `json:"namespace" yaml:"namespace"`
-	Username  string   `json:"username" yaml:"username"`
-	Password  string   `json:"password" yaml:"password"`
-	SSL       SSL      `json:"ssl" yaml:"ssl"`
+	Endpoints []string `json:"endpoints"`
+	Namespace string   `json:"namespace"`
+	Username  string   `json:"username"`
+	Password  string   `json:"password"`
+	SSL       SSL      `json:"ssl"`
 }
 
 // Open creates a new storage implementation backed by Etcd

--- a/storage/sql/config.go
+++ b/storage/sql/config.go
@@ -78,7 +78,7 @@ type SSL struct {
 type Postgres struct {
 	NetworkDB
 
-	SSL SSL `json:"ssl" yaml:"ssl"`
+	SSL SSL `json:"ssl"`
 }
 
 // Open creates a new storage implementation backed by Postgres.
@@ -206,7 +206,7 @@ func (p *Postgres) open(logger *slog.Logger) (*conn, error) {
 type MySQL struct {
 	NetworkDB
 
-	SSL SSL `json:"ssl" yaml:"ssl"`
+	SSL SSL `json:"ssl"`
 
 	// TODO(pborzenkov): used by tests to reduce lock wait timeout. Should
 	// we make it exported and allow users to provide arbitrary params?

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -149,28 +149,28 @@ type Storage interface {
 //   - Public clients: https://developers.google.com/api-client-library/python/auth/installed-app
 type Client struct {
 	// Client ID and secret used to identify the client.
-	ID        string `json:"id" yaml:"id"`
-	IDEnv     string `json:"idEnv" yaml:"idEnv"`
-	Secret    string `json:"secret" yaml:"secret"`
-	SecretEnv string `json:"secretEnv" yaml:"secretEnv"`
+	ID        string `json:"id"`
+	IDEnv     string `json:"idEnv"`
+	Secret    string `json:"secret"`
+	SecretEnv string `json:"secretEnv"`
 
 	// A registered set of redirect URIs. When redirecting from dex to the client, the URI
 	// requested to redirect to MUST match one of these values, unless the client is "public".
-	RedirectURIs []string `json:"redirectURIs" yaml:"redirectURIs"`
+	RedirectURIs []string `json:"redirectURIs"`
 
 	// TrustedPeers are a list of peers which can issue tokens on this client's behalf using
 	// the dynamic "oauth2:server:client_id:(client_id)" scope. If a peer makes such a request,
 	// this client's ID will appear as the ID Token's audience.
 	//
 	// Clients inherently trust themselves.
-	TrustedPeers []string `json:"trustedPeers" yaml:"trustedPeers"`
+	TrustedPeers []string `json:"trustedPeers"`
 
 	// Public clients must use either use a redirectURL 127.0.0.1:X or "urn:ietf:wg:oauth:2.0:oob"
-	Public bool `json:"public" yaml:"public"`
+	Public bool `json:"public"`
 
 	// Name and LogoURL used when displaying this client to the end user.
-	Name    string `json:"name" yaml:"name"`
-	LogoURL string `json:"logoURL" yaml:"logoURL"`
+	Name    string `json:"name"`
+	LogoURL string `json:"logoURL"`
 }
 
 // Claims represents the ID Token claims supported by the server.


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

This pull request introduces a new feature flag to optionally enforce strict config validation by disallowing unknown fields in JSON configuration files. It also refactors config unmarshalling logic to use a centralized function that can toggle this strictness based on the feature flag. Additionally, it removes YAML tags from various struct definitions, standardizing on JSON tags only.

#### What this PR does / why we need it

It is hard to debug misspellings in the config.

#### Special notes for your reviewer

There is a known limitation that only the first error is shown. Other solutions are more complicated.