### PR TITLE
feat(server): log successful token exchange requests

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1856,6 +1856,18 @@ func (s *Server) handleTokenExchange(w http.ResponseWriter, r *http.Request, cli
 		return
 	}
 
+	email := identity.Email
+	if !identity.EmailVerified {
+		email += " (unverified)"
+	}
+
+	s.logger.InfoContext(ctx, "token exchange successful",
+		"connector_id", connID, "client_id", client.ID,
+		"user_id", identity.UserID,
+		"username", identity.Username, "preferred_username", identity.PreferredUsername,
+		"email", email, "groups", identity.Groups,
+		"subject_token_type", subjectTokenType, "requested_token_type", requestedTokenType)
+
 	claims := storage.Claims{
 		UserID:            identity.UserID,
 		Username:          identity.Username,

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1739,6 +1740,56 @@ func TestHandleTokenExchange(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleTokenExchangeLogsSuccess(t *testing.T) {
+	ctx := t.Context()
+	var logBuf bytes.Buffer
+	httpServer, s := newTestServer(t, func(c *Config) {
+		c.Logger = slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		c.Storage.CreateClient(ctx, storage.Client{
+			ID:     "client_1",
+			Secret: "secret_1",
+		})
+	})
+	defer httpServer.Close()
+
+	vals := make(url.Values)
+	vals.Set("grant_type", grantTypeTokenExchange)
+	vals.Set("connector_id", "mock")
+	vals.Set("scope", "openid")
+	vals.Set("requested_token_type", tokenTypeAccess)
+	vals.Set("subject_token_type", tokenTypeID)
+	vals.Set("subject_token", "foobar")
+	vals.Set("client_id", "client_1")
+	vals.Set("client_secret", "secret_1")
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, httpServer.URL+"/token", strings.NewReader(vals.Encode()))
+	req.Header.Set("content-type", "application/x-www-form-urlencoded")
+
+	s.handleToken(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var found map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(logBuf.String()), "\n") {
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &entry))
+		if entry["msg"] == "token exchange successful" {
+			found = entry
+			break
+		}
+	}
+	require.NotNil(t, found, "expected \"token exchange successful\" log line, got: %s", logBuf.String())
+	require.Equal(t, "INFO", found["level"])
+	require.Equal(t, "mock", found["connector_id"])
+	require.Equal(t, "client_1", found["client_id"])
+	require.Equal(t, "0-385-28089-0", found["user_id"])
+	require.Equal(t, "Kilgore Trout", found["username"])
+	require.Equal(t, "kilgore@kilgore.trout", found["email"])
+	require.Equal(t, []any{"authors"}, found["groups"])
+	require.Equal(t, tokenTypeID, found["subject_token_type"])
+	require.Equal(t, tokenTypeAccess, found["requested_token_type"])
 }
 
 func TestHandleTokenExchangeConnectorGrantTypeRestriction(t *testing.T) {


### PR DESCRIPTION
#### Overview

Adds an info-level `"token exchange successful"` log line to `handleTokenExchange`, mirroring the existing `"login successful"` log that `finalizeLogin` emits for the authorization code flow.

#### What this PR does / why we need it

The authorization code flow logs a detailed success line in `finalizeLogin` (`server/handlers.go`) with the resolved identity — `user_id`, `username`, `preferred_username`, `email`, `groups`, `connector_id`. This is invaluable for operators auditing who logged in and which groups they had at login time.

The RFC 8693 token exchange flow (`handleTokenExchange`) has no equivalent log line. It only emits error-level logs on failure, so successful CI/CD-style token exchanges are effectively invisible in operator logs — even at debug level, because there is nothing to print on the success path.

This PR adds a single `InfoContext` call after `TokenIdentity` returns, structured the same way as `finalizeLogin`:

- Same fields as `finalizeLogin` for consistency: `connector_id`, `user_id`, `username`, `preferred_username`, `email` (with the same `(unverified)` suffix convention), `groups`.
- Three additional fields specific to this grant: `client_id`, `subject_token_type`, `requested_token_type` — useful operational context when multiple clients or token types use the same connector.
- Different message (`"token exchange successful"` vs `"login successful"`) so log aggregators can distinguish the two flows without keying off `connector_id`.

Example output (JSON handler):

```json
{"time":"...","level":"INFO","msg":"token exchange successful",
 "connector_id":"gitlab-ci","client_id":"argo-cd",
 "user_id":"12345","username":"jane.doe","preferred_username":"",
 "email":"jane.doe@example.com","groups":["gitlab:environment:prod"],
 "subject_token_type":"urn:ietf:params:oauth:token-type:id_token",
 "requested_token_type":"urn:ietf:params:oauth:token-type:access_token"}
```

#### Special notes for your reviewer

- Test added: `TestHandleTokenExchangeLogsSuccess` injects a JSON `slog` handler via the test server config, invokes the token exchange flow, and asserts the log line is emitted with the expected fields. Pattern matches `cmd/dex/excluding_handler_test.go` (`bytes.Buffer` + `NewJSONHandler` + `json.Unmarshal`).
- No API, storage, or behavior changes — this is purely observability.
- `gofmt` and `go vet` clean; full `go test ./server/...` passes.