### PR TITLE
fix(mysql): quote `groups` reserved word in query replacer

### DIFF
--- a/storage/sql/sql.go
+++ b/storage/sql/sql.go
@@ -95,7 +95,7 @@ var (
 			// For compound indexes (with two keys) even less.
 			{matchLiteral("text"), "varchar(384)"},
 			// Quote keywords and reserved words used as identifiers.
-			{regexp.MustCompile(`\b(keys)\b`), "`$1`"},
+			{regexp.MustCompile(`\b(keys|groups)\b`), "`$1`"},
 			// Change default timestamp to fit datetime.
 			{regexp.MustCompile(`0001-01-01 00:00:00 UTC`), "1000-01-01 00:00:00"},
 		},


### PR DESCRIPTION
Fixes #4579

`groups` is a reserved word in MySQL >= 8.0.2. Migration 13 (from #4456) fails with:

```
migration 13 statement 2 failed: Error 1064 (42000): ... right syntax to use near 'groups blob'
```

Additionally, since MySQL auto-commits DDL, statement 1 (`preferred_username`) is persisted
despite the transaction rollback, leaving the migration in an unrecoverable state on restart.

### Fix

Add `groups` to the existing reserved word quoting regex in `flavorMySQL.queryReplacers`,
alongside `keys` which is already handled.

### Recovery

Users stuck with a half-applied migration 13 need to drop the orphaned column before restarting:

```sql
ALTER TABLE password DROP COLUMN preferred_username;
```