### PR TITLE
fix: use correct id value for label

### DIFF
--- a/web/templates/password.html
+++ b/web/templates/password.html
@@ -5,7 +5,7 @@
   <form method="post" action="{{ .PostURL }}">
     <div class="theme-form-row">
       <div class="theme-form-label">
-        <label for="userid">{{ .UsernamePrompt }}</label>
+        <label for="login">{{ .UsernamePrompt }}</label>
       </div>
 	  <input tabindex="1" required id="login" name="login" type="text" class="theme-form-input" placeholder="{{ .UsernamePrompt | lower }}" {{ if .Username }} value="{{ .Username }}" {{ else }} autofocus {{ end }}/>
     </div>


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Fixes [https://github.com/dexidp/dex/issues/4540](https://github.com/dexidp/dex/issues/4540)

Fixes an accessibility issue in the default login template where the username `<label>` is not correctly associated with its `<input>`.


#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

The username label currently uses `for="userid"`, but the corresponding input has `id="login"`. This breaks the label/input association, so:

* Clicking the “Username” label does not focus the username field
* Assistive technologies may not correctly associate the label with the input
* Automated testing tools (e.g., Playwright `getByLabelText`) cannot target the field

This PR updates the label to `for="login"` to match the existing input `id`, restoring correct accessibility semantics.