### PR TITLE
Expand .dockerignore to reduce unnecessary cache invalidation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,33 @@
 bin/
 tmp/
+
+# Git metadata - changes on every commit and invalidates Docker cache
+.git/
+.gitignore
+
+# CI/CD and GitHub files
+.github/
+
+# Documentation - not needed for runtime
+docs/
+*.md
+LICENSE
+
+# Examples and development configs
+examples/
+config.dev.yaml
+config.yaml.dist
+docker-compose*.yaml
+docker-compose*.dist
+
+# Editor and tool configs
+.editorconfig
+.envrc
+.golangci.yaml
+
+# Nix flakes
+flake.lock
+flake.nix
+
+# The Dockerfile itself
+Dockerfile


### PR DESCRIPTION
Fixes #1968

The Dockerfile uses `COPY . .` which copies the entire source tree into the build context. This means any change to files that aren't needed for the build (like `.git/`, `docs/`, `examples/`) still invalidates the Docker layer cache.

This is particularly noticeable with `.git/` -- every new commit, branch, or tag causes a full rebuild even though the actual source code hasn't changed.

The fix expands `.dockerignore` to exclude:
- `.git/` and `.gitignore`
- `docs/`, `examples/`, and Markdown files
- Editor and CI configs (`.github/`, `.editorconfig`, etc.)
- Development-only files (`docker-compose*.yaml`, `config.dev.yaml`)
- The `Dockerfile` itself

This keeps the build context minimal and focused on what the image actually needs: Go source files, dependencies (`go.mod`/`go.sum`), `config.docker.yaml`, and `web/` templates.