### PR TITLE
fix(oidc): verify userinfo sub matches the ID Token sub

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -591,6 +591,9 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 		return identity, errors.New("oidc: no id_token in token response")
 	}
 
+	// Keep the verified ID Token subject to compare against the userinfo response below.
+	idTokenSubject, _ := claims["sub"].(string)
+
 	// We immediately want to run getUserInfo if configured before we validate the claims.
 	// For token exchanges with access tokens, this is how we verify the token.
 	if c.getUserInfo {
@@ -603,6 +606,11 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 		}
 		if err := userInfo.Claims(&claims); err != nil {
 			return identity, fmt.Errorf("oidc: failed to decode userinfo claims: %v", err)
+		}
+
+		// The userinfo sub must match the ID Token sub (OpenID Connect Core 5.3.2).
+		if userInfoSubject, _ := claims["sub"].(string); idTokenSubject != "" && userInfoSubject != idTokenSubject {
+			return identity, fmt.Errorf("oidc: userinfo sub %q does not match id_token sub %q", userInfoSubject, idTokenSubject)
 		}
 	}
 

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -835,7 +835,7 @@ func TestProviderOverride(t *testing.T) {
 	})
 }
 
-func setupServer(tok map[string]interface{}, idTokenDesired bool) (*httptest.Server, error) {
+func setupServer(tok map[string]interface{}, idTokenDesired bool, userInfoOverride ...map[string]interface{}) (*httptest.Server, error) {
 	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate rsa key: %v", err)
@@ -886,9 +886,14 @@ func setupServer(tok map[string]interface{}, idTokenDesired bool) (*httptest.Ser
 		}
 	})
 
+	userInfo := tok
+	if len(userInfoOverride) > 0 {
+		userInfo = userInfoOverride[0]
+	}
+
 	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(tok)
+		json.NewEncoder(w).Encode(userInfo)
 	})
 
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
@@ -1081,4 +1086,73 @@ func TestEndSessionURLOverride(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, "https://custom.example.com/logout", conn.endSessionURL)
+}
+
+func TestHandleCallbackUserInfoSubMatch(t *testing.T) {
+	tests := []struct {
+		name string
+		// When set, the userinfo endpoint returns this sub instead of the ID Token's.
+		userInfoSub string
+		expectError bool
+	}{
+		{
+			name: "userinfo sub matches id_token sub",
+		},
+		{
+			name:        "userinfo sub differs from id_token sub",
+			userInfoSub: "other-subvalue",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var userInfoOverride []map[string]interface{}
+			if tc.userInfoSub != "" {
+				userInfoOverride = append(userInfoOverride, map[string]interface{}{"sub": tc.userInfoSub})
+			}
+
+			testServer, err := setupServer(map[string]interface{}{
+				"sub":            "subvalue",
+				"name":           "namevalue",
+				"email":          "emailvalue",
+				"email_verified": true,
+			}, true, userInfoOverride...)
+			if err != nil {
+				t.Fatal("failed to setup test server", err)
+			}
+			defer testServer.Close()
+
+			basicAuth := true
+			conn, err := newConnector(Config{
+				Issuer:               testServer.URL,
+				ClientID:             "clientID",
+				ClientSecret:         "clientSecret",
+				RedirectURI:          fmt.Sprintf("%s/callback", testServer.URL),
+				GetUserInfo:          true,
+				BasicAuthUnsupported: &basicAuth,
+			})
+			if err != nil {
+				t.Fatal("failed to create new connector", err)
+			}
+
+			req, err := newRequestWithAuthCode(testServer.URL, "someCode")
+			if err != nil {
+				t.Fatal("failed to create request", err)
+			}
+
+			connectorData := []byte(`{"codeChallenge":"","codeChallengeMethod":""}`)
+			identity, err := conn.HandleCallback(connector.Scopes{}, connectorData, req)
+			if tc.expectError {
+				if err == nil {
+					t.Fatalf("expected the userinfo sub mismatch to be rejected, got identity %+v", identity)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal("handle callback failed", err)
+			}
+			expectEquals(t, identity.UserID, "subvalue")
+		})
+	}
 }


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Verify the userinfo `sub` against the ID Token `sub` in the OIDC connector, as required by OpenID Connect Core 5.3.2.

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

With `getUserInfo: true`, `createIdentity` merged the userinfo response into the verified ID Token claims and read `sub` from the result, so a userinfo `sub` that differed from the ID Token `sub` silently became the subject (`Identity.UserID`). OpenID Connect Core 5.3.2 requires the two to match.

This keeps the ID Token `sub` before the userinfo merge and returns an error on mismatch. When there is no ID Token (the access-token token exchange, where userinfo is itself the verification) the check is skipped, so that path is unchanged.

Closes https://github.com/dexidp/dex/issues/4827

#### Special notes for your reviewer
