### PR TITLE
fix(refreshhandlers): preserve existing username

### DIFF
--- a/connector/google/google.go
+++ b/connector/google/google.go
@@ -247,6 +247,15 @@ func (c *googleConnector) createIdentity(ctx context.Context, identity connector
 		return identity, fmt.Errorf("oidc: failed to decode claims: %v", err)
 	}
 
+	// Google sometimes do not return username and other claims. It is correct, according to OIDC spec.
+	// One option to solve this is to call the user endpoint, but Google throttles it more aggressive than
+	// the token endpoint. For concurrent refreshes it is an unwanted behavior.
+	// As a tradeoff, dex preserves previous username and preferred username if absent in the ide token
+	// as a way to keep the claims and do not call the userinfo endpoint.
+	if claims.Username == "" {
+		claims.Username = identity.Username
+	}
+
 	if len(c.hostedDomains) > 0 {
 		found := false
 		for _, domain := range c.hostedDomains {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

The name claim is missing in ID tokens after using `refresh_token` grant with certain OIDC providers (e.g., Google). 

During initial authentication, Google returns the name field in the ID token. However, when refreshing tokens, Google's OAuth2 endpoint does not include the name field in the refreshed ID token. This causes the name claim to be lost in subsequent ID tokens issued by Dex.

#### What this PR does / why we need it

Modified the refresh token update logic in `server/refreshhandlers.go` to preserve `username` and `preferred_username` from the stored refresh token when the connector returns empty values. The fix ensures that:

- If the connector returns an empty username but the stored token has one, the old value is preserved
- If the connector returns a username, it updates the stored value
- The preserved username is used in both the stored refresh token and the identity object returned to create new tokens

#### Special notes for your reviewer

- I only test it with Google connector
- I test it both manually and added the test case in `server/refreshhandlers_test.go`
- Fixes #4458