### PR TITLE
fix(google): allow "*" wildcard in hostedDomains to accept any hd claim

### DIFF
--- a/connector/google/google.go
+++ b/connector/google/google.go
@@ -168,6 +168,23 @@ func (c *googleConnector) Close() error {
 	return nil
 }
 
+// matchHostedDomain reports whether the given Google "hd" claim is allowed by
+// the configured hostedDomains list. An entry of "*" acts as a wildcard that
+// accepts any non-empty hd claim, allowing operators to require that users
+// authenticate with a Workspace account (any domain) rather than a personal
+// account, without enumerating every domain.
+func matchHostedDomain(claim string, allowed []string) bool {
+	for _, domain := range allowed {
+		if domain == "*" && claim != "" {
+			return true
+		}
+		if claim == domain {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *googleConnector) LoginURL(s connector.Scopes, callbackURL, state string) (string, []byte, error) {
 	if c.redirectURI != callbackURL {
 		return "", nil, fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
@@ -256,18 +273,8 @@ func (c *googleConnector) createIdentity(ctx context.Context, identity connector
 		claims.Username = identity.Username
 	}
 
-	if len(c.hostedDomains) > 0 {
-		found := false
-		for _, domain := range c.hostedDomains {
-			if claims.HostedDomain == domain {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			return identity, fmt.Errorf("oidc: unexpected hd claim %v", claims.HostedDomain)
-		}
+	if len(c.hostedDomains) > 0 && !matchHostedDomain(claims.HostedDomain, c.hostedDomains) {
+		return identity, fmt.Errorf("oidc: unexpected hd claim %v", claims.HostedDomain)
 	}
 
 	var groups []string

--- a/connector/google/google_test.go
+++ b/connector/google/google_test.go
@@ -449,3 +449,61 @@ func TestPromptTypeConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchHostedDomain(t *testing.T) {
+	tests := []struct {
+		name    string
+		claim   string
+		allowed []string
+		want    bool
+	}{
+		{
+			name:    "exact match",
+			claim:   "example.com",
+			allowed: []string{"example.com"},
+			want:    true,
+		},
+		{
+			name:    "exact match within multiple",
+			claim:   "example.com",
+			allowed: []string{"foo.com", "example.com", "bar.com"},
+			want:    true,
+		},
+		{
+			name:    "no match",
+			claim:   "ferrix.ai",
+			allowed: []string{"example.com"},
+			want:    false,
+		},
+		{
+			name:    "wildcard accepts any non-empty hd",
+			claim:   "ferrix.ai",
+			allowed: []string{"*"},
+			want:    true,
+		},
+		{
+			name:    "wildcard alongside explicit domains",
+			claim:   "anything.dev",
+			allowed: []string{"example.com", "*"},
+			want:    true,
+		},
+		{
+			name:    "wildcard rejects empty hd claim",
+			claim:   "",
+			allowed: []string{"*"},
+			want:    false,
+		},
+		{
+			name:    "empty claim with explicit domains",
+			claim:   "",
+			allowed: []string{"example.com"},
+			want:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, matchHostedDomain(tc.claim, tc.allowed))
+		})
+	}
+}


### PR DESCRIPTION
#### Overview

Allow `"*"` as a wildcard entry in the Google connector's `hostedDomains` config so that any non-empty `hd` claim is accepted. This brings the post-token claim check in line with the existing `LoginURL` behavior, which already passes `hd=*` to Google.

#### What this PR does / why we need it

When `hostedDomains: ["*"]` is configured, `LoginURL` correctly sets `hd=*` on the Google auth URL, which tells Google to restrict the picker to Workspace (hosted) accounts. However the post-token validation in `createIdentity` did a strict equality check between `claims.HostedDomain` and each configured entry, so the wildcard never matched a real domain and login failed with:

```
oidc: unexpected hd claim <domain>
```

This is a common ask for multi-tenant Workspace deployments where the operator wants to allow any corporate Google account (i.e. block personal `@gmail.com`) without enumerating every domain.

Changes:
- Extract the validation loop into a small `matchHostedDomain(claim, allowed)` helper.
- Treat a `"*"` entry as a wildcard that accepts any **non-empty** `hd` claim. An empty `hd` (personal Gmail) is still rejected when `*` is configured — that's the intent.
- Add table-driven unit tests covering: exact match, exact match within multiple, no match, wildcard accepting any non-empty `hd`, wildcard alongside explicit domains, wildcard rejecting empty `hd`, and empty claim with explicit domains.

#### Special notes for your reviewer

- No config-schema change. `hostedDomains` is already `[]string`; this just makes `"*"` a meaningful value end-to-end.
- Backwards compatible: prior to this change, `"*"` was never a valid `hd` claim value, so the new branch only fires for operators who explicitly opt in.
- The existing `LoginURL` logic already uses `"*"` as the wildcard when multiple domains are configured (`connector/google/google.go` line ~180), so this PR makes the two sides of the validation consistent.

#### Does this PR introduce a user-facing change?

```release-note
google: allow `"*"` in `hostedDomains` to accept any non-empty `hd` claim.
```