### PR TITLE
feat(google): fetch groups in parallel

### DIFF
--- a/connector/google/google.go
+++ b/connector/google/google.go
@@ -8,7 +8,9 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
@@ -16,6 +18,7 @@ import (
 	"golang.org/x/exp/slices"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"golang.org/x/sync/errgroup"
 	admin "google.golang.org/api/admin/directory/v1"
 	"google.golang.org/api/impersonate"
 	"google.golang.org/api/option"
@@ -27,6 +30,10 @@ import (
 const (
 	issuerURL                  = "https://accounts.google.com"
 	wildcardDomainToAdminEmail = "*"
+
+	// defaultConcurrentGroupLookups is the limit used when Config.MaxConcurrentGroupLookups
+	// is zero or negative.
+	defaultConcurrentGroupLookups = 10
 )
 
 // Config holds configuration options for Google logins.
@@ -60,6 +67,10 @@ type Config struct {
 
 	// If this field is true, fetch direct group membership and transitive group membership
 	FetchTransitiveGroupMembership bool `json:"fetchTransitiveGroupMembership"`
+
+	// MaxConcurrentGroupLookups limits concurrent Admin Directory API calls when resolving
+	// transitive group membership. If zero or negative, the connector default limit applies.
+	MaxConcurrentGroupLookups int `json:"maxConcurrentGroupLookups"`
 
 	// Optional value for the prompt parameter, defaults to consent when offline_access
 	// scope is requested
@@ -119,6 +130,11 @@ func (c *Config) Open(id string, logger *slog.Logger) (conn connector.Connector,
 	}
 
 	clientID := c.ClientID
+	maxConcurrent := c.MaxConcurrentGroupLookups
+	if maxConcurrent <= 0 {
+		maxConcurrent = defaultConcurrentGroupLookups
+	}
+
 	return &googleConnector{
 		redirectURI: c.RedirectURI,
 		oauth2Config: &oauth2.Config{
@@ -138,6 +154,7 @@ func (c *Config) Open(id string, logger *slog.Logger) (conn connector.Connector,
 		serviceAccountFilePath:         c.ServiceAccountFilePath,
 		domainToAdminEmail:             c.DomainToAdminEmail,
 		fetchTransitiveGroupMembership: c.FetchTransitiveGroupMembership,
+		maxConcurrentGroupLookups:      maxConcurrent,
 		adminSrv:                       adminSrv,
 		promptType:                     promptType,
 	}, nil
@@ -159,6 +176,7 @@ type googleConnector struct {
 	serviceAccountFilePath         string
 	domainToAdminEmail             map[string]string
 	fetchTransitiveGroupMembership bool
+	maxConcurrentGroupLookups      int
 	adminSrv                       map[string]*admin.Service
 	promptType                     string
 }
@@ -272,8 +290,7 @@ func (c *googleConnector) createIdentity(ctx context.Context, identity connector
 
 	var groups []string
 	if s.Groups && len(c.adminSrv) > 0 {
-		checkedGroups := make(map[string]struct{})
-		groups, err = c.getGroups(claims.Email, c.fetchTransitiveGroupMembership, checkedGroups)
+		groups, err = c.getGroups(ctx, claims.Email, c.fetchTransitiveGroupMembership)
 		if err != nil {
 			return identity, fmt.Errorf("google: could not retrieve groups: %v", err)
 		}
@@ -298,44 +315,99 @@ func (c *googleConnector) createIdentity(ctx context.Context, identity connector
 }
 
 // getGroups creates a connection to the admin directory service and lists
-// all groups the user is a member of
-func (c *googleConnector) getGroups(email string, fetchTransitiveGroupMembership bool, checkedGroups map[string]struct{}) ([]string, error) {
-	var userGroups []string
-	var err error
-	groupsList := &admin.Groups{}
-	domain := c.extractDomainFromEmail(email)
+// all groups the user is a member of.
+func (c *googleConnector) getGroups(ctx context.Context, email string, fetchTransitiveGroupMembership bool) ([]string, error) {
+	directGroups, err := c.listGroupEmails(ctx, email)
+	if err != nil {
+		return nil, err
+	}
+
+	var seenMu sync.Mutex
+	seen := make(map[string]struct{})
+	userGroups := make([]string, 0, len(directGroups))
+	addGroup := func(groupEmail string) bool {
+		seenMu.Lock()
+		defer seenMu.Unlock()
+		if _, exists := seen[groupEmail]; exists {
+			return false
+		}
+		seen[groupEmail] = struct{}{}
+		// TODO (joelspeed): Make desired group key configurable
+		userGroups = append(userGroups, groupEmail)
+		return true
+	}
+
+	seeds := make([]string, 0, len(directGroups))
+	for _, groupEmail := range directGroups {
+		if addGroup(groupEmail) {
+			seeds = append(seeds, groupEmail)
+		}
+	}
+
+	if !fetchTransitiveGroupMembership || len(seeds) == 0 {
+		sort.Strings(userGroups)
+		return userGroups, nil
+	}
+
+	apiSem := make(chan struct{}, c.maxConcurrentGroupLookups)
+	g, gctx := errgroup.WithContext(ctx)
+
+	var enqueue func(string)
+	enqueue = func(groupEmail string) {
+		g.Go(func() error {
+			if err := gctx.Err(); err != nil {
+				return err
+			}
+			select {
+			case <-gctx.Done():
+				return gctx.Err()
+			case apiSem <- struct{}{}:
+			}
+			defer func() { <-apiSem }()
+
+			parentGroups, err := c.listGroupEmails(gctx, groupEmail)
+			if err != nil {
+				return fmt.Errorf("could not list transitive groups: %w", err)
+			}
+			for _, parent := range parentGroups {
+				if addGroup(parent) {
+					enqueue(parent)
+				}
+			}
+			return nil
+		})
+	}
+
+	for _, groupEmail := range seeds {
+		enqueue(groupEmail)
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	sort.Strings(userGroups)
+	return userGroups, nil
+}
+
+func (c *googleConnector) listGroupEmails(ctx context.Context, userKey string) ([]string, error) {
+	domain := c.extractDomainFromEmail(userKey)
 	adminSrv, err := c.findAdminService(domain)
 	if err != nil {
 		return nil, err
 	}
 
+	groupEmails := []string{}
+	groupsList := &admin.Groups{}
 	for {
 		groupsList, err = adminSrv.Groups.List().
-			UserKey(email).PageToken(groupsList.NextPageToken).Do()
+			UserKey(userKey).PageToken(groupsList.NextPageToken).Context(ctx).Do()
 		if err != nil {
 			return nil, fmt.Errorf("could not list groups: %v", err)
 		}
 
 		for _, group := range groupsList.Groups {
-			if _, exists := checkedGroups[group.Email]; exists {
-				continue
-			}
-
-			checkedGroups[group.Email] = struct{}{}
-			// TODO (joelspeed): Make desired group key configurable
-			userGroups = append(userGroups, group.Email)
-
-			if !fetchTransitiveGroupMembership {
-				continue
-			}
-
-			// getGroups takes a user's email/alias as well as a group's email/alias
-			transitiveGroups, err := c.getGroups(group.Email, fetchTransitiveGroupMembership, checkedGroups)
-			if err != nil {
-				return nil, fmt.Errorf("could not list transitive groups: %v", err)
-			}
-
-			userGroups = append(userGroups, transitiveGroups...)
+			groupEmails = append(groupEmails, group.Email)
 		}
 
 		if groupsList.NextPageToken == "" {
@@ -343,7 +415,7 @@ func (c *googleConnector) getGroups(email string, fetchTransitiveGroupMembership
 		}
 	}
 
-	return userGroups, nil
+	return groupEmails, nil
 }
 
 func (c *googleConnector) findAdminService(domain string) (*admin.Service, error) {

--- a/connector/google/google_test.go
+++ b/connector/google/google_test.go
@@ -10,7 +10,9 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	admin "google.golang.org/api/admin/directory/v1"
@@ -32,7 +34,8 @@ var (
 		"groups_2@dexidp.com": {{Email: "groups_0@dexidp.com"}},
 		"groups_0@dexidp.com": {},
 	}
-	callCounter = make(map[string]int)
+	callCounterMu sync.Mutex
+	callCounter   = make(map[string]int)
 )
 
 func testSetup() *httptest.Server {
@@ -43,7 +46,9 @@ func testSetup() *httptest.Server {
 		userKey := r.URL.Query().Get("userKey")
 		if groups, ok := testGroups[userKey]; ok {
 			json.NewEncoder(w).Encode(admin.Groups{Groups: groups})
+			callCounterMu.Lock()
 			callCounter[userKey]++
+			callCounterMu.Unlock()
 		}
 	})
 
@@ -224,21 +229,69 @@ func TestGetGroups(t *testing.T) {
 		},
 	} {
 		testCase := testCase
-		callCounter = map[string]int{}
+		callCounterMu.Lock()
+		callCounter = make(map[string]int)
+		callCounterMu.Unlock()
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			lookup := make(map[string]struct{})
 
-			groups, err := conn.getGroups(testCase.userKey, testCase.fetchTransitiveGroupMembership, lookup)
+			groups, err := conn.getGroups(context.Background(), testCase.userKey, testCase.fetchTransitiveGroupMembership)
 			if testCase.shouldErr {
 				assert.NotNil(err)
 			} else {
 				assert.Nil(err)
 			}
 			assert.ElementsMatch(testCase.expectedGroups, groups)
-			t.Logf("[%s] Amount of API calls per userKey: %+v\n", t.Name(), callCounter)
+			callCounterMu.Lock()
+			s := fmt.Sprintf("%+v", callCounter)
+			callCounterMu.Unlock()
+			t.Logf("[%s] Amount of API calls per userKey: %s\n", t.Name(), s)
 		})
 	}
+}
+
+// Regression test for MaxConcurrentGroupLookups=1 with a user -> A -> B membership chain.
+func TestGetGroups_transitiveNoDeadlockAtConcurrentLimitOne(t *testing.T) {
+	chain := map[string][]*admin.Group{
+		"user_chain@dexidp.com": {{Email: "group_a@dexidp.com"}},
+		"group_a@dexidp.com":    {{Email: "group_b@dexidp.com"}},
+		"group_b@dexidp.com":    {},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/admin/directory/v1/groups/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		userKey := r.URL.Query().Get("userKey")
+		if groups, ok := chain[userKey]; ok {
+			_ = json.NewEncoder(w).Encode(admin.Groups{Groups: groups})
+		}
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	serviceAccountFilePath, err := tempServiceAccountKey()
+	assert.Nil(t, err)
+
+	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", serviceAccountFilePath)
+	conn, err := newConnector(&Config{
+		ClientID:                  "testClient",
+		ClientSecret:              "testSecret",
+		RedirectURI:               ts.URL + "/callback",
+		Scopes:                    []string{"openid", "groups"},
+		DomainToAdminEmail:        map[string]string{"*": "admin@dexidp.com"},
+		MaxConcurrentGroupLookups: 1,
+	})
+	assert.Nil(t, err)
+
+	conn.adminSrv[wildcardDomainToAdminEmail], err = admin.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(ts.URL))
+	assert.Nil(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	groups, err := conn.getGroups(ctx, "user_chain@dexidp.com", true)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"group_a@dexidp.com", "group_b@dexidp.com"}, groups)
 }
 
 func TestDomainToAdminEmailConfig(t *testing.T) {
@@ -280,18 +333,22 @@ func TestDomainToAdminEmailConfig(t *testing.T) {
 		},
 	} {
 		testCase := testCase
-		callCounter = map[string]int{}
+		callCounterMu.Lock()
+		callCounter = make(map[string]int)
+		callCounterMu.Unlock()
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			lookup := make(map[string]struct{})
 
-			_, err := conn.getGroups(testCase.userKey, true, lookup)
+			_, err := conn.getGroups(context.Background(), testCase.userKey, true)
 			if testCase.expectedErr != "" {
 				assert.ErrorContains(err, testCase.expectedErr)
 			} else {
 				assert.Nil(err)
 			}
-			t.Logf("[%s] Amount of API calls per userKey: %+v\n", t.Name(), callCounter)
+			callCounterMu.Lock()
+			s := fmt.Sprintf("%+v", callCounter)
+			callCounterMu.Unlock()
+			t.Logf("[%s] Amount of API calls per userKey: %s\n", t.Name(), s)
 		})
 	}
 }
@@ -381,9 +438,8 @@ func TestGCEWorkloadIdentity(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			lookup := make(map[string]struct{})
 
-			_, err := conn.getGroups(testCase.userKey, true, lookup)
+			_, err := conn.getGroups(context.Background(), testCase.userKey, true)
 			if testCase.expectedErr != "" {
 				assert.ErrorContains(err, testCase.expectedErr)
 			} else {

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	golang.org/x/exp v0.0.0-20240823005443-9b4947da3948
 	golang.org/x/net v0.53.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
 	google.golang.org/api v0.277.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
@@ -141,7 +142,6 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/mod v0.34.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.15.0 // indirect


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

Fetches nested (transitive) group membership in parallel (with a concurrency limit) instead of strictly sequential API calls, so large/deep group graphs complete faster.

In my tests the loading times went form 10-15 seconds down to 2-3 seconds. I tested the changes with 20 nested groups. And I'm using this fork for over a month with no problems.

Closes https://github.com/dexidp/dex/issues/3929

#### Special notes for your reviewer
