### PR TITLE
feat: enhance git-version script to generate pseudo-versions

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -52,6 +52,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-tags: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
@@ -92,6 +94,12 @@ jobs:
 
       # Multiple exporters are not supported yet
       # See https://github.com/moby/buildkit/pull/2760
+      - name: Get version from git-version script
+        id: version
+        run: echo "value=$(bash ./scripts/git-version)" >> "$GITHUB_OUTPUT"
+
+      # Multiple exporters are not supported yet
+      # See https://github.com/moby/buildkit/pull/2760
       - name: Determine build output
         uses: haya14busa/action-cond@94f77f7a80cd666cb3155084e428254fea4281fd # v1.2.1
         id: build-output
@@ -124,10 +132,11 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             BASE_IMAGE=${{ matrix.variant }}
-            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+            VERSION=${{ steps.version.outputs.value }}
             COMMIT_HASH=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
             BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
           # cache-from: type=gha
           # cache-to: type=gha,mode=max
           outputs: ${{ steps.build-output.outputs.value }}

--- a/scripts/git-version
+++ b/scripts/git-version
@@ -1,14 +1,42 @@
 #!/bin/sh -e
 
 # parse the current git commit hash
-COMMIT=`git rev-parse HEAD`
+COMMIT=`git rev-parse --short=8 HEAD`
 
-# check if the current commit has a matching tag
-TAG=$(git describe --exact-match --abbrev=0 --tags ${COMMIT} 2> /dev/null || true)
+# check if the current commit has a matching tag (filter for v* tags, excluding api/)
+TAG=$(git describe --exact-match --abbrev=0 --tags --match="v[0-9]*" 2> /dev/null || true)
 
 # use the matching tag as the version, if available
 if [ -z "$TAG" ]; then
-    VERSION=$COMMIT
+    # No exact tag on current commit, find the last version tag and bump minor version
+    # Get all tags matching v[0-9]*, sort them, and take the last one
+    LAST_TAG=$(git tag --list "v[0-9]*" --sort=-version:refname | head -1)
+
+    if [ -z "$LAST_TAG" ]; then
+        # No tags found, use v0.1.0 as fallback
+        BASE_VERSION="v0.1.0"
+    else
+        # Parse the last tag and bump minor version
+        # Remove 'v' prefix
+        TAG_WITHOUT_V="${LAST_TAG#v}"
+
+        # Split version into parts (major.minor.patch)
+        MAJOR=$(echo "$TAG_WITHOUT_V" | cut -d. -f1)
+        MINOR=$(echo "$TAG_WITHOUT_V" | cut -d. -f2)
+        PATCH=$(echo "$TAG_WITHOUT_V" | cut -d. -f3)
+
+        # Bump minor version
+        MINOR=$((MINOR + 1))
+
+        # Construct base version with bumped minor
+        BASE_VERSION="v${MAJOR}.${MINOR}.0"
+    fi
+
+    # Get commit timestamp in YYYYMMDDhhmmss format
+    TIMESTAMP=$(git log -1 --format=%ci HEAD | sed 's/[-: ]//g' | cut -c1-14)
+
+    # Construct pseudo-version
+    VERSION="${BASE_VERSION}-${TIMESTAMP}-${COMMIT}"
 else
     VERSION=$TAG
 fi


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Generate a pseudo version instead of using just a branch name.

Use next minor version as the pseudo tag

Example:
```
➜  dex git:(master) ✗ make build > /dev/null 2>&1 && ./bin/dex version
Dex Version: v2.45.0-20260216164129-7d4414ea
Go Version: go1.25.0
Go OS/ARCH: darwin arm64
```

#### What this PR does / why we need it

The main issue is that when we build images on branches, the tag is equal to the branch name, which is not good. 

<img width="1997" height="451" alt="image" src="https://github.com/user-attachments/assets/5ea6a538-5790-4fc9-93be-cb70f09990c3" />

Security scanners trigger alerts on the pseudo version added to buildinfo by golang compiler.

#### Special notes for your reviewer
