### PR TITLE
fix(server): enforce client.AllowedConnectors in handleTokenExchange (GHSA-7qjx-gp9h-65qj)

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1832,6 +1832,13 @@ func (s *Server) handleTokenExchange(w http.ResponseWriter, r *http.Request, cli
 		return
 	}
 
+	if !isConnectorAllowed(client.AllowedConnectors, connID) {
+		s.logger.ErrorContext(r.Context(), "connector not allowed for client",
+			"connector_id", connID, "client_id", client.ID)
+		s.tokenErrHelper(w, errInvalidRequest, "Connector not allowed for this client.", http.StatusBadRequest)
+		return
+	}
+
 	conn, err := s.getConnector(ctx, connID)
 	if err != nil {
 		s.logger.ErrorContext(r.Context(), "failed to get connector", "err", err)

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -1832,6 +1832,67 @@ func TestHandleTokenExchangeConnectorGrantTypeRestriction(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
 }
 
+func TestHandleTokenExchangeAllowedConnectors(t *testing.T) {
+	tests := []struct {
+		name              string
+		allowedConnectors []string
+		expectedCode      int
+	}{
+		{
+			name:              "connector in allowed list",
+			allowedConnectors: []string{"mock"},
+			expectedCode:      http.StatusOK,
+		},
+		{
+			name:              "connector matches non-first entry in allowed list",
+			allowedConnectors: []string{"other", "mock"},
+			expectedCode:      http.StatusOK,
+		},
+		{
+			name:              "connector not in allowed list",
+			allowedConnectors: []string{"other"},
+			expectedCode:      http.StatusBadRequest,
+		},
+		{
+			name:              "empty allowed list permits any connector",
+			allowedConnectors: nil,
+			expectedCode:      http.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			httpServer, s := newTestServer(t, func(c *Config) {
+				c.Storage.CreateClient(ctx, storage.Client{
+					ID:                "client_1",
+					Secret:            "secret_1",
+					AllowedConnectors: tc.allowedConnectors,
+				})
+			})
+			defer httpServer.Close()
+
+			vals := make(url.Values)
+			vals.Set("grant_type", grantTypeTokenExchange)
+			vals.Set("connector_id", "mock")
+			vals.Set("scope", "openid")
+			vals.Set("requested_token_type", tokenTypeAccess)
+			vals.Set("subject_token_type", tokenTypeID)
+			vals.Set("subject_token", "foobar")
+			vals.Set("client_id", "client_1")
+			vals.Set("client_secret", "secret_1")
+
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, httpServer.URL+"/token", strings.NewReader(vals.Encode()))
+			req.Header.Set("content-type", "application/x-www-form-urlencoded")
+
+			s.handleToken(rr, req)
+
+			require.Equal(t, tc.expectedCode, rr.Code, rr.Body.String())
+		})
+	}
+}
+
 func TestHandleAuthorizationConnectorGrantTypeFiltering(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
#### Overview

Adds enforcement of `client.AllowedConnectors` in `handleTokenExchange`. Two sibling code paths already enforce this client policy; the token exchange path was missing it.

Addresses [GHSA-7qjx-gp9h-65qj](https://github.com/dexidp/dex/security/advisories/GHSA-7qjx-gp9h-65qj). Only master is affected.

#### What this PR does / why we need it

The asymmetry before this PR:

- `server/handlers.go::handleConnectorLogin` line 377 calls `isConnectorAllowed(client.AllowedConnectors, connID)` before `getConnector` and returns 403 on deny.
- `server/oauth2.go::parseAuthorizationRequest` line 535 calls the same helper and returns a redirected `errInvalidRequest` on deny.
- `server/handlers.go::handleTokenExchange` did not call it. A confidential client with `AllowedConnectors: ["okta"]` could exchange a subject token via `connector_id=ldap` provided that LDAP connector existed in the dex configuration and supported the token-exchange grant type.

The change inserts one call to `isConnectorAllowed` in `handleTokenExchange` between the existing `subjectToken` empty check and `getConnector`. Placement mirrors `handleConnectorLogin:377` and `oauth2.go:535` (check runs before the connector fetch) so a disallowed request cannot probe connector existence. Error shape mirrors sibling token-endpoint errors in the same function: `tokenErrHelper(errInvalidRequest, "Connector not allowed for this client.", http.StatusBadRequest)`. Log message and field shape mirror `handleConnectorLogin:378-379` exactly.

Tests added under `TestHandleTokenExchangeAllowedConnectors` cover four cases: allowed (single entry), allowed (non-first entry in a multi-entry list), denied, and empty list (existing permit-any semantic). Structure mirrors `TestHandleTokenExchangeConnectorGrantTypeRestriction`. `go test ./server/...` passes for the diff. One unrelated pre-existing flake in `TestOAuth2DeviceFlow/verify_id_token_and_oauth2_token_expiry#01` reproduces on stock master at the same commit (token-expiry timing assertion drifting under containerized scheduling) and is not introduced by this PR.

#### Special notes for your reviewer

- Targets master at `ca3d56763f168bd6faee3e7701c43fd379d813d8`.
- PR #4611 (ID-JAG token issuance) also modifies `handleTokenExchange`. The two PRs do not overlap (a grep of the #4611 diff for `AllowedConnectors` and `isConnectorAllowed` returns zero hits); if #4611 lands first I will rebase and re-test.
- No exploit code or live payload is included; the GHSA advisory has the reproduction.
- Reported by Matteo Panzeri (GitHub: matte1782, contact: matteo1782@gmail.com).
