### PR TITLE
docs: document Docker gomplate configuration

### DIFF
--- a/examples/k8s/dex.yaml
+++ b/examples/k8s/dex.yaml
@@ -25,6 +25,9 @@ spec:
       containers:
       - image: ghcr.io/dexidp/dex:v2.32.0
         name: dex
+        # This example runs the dex binary directly, so the Docker entrypoint's
+        # gomplate preprocessing is skipped. The $GITHUB_* values below are
+        # expanded by dex's built-in config environment expansion.
         command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
 
         ports:


### PR DESCRIPTION
#### Overview

Closes #2645.

#### What this PR does / why we need it

- Documents that the official container entrypoint renders `.yaml`, `.tpl`, and `.tmpl` config arguments with gomplate before starting dex.
- Clarifies that this preprocessing is separate from dex's built-in `$VAR` config expansion.
- Notes that the Kubernetes example overrides the image entrypoint, so it uses dex config expansion rather than gomplate.

#### Special notes for your reviewer

Validation:
- `go test ./cmd/docker-entrypoint -run TestRun -count=1`
- `go test ./cmd/dex -run "TestUnmarshalConfigWithEnv(NoExpand|Expand)$" -count=1`
- `git diff --check`