### PR TITLE
fix(gitlab): drop openid scope requirement if there are no groups presented

### DIFF
--- a/connector/gitlab/gitlab.go
+++ b/connector/gitlab/gitlab.go
@@ -140,8 +140,9 @@ type gitlabConnector struct {
 
 // oauth2Config builds the OAuth2 client configuration and scopes for this connector.
 func (c *gitlabConnector) oauth2Config(scopes connector.Scopes) *oauth2.Config {
-	gitlabScopes := []string{scopeUser, scopeOpenID}
+	gitlabScopes := []string{scopeUser}
 	if c.groupsRequired(scopes.Groups) {
+		gitlabScopes = append(gitlabScopes, scopeOpenID)
 		if c.inheritedGroups {
 			gitlabScopes = append(gitlabScopes, scopeReadAPI)
 		}

--- a/connector/gitlab/gitlab_test.go
+++ b/connector/gitlab/gitlab_test.go
@@ -180,7 +180,7 @@ func TestOAuth2ConfigScopesForInheritedGroups(t *testing.T) {
 	c := gitlabConnector{inheritedGroups: true}
 
 	cfg := c.oauth2Config(connector.Scopes{})
-	expectEquals(t, cfg.Scopes, []string{scopeUser, scopeOpenID})
+	expectEquals(t, cfg.Scopes, []string{scopeUser})
 
 	cfg = c.oauth2Config(connector.Scopes{Groups: true})
 	expectEquals(t, cfg.Scopes, []string{scopeUser, scopeOpenID, scopeReadAPI})


### PR DESCRIPTION
#### Overview

Restore the previous GitLab OAuth scope behavior for logins that do not need group claims.

#### What this PR does / why we need it

PR #4800 added inherited group support and correctly requires `read_api` when `inheritedGroups` is enabled. However, it also made the GitLab connector request `openid` even when groups are not required.

Before #4800, GitLab logins without group requirements requested only `read_user`. Keeping `openid` out of the no-groups flow preserves compatibility with existing GitLab OAuth applications that were configured only for `read_user`.

This PR changes scope selection so:

- no groups required: `read_user`
- groups required: `read_user`, `openid`
- inherited groups required: `read_user`, `openid`, `read_api`

The GitLab scope test is updated to cover the restored no-groups behavior.

#### Special notes for your reviewer

To reproduce this issue I've created GitLab OAuth application with only the `read_user` scope enabled, then ran Dex with a GitLab connector that has no `groups`, no `getGroupsPermission`, and no `inheritedGroups`, plus the example app on `http://127.0.0.1:5555`.

Before this fix, starting the authorization code flow from the example app redirected to GitLab with:

`scope=read_user+openid`

That fails for an OAuth application configured only with `read_user`.

With this fix, the same flow redirects to GitLab (if groupsRequired == false) with:

`scope=read_user`