### PR TITLE
fix(storage): compare DeviceRequest expiry by instant in conformance test

### DIFF
--- a/storage/conformance/conformance.go
+++ b/storage/conformance/conformance.go
@@ -1225,6 +1225,14 @@ func testDeviceRequestCRUD(t *testing.T, s storage.Storage) {
 		t.Fatalf("failed to get device request: %v", err)
 	}
 
+	// Storage backends are not expected to preserve the time.Location of the
+	// stored value, only the instant. Postgres, for example, returns the
+	// expiry in a loaded "Etc/UTC" location rather than the time.UTC
+	// singleton, which makes reflect.DeepEqual (used by require.Equal)
+	// report a difference even though the two times are the same instant.
+	// Normalize to UTC before comparing, matching the other CRUD tests.
+	got.Expiry = got.Expiry.UTC()
+
 	require.Equal(t, d1, got)
 
 	// No manual deletes for device requests, will be handled by garbage collection routines


### PR DESCRIPTION
Fixes #4461

## Problem

`TestPostgres/DeviceRequestCRUD` fails when the Postgres database is in the UTC timezone (`export DEX_POSTGRES_HOST=...; make testall`):

```
=== RUN   TestPostgres/DeviceRequestCRUD
    conformance.go: Not equal:
        expected: ...Expiry:time.Date(2125, time.December, 12, 14, 11, 18, 0, time.UTC)
        actual  : ...Expiry:time.Date(2125, time.December, 12, 14, 11, 18, 0, time.Location("Etc/UTC"))
        Diff:
          ext: (int64) 67056819078,
        - loc: (*time.Location)(<nil>)
        + loc: (*time.Location)({ name: "Etc/UTC", ... })
```

## Root cause

`testDeviceRequestCRUD` compares the stored and retrieved `DeviceRequest` with `require.Equal(t, d1, got)`. For a struct testify falls back to `reflect.DeepEqual`, which on a `time.Time` compares the wall-clock fields *and the `*time.Location` pointer*, not just the instant.

The expected `Expiry` is built from `neverExpire` (`time.Now().UTC()...`), so its location is the `time.UTC` singleton (`loc == nil`). The value that round-trips through Postgres comes back carrying a *loaded* `Etc/UTC` location object. The two values are the **same instant** (note the identical `ext: 67056819078`), but the `loc` pointers differ, so `reflect.DeepEqual` reports them as unequal.

This is not a storage bug. Dex deliberately does not expect storage backends to preserve the `time.Location`, only the instant. The same notes already exist in the auth-code test:

- `testAuthCodeCRUD`: `got.Expiry = a1.Expiry // time fields do not compare well`
- `testAuthCodeCRUD`: `// We DO NOT expect timezones to be preserved.`

`testDeviceRequestCRUD` was the only CRUD test that did not normalize the retrieved time before comparing. The auth-code, user, and session tests all do (`got.X = got.X.UTC().Round(...)`).

## Fix

Normalize the retrieved `Expiry` to UTC before `require.Equal`, matching the other CRUD tests:

```go
got.Expiry = got.Expiry.UTC()
require.Equal(t, d1, got)
```

`d1.Expiry` is already UTC (`neverExpire.Round(time.Second)`), so after normalizing `got` to the same `time.UTC` singleton the comparison passes regardless of the location object the driver returns.

## Reproduction and verification

A standalone unit reproduction of the exact comparison (`time.UTC` singleton vs a loaded `Etc/UTC` location, same instant) produces a diff byte-for-byte identical to the failure above, and passes once the retrieved time is normalized with `.UTC()`.

Test runs (no Docker needed for these):

- `go build ./...` - ok
- `go test ./storage/sql/ -run TestSQLite3` - ok (full conformance, including `DeviceRequestCRUD`)
- `TZ=America/New_York go test ./storage/sql/ -run TestSQLite3/DeviceRequestCRUD` - PASS (DST timezone)
- `TZ=America/New_York go test ./storage/ent/ -run TestSQLite/DeviceRequestCRUD` - PASS
- `go test ./storage/memory/ ./storage/etcd/` - ok (regression guard)

The dockerized `TestPostgres` path (the one in the report) needs `DEX_POSTGRES_HOST` and was not run locally, but the fix is backend-agnostic: it normalizes the retrieved instant to UTC before comparison, so the assertion holds for any driver regardless of the `time.Location` it returns.
