### PR TITLE
fix(connector): update authproxy and oauth to match CallbackConnector

### DIFF
--- a/connector/authproxy/authproxy.go
+++ b/connector/authproxy/authproxy.go
@@ -83,20 +83,20 @@ type callback struct {
 }
 
 // LoginURL returns the URL to redirect the user to login with.
-func (m *callback) LoginURL(s connector.Scopes, callbackURL, state string) (string, error) {
+func (m *callback) LoginURL(s connector.Scopes, callbackURL, state string) (string, []byte, error) {
 	u, err := url.Parse(callbackURL)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse callbackURL %q: %v", callbackURL, err)
+		return "", nil, fmt.Errorf("failed to parse callbackURL %q: %v", callbackURL, err)
 	}
 	u.Path += m.pathSuffix
 	v := u.Query()
 	v.Set("state", state)
 	u.RawQuery = v.Encode()
-	return u.String(), nil
+	return u.String(), nil, nil
 }
 
 // HandleCallback parses the request and returns the user's identity
-func (m *callback) HandleCallback(s connector.Scopes, r *http.Request) (connector.Identity, error) {
+func (m *callback) HandleCallback(s connector.Scopes, _ []byte, r *http.Request) (connector.Identity, error) {
 	remoteUser := r.Header.Get(m.userHeader)
 	if remoteUser == "" {
 		return connector.Identity{}, fmt.Errorf("required HTTP header %s is not set", m.userHeader)

--- a/connector/authproxy/authproxy_test.go
+++ b/connector/authproxy/authproxy_test.go
@@ -36,7 +36,7 @@ func TestUser(t *testing.T) {
 		"X-Remote-User": {testUsername},
 	}
 
-	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, nil, req)
 	expectNil(t, err)
 
 	// If not specified, the userID and email should fall back to the remote user
@@ -62,7 +62,7 @@ func TestExtraHeaders(t *testing.T) {
 		"X-Remote-User-Email": {testEmail},
 	}
 
-	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, nil, req)
 	expectNil(t, err)
 
 	expectEquals(t, ident.UserID, testUserID)
@@ -85,7 +85,7 @@ func TestSingleGroup(t *testing.T) {
 		"X-Remote-Group": {testGroup1},
 	}
 
-	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, nil, req)
 	expectNil(t, err)
 
 	expectEquals(t, ident.UserID, testEmail)
@@ -106,7 +106,7 @@ func TestMultipleGroup(t *testing.T) {
 		"X-Remote-Group": {testGroup1 + ", " + testGroup2 + ", " + testGroup3 + ", " + testGroup4},
 	}
 
-	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, nil, req)
 	expectNil(t, err)
 
 	expectEquals(t, ident.UserID, testEmail)
@@ -132,7 +132,7 @@ func TestMultipleGroupWithCustomSeparator(t *testing.T) {
 		"X-Remote-Group": {testGroup1 + ";" + testGroup2 + ";" + testGroup3 + ";" + testGroup4},
 	}
 
-	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, nil, req)
 	expectNil(t, err)
 
 	expectEquals(t, ident.UserID, testEmail)
@@ -158,7 +158,7 @@ func TestStaticGroup(t *testing.T) {
 		"X-Remote-Group": {testGroup1 + ", " + testGroup2 + ", " + testGroup3 + ", " + testGroup4},
 	}
 
-	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, req)
+	ident, err := callback.HandleCallback(connector.Scopes{OfflineAccess: true, Groups: true}, nil, req)
 	expectNil(t, err)
 
 	expectEquals(t, ident.UserID, testEmail)

--- a/connector/oauth/oauth.go
+++ b/connector/oauth/oauth.go
@@ -116,9 +116,9 @@ func (c *Config) Open(id string, logger *slog.Logger) (connector.Connector, erro
 	return oauthConn, err
 }
 
-func (c *oauthConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
+func (c *oauthConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, []byte, error) {
 	if c.redirectURI != callbackURL {
-		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
+		return "", nil, fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}
 
 	oauth2Config := &oauth2.Config{
@@ -129,10 +129,10 @@ func (c *oauthConnector) LoginURL(scopes connector.Scopes, callbackURL, state st
 		Scopes:       c.scopes,
 	}
 
-	return oauth2Config.AuthCodeURL(state), nil
+	return oauth2Config.AuthCodeURL(state), nil, nil
 }
 
-func (c *oauthConnector) HandleCallback(s connector.Scopes, r *http.Request) (identity connector.Identity, err error) {
+func (c *oauthConnector) HandleCallback(s connector.Scopes, _ []byte, r *http.Request) (identity connector.Identity, err error) {
 	q := r.URL.Query()
 	if errType := q.Get("error"); errType != "" {
 		return identity, errors.New(q.Get("error_description"))

--- a/connector/oauth/oauth_test.go
+++ b/connector/oauth/oauth_test.go
@@ -50,7 +50,7 @@ func TestLoginURL(t *testing.T) {
 
 	conn := newConnector(t, testServer.URL)
 
-	loginURL, err := conn.LoginURL(connector.Scopes{}, conn.redirectURI, "some-state")
+	loginURL, _, err := conn.LoginURL(connector.Scopes{}, conn.redirectURI, "some-state")
 	assert.Equal(t, err, nil)
 
 	expectedURL, err := url.Parse(testServer.URL + "/authorize")
@@ -86,7 +86,7 @@ func TestHandleCallBackForGroupsInUserInfo(t *testing.T) {
 	conn := newConnector(t, testServer.URL)
 	req := newRequestWithAuthCode(t, testServer.URL, "TestHandleCallBackForGroupsInUserInfo")
 
-	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 	assert.Equal(t, err, nil)
 
 	sort.Strings(identity.Groups)
@@ -122,7 +122,7 @@ func TestHandleCallBackForGroupMapsInUserInfo(t *testing.T) {
 	conn := newConnector(t, testServer.URL)
 	req := newRequestWithAuthCode(t, testServer.URL, "TestHandleCallBackForGroupMapsInUserInfo")
 
-	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 	assert.Equal(t, err, nil)
 
 	sort.Strings(identity.Groups)
@@ -156,7 +156,7 @@ func TestHandleCallBackForGroupsInToken(t *testing.T) {
 	conn := newConnector(t, testServer.URL)
 	req := newRequestWithAuthCode(t, testServer.URL, "TestHandleCallBackForGroupsInToken")
 
-	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 	assert.Equal(t, err, nil)
 
 	assert.Equal(t, len(identity.Groups), 1)
@@ -186,7 +186,7 @@ func TestHandleCallbackForNumericUserID(t *testing.T) {
 	conn := newConnector(t, testServer.URL)
 	req := newRequestWithAuthCode(t, testServer.URL, "TestHandleCallbackForNumericUserID")
 
-	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 	assert.Equal(t, err, nil)
 
 	assert.Equal(t, identity.UserID, "1000")


### PR DESCRIPTION
Fix for https://github.com/dexidp/dex/issues/4588

In v2.45.0, PKCE support was added to the OIDC connector (commit `25591eea`). This changed the `CallbackConnector` interface in `connector/connector.go`:

```go
// OLD (v2.44.0)
LoginURL(s Scopes, callbackURL, state string) (string, error)
HandleCallback(s Scopes, r *http.Request) (identity Identity, err error)

// NEW (v2.45.0)
LoginURL(s Scopes, callbackURL, state string) (string, []byte, error)
HandleCallback(s Scopes, connData []byte, r *http.Request) (identity Identity, err error)
```

Most connectors (github, gitlab, google, oidc, microsoft, etc.) were updated to match the new interface, but **authproxy** and **oauth** were missed.

Because these two connectors no longer satisfy the `CallbackConnector` interface, the type switch in `server/handlers.go:handleConnectorLogin()` falls through to the `default` case, which renders the "Requested resource does not exist." error.