### PR TITLE
fix: retry refresh token updates on serialization failures (SQL & ent)

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -26,6 +26,10 @@ storage:
   #   password: mysql
   #   ssl:
   #     mode: "false"
+  #   # Opt in to retrying refresh-token updates aborted by transient
+  #   # serialization failures / deadlocks under SERIALIZABLE isolation.
+  #   # Off by default; only affects the postgres and mysql backends.
+  #   retryOnSerializationFailure: true
 
   # type: postgres
   # config:
@@ -36,6 +40,10 @@ storage:
   #   password: postgres
   #   ssl:
   #     mode: disable
+  #   # Opt in to retrying refresh-token updates aborted by transient
+  #   # serialization failures / deadlocks under SERIALIZABLE isolation.
+  #   # Off by default; only affects the postgres and mysql backends.
+  #   retryOnSerializationFailure: true
 
   # type: etcd
   # config:

--- a/storage/ent/client/main.go
+++ b/storage/ent/client/main.go
@@ -23,6 +23,11 @@ type Database struct {
 	txOptions *sql.TxOptions
 
 	hasher func() hash.Hash
+
+	// txRetryCheck classifies transient transaction failures (serialization
+	// failures / deadlocks) that are safe to retry. Nil (the default) disables
+	// retries; set via WithTxRetryCheck.
+	txRetryCheck func(error) bool
 }
 
 // NewDatabase returns new database client with set options.
@@ -52,6 +57,14 @@ func WithHasher(h func() hash.Hash) func(*Database) {
 func WithTxIsolationLevel(level sql.IsolationLevel) func(*Database) {
 	return func(s *Database) {
 		s.txOptions = &sql.TxOptions{Isolation: level}
+	}
+}
+
+// WithTxRetryCheck enables retrying transactions aborted by transient failures
+// classified as retryable by check. Nil (the default) disables retries.
+func WithTxRetryCheck(check func(error) bool) func(*Database) {
+	return func(s *Database) {
+		s.txRetryCheck = check
 	}
 }
 

--- a/storage/ent/client/refreshtoken.go
+++ b/storage/ent/client/refreshtoken.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/dexidp/dex/storage"
+	"github.com/dexidp/dex/storage/sqlretry"
 )
 
 // CreateRefresh saves provided refresh token into the database.
@@ -66,7 +67,20 @@ func (d *Database) DeleteRefresh(ctx context.Context, id string) error {
 }
 
 // UpdateRefreshToken changes a refresh token by id using an updater function and saves it to the database.
+//
+// The update runs in a SERIALIZABLE transaction; under concurrent refresh-token
+// rotation of the same token the database aborts conflicting transactions with a
+// serialization failure. Retry the whole transaction on those transient errors
+// so concurrent refreshes succeed instead of surfacing as 500s.
 func (d *Database) UpdateRefreshToken(ctx context.Context, id string, updater func(old storage.RefreshToken) (storage.RefreshToken, error)) error {
+	return sqlretry.Do(
+		func() error { return d.updateRefreshTokenOnce(ctx, id, updater) },
+		sqlretry.IsSerializationFailure,
+		nil,
+	)
+}
+
+func (d *Database) updateRefreshTokenOnce(ctx context.Context, id string, updater func(old storage.RefreshToken) (storage.RefreshToken, error)) error {
 	tx, err := d.BeginTx(ctx)
 	if err != nil {
 		return convertDBError("update refresh token tx: %w", err)

--- a/storage/ent/client/refreshtoken.go
+++ b/storage/ent/client/refreshtoken.go
@@ -75,7 +75,7 @@ func (d *Database) DeleteRefresh(ctx context.Context, id string) error {
 func (d *Database) UpdateRefreshToken(ctx context.Context, id string, updater func(old storage.RefreshToken) (storage.RefreshToken, error)) error {
 	return sqlretry.Do(
 		func() error { return d.updateRefreshTokenOnce(ctx, id, updater) },
-		sqlretry.IsSerializationFailure,
+		d.txRetryCheck,
 		nil,
 	)
 }

--- a/storage/ent/mysql.go
+++ b/storage/ent/mysql.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dexidp/dex/storage"
 	"github.com/dexidp/dex/storage/ent/client"
 	"github.com/dexidp/dex/storage/ent/db"
+	"github.com/dexidp/dex/storage/sqlretry"
 )
 
 const (
@@ -46,12 +47,17 @@ func (m *MySQL) Open(logger *slog.Logger) (storage.Storage, error) {
 		return nil, err
 	}
 
-	databaseClient := client.NewDatabase(
+	opts := []func(*client.Database){
 		client.WithClient(db.NewClient(db.Driver(drv))),
 		client.WithHasher(sha256.New),
 		// Set tx isolation leve for each transaction as dex does for postgres
 		client.WithTxIsolationLevel(sql.LevelSerializable),
-	)
+	}
+	if m.RetryOnSerializationFailure {
+		opts = append(opts, client.WithTxRetryCheck(sqlretry.IsSerializationFailure))
+	}
+
+	databaseClient := client.NewDatabase(opts...)
 
 	if err := databaseClient.Schema().Create(context.TODO()); err != nil {
 		return nil, err

--- a/storage/ent/mysql_test.go
+++ b/storage/ent/mysql_test.go
@@ -34,6 +34,9 @@ func mysqlTestConfig(host string, port uint64) *MySQL {
 			Password: getenv(MySQLEntPasswordEnv, "mysql"),
 			Host:     host,
 			Port:     uint16(port),
+			// Concurrency conformance tests rotate the same token from many
+			// goroutines; without retry the deadlock aborts surface as errors.
+			RetryOnSerializationFailure: true,
 		},
 		SSL: SSL{
 			// This was originally mysqlSSLSkipVerify. It lead to handshake errors.
@@ -54,6 +57,9 @@ func mysql8TestConfig(host string, port uint64) *MySQL {
 			Password: getenv(MySQL8EntPasswordEnv, "mysql"),
 			Host:     host,
 			Port:     uint16(port),
+			// Concurrency conformance tests rotate the same token from many
+			// goroutines; without retry the deadlock aborts surface as errors.
+			RetryOnSerializationFailure: true,
 		},
 		SSL: SSL{
 			Mode: mysqlSSLFalse,

--- a/storage/ent/mysql_test.go
+++ b/storage/ent/mysql_test.go
@@ -105,11 +105,7 @@ func TestMySQL(t *testing.T) {
 	}
 	conformance.RunTests(t, newStorage)
 	conformance.RunTransactionTests(t, newStorage)
-
-	// TODO(nabokihms): ent MySQL does not retry on deadlocks (Error 1213, SQLSTATE 40001:
-	// Deadlock found when trying to get lock; try restarting transaction).
-	// Under high contention most updates fail.
-	// conformance.RunConcurrencyTests(t, newStorage)
+	conformance.RunConcurrencyTests(t, newStorage)
 }
 
 func TestMySQL8(t *testing.T) {
@@ -131,11 +127,7 @@ func TestMySQL8(t *testing.T) {
 	}
 	conformance.RunTests(t, newStorage)
 	conformance.RunTransactionTests(t, newStorage)
-
-	// TODO(nabokihms): ent MySQL 8 does not retry on deadlocks (Error 1213, SQLSTATE 40001:
-	// Deadlock found when trying to get lock; try restarting transaction).
-	// Under high contention most updates fail.
-	// conformance.RunConcurrencyTests(t, newStorage)
+	conformance.RunConcurrencyTests(t, newStorage)
 }
 
 func TestMySQLDSN(t *testing.T) {

--- a/storage/ent/postgres.go
+++ b/storage/ent/postgres.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dexidp/dex/storage"
 	"github.com/dexidp/dex/storage/ent/client"
 	"github.com/dexidp/dex/storage/ent/db"
+	"github.com/dexidp/dex/storage/sqlretry"
 )
 
 const (
@@ -43,7 +44,7 @@ func (p *Postgres) Open(logger *slog.Logger) (storage.Storage, error) {
 		return nil, err
 	}
 
-	databaseClient := client.NewDatabase(
+	opts := []func(*client.Database){
 		client.WithClient(db.NewClient(db.Driver(drv))),
 		client.WithHasher(sha256.New),
 		// The default behavior for Postgres transactions is consistent reads, not consistent writes.
@@ -51,7 +52,12 @@ func (p *Postgres) Open(logger *slog.Logger) (storage.Storage, error) {
 		//
 		// See: https://www.postgresql.org/docs/9.3/static/sql-set-transaction.html
 		client.WithTxIsolationLevel(sql.LevelSerializable),
-	)
+	}
+	if p.RetryOnSerializationFailure {
+		opts = append(opts, client.WithTxRetryCheck(sqlretry.IsSerializationFailure))
+	}
+
+	databaseClient := client.NewDatabase(opts...)
 
 	if err := databaseClient.Schema().Create(context.TODO()); err != nil {
 		return nil, err

--- a/storage/ent/postgres_test.go
+++ b/storage/ent/postgres_test.go
@@ -65,11 +65,7 @@ func TestPostgres(t *testing.T) {
 	}
 	conformance.RunTests(t, newStorage)
 	conformance.RunTransactionTests(t, newStorage)
-
-	// TODO(nabokihms): ent Postgres uses SERIALIZABLE transaction isolation for UpdateRefreshToken,
-	// but does not retry on serialization failures (pq: could not serialize access due to
-	// concurrent update, SQLSTATE 40001). Under high contention most updates fail immediately.
-	// conformance.RunConcurrencyTests(t, newStorage)
+	conformance.RunConcurrencyTests(t, newStorage)
 }
 
 func TestPostgresDSN(t *testing.T) {

--- a/storage/ent/postgres_test.go
+++ b/storage/ent/postgres_test.go
@@ -28,6 +28,9 @@ func postgresTestConfig(host string, port uint64) *Postgres {
 			Password: getenv(PostgresEntPasswordEnv, "postgres"),
 			Host:     host,
 			Port:     uint16(port),
+			// Concurrency conformance tests rotate the same token from many
+			// goroutines; without retry the SERIALIZABLE aborts surface as errors.
+			RetryOnSerializationFailure: true,
 		},
 		SSL: SSL{
 			Mode: pgSSLDisable, // Postgres container doesn't support SSL.

--- a/storage/ent/types.go
+++ b/storage/ent/types.go
@@ -13,6 +13,11 @@ type NetworkDB struct {
 	MaxOpenConns    int // default: 5
 	MaxIdleConns    int // default: 5
 	ConnMaxLifetime int // Seconds, default: not set
+
+	// RetryOnSerializationFailure enables bounded, jittered retry of refresh-token
+	// updates aborted by transient serialization failures / deadlocks under
+	// SERIALIZABLE isolation. Off by default. Retry parameters are not configurable.
+	RetryOnSerializationFailure bool
 }
 
 // SSL represents SSL options for network databases.

--- a/storage/sql/config.go
+++ b/storage/sql/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lib/pq"
 
 	"github.com/dexidp/dex/storage"
+	"github.com/dexidp/dex/storage/sqlretry"
 )
 
 const (
@@ -195,7 +196,7 @@ func (p *Postgres) open(logger *slog.Logger) (*conn, error) {
 		return sqlErr.Code == pgErrUniqueViolation
 	}
 
-	c := &conn{db, &flavorPostgres, logger, errCheck}
+	c := &conn{db, &flavorPostgres, logger, errCheck, sqlretry.IsSerializationFailure}
 	if _, err := c.migrate(); err != nil {
 		return nil, fmt.Errorf("failed to perform migrations: %v", err)
 	}
@@ -307,7 +308,7 @@ func (s *MySQL) open(logger *slog.Logger) (*conn, error) {
 			sqlErr.Number == mysqlErrDupEntryWithKeyName
 	}
 
-	c := &conn{db, &flavorMySQL, logger, errCheck}
+	c := &conn{db, &flavorMySQL, logger, errCheck, sqlretry.IsSerializationFailure}
 	if _, err := c.migrate(); err != nil {
 		return nil, fmt.Errorf("failed to perform migrations: %v", err)
 	}

--- a/storage/sql/config.go
+++ b/storage/sql/config.go
@@ -64,6 +64,11 @@ type NetworkDB struct {
 	MaxOpenConns    int // default: 5
 	MaxIdleConns    int // default: 5
 	ConnMaxLifetime int // Seconds, default: not set
+
+	// RetryOnSerializationFailure enables bounded, jittered retry of refresh-token
+	// updates aborted by transient serialization failures / deadlocks under
+	// SERIALIZABLE isolation. Off by default. Retry parameters are not configurable.
+	RetryOnSerializationFailure bool
 }
 
 // SSL represents SSL options for network databases.
@@ -196,7 +201,12 @@ func (p *Postgres) open(logger *slog.Logger) (*conn, error) {
 		return sqlErr.Code == pgErrUniqueViolation
 	}
 
-	c := &conn{db, &flavorPostgres, logger, errCheck, sqlretry.IsSerializationFailure}
+	var txRetryCheck func(error) bool
+	if p.RetryOnSerializationFailure {
+		txRetryCheck = sqlretry.IsSerializationFailure
+	}
+
+	c := &conn{db, &flavorPostgres, logger, errCheck, txRetryCheck}
 	if _, err := c.migrate(); err != nil {
 		return nil, fmt.Errorf("failed to perform migrations: %v", err)
 	}
@@ -308,7 +318,12 @@ func (s *MySQL) open(logger *slog.Logger) (*conn, error) {
 			sqlErr.Number == mysqlErrDupEntryWithKeyName
 	}
 
-	c := &conn{db, &flavorMySQL, logger, errCheck, sqlretry.IsSerializationFailure}
+	var txRetryCheck func(error) bool
+	if s.RetryOnSerializationFailure {
+		txRetryCheck = sqlretry.IsSerializationFailure
+	}
+
+	c := &conn{db, &flavorMySQL, logger, errCheck, txRetryCheck}
 	if _, err := c.migrate(); err != nil {
 		return nil, fmt.Errorf("failed to perform migrations: %v", err)
 	}

--- a/storage/sql/config_test.go
+++ b/storage/sql/config_test.go
@@ -238,6 +238,9 @@ func TestPostgres(t *testing.T) {
 			Host:              host,
 			Port:              uint16(port),
 			ConnectionTimeout: 5,
+			// Concurrency conformance tests rotate the same token from many
+			// goroutines; without retry the SERIALIZABLE aborts surface as errors.
+			RetryOnSerializationFailure: true,
 		},
 		SSL: SSL{
 			Mode: pgSSLDisable, // Postgres container doesn't support SSL.
@@ -272,6 +275,9 @@ func TestMySQL(t *testing.T) {
 			Host:              host,
 			Port:              uint16(port),
 			ConnectionTimeout: 5,
+			// Concurrency conformance tests rotate the same token from many
+			// goroutines; without retry the deadlock aborts surface as errors.
+			RetryOnSerializationFailure: true,
 		},
 		SSL: SSL{
 			Mode: mysqlSSLFalse,
@@ -309,6 +315,9 @@ func TestMySQL8(t *testing.T) {
 			Host:              host,
 			Port:              uint16(port),
 			ConnectionTimeout: 5,
+			// Concurrency conformance tests rotate the same token from many
+			// goroutines; without retry the deadlock aborts surface as errors.
+			RetryOnSerializationFailure: true,
 		},
 		SSL: SSL{
 			Mode: mysqlSSLFalse,

--- a/storage/sql/config_test.go
+++ b/storage/sql/config_test.go
@@ -243,7 +243,7 @@ func TestPostgres(t *testing.T) {
 			Mode: pgSSLDisable, // Postgres container doesn't support SSL.
 		},
 	}
-	testDB(t, p, true, false)
+	testDB(t, p, true, true)
 }
 
 const testMySQLEnv = "DEX_MYSQL_HOST"
@@ -280,7 +280,7 @@ func TestMySQL(t *testing.T) {
 			"innodb_lock_wait_timeout": "3",
 		},
 	}
-	testDB(t, s, true, false)
+	testDB(t, s, true, true)
 }
 
 const testMySQL8Env = "DEX_MYSQL8_HOST"
@@ -317,5 +317,5 @@ func TestMySQL8(t *testing.T) {
 			"innodb_lock_wait_timeout": "3",
 		},
 	}
-	testDB(t, s, true, false)
+	testDB(t, s, true, true)
 }

--- a/storage/sql/crud.go
+++ b/storage/sql/crud.go
@@ -51,7 +51,7 @@ type jsonEncoder struct {
 func (j jsonEncoder) Value() (driver.Value, error) {
 	b, err := json.Marshal(j.i)
 	if err != nil {
-		return nil, fmt.Errorf("marshal: %v", err)
+		return nil, fmt.Errorf("marshal: %w", err)
 	}
 	return b, nil
 }
@@ -69,7 +69,7 @@ func (j jsonDecoder) Scan(dest interface{}) error {
 		return fmt.Errorf("expected []byte got %T", dest)
 	}
 	if err := json.Unmarshal(b, &j.i); err != nil {
-		return fmt.Errorf("unmarshal: %v", err)
+		return fmt.Errorf("unmarshal: %w", err)
 	}
 	return nil
 }
@@ -91,7 +91,7 @@ func (c *conn) GarbageCollect(ctc context.Context, now time.Time) (storage.GCRes
 
 	r, err := c.Exec(`delete from auth_request where expiry < $1`, now)
 	if err != nil {
-		return result, fmt.Errorf("gc auth_request: %v", err)
+		return result, fmt.Errorf("gc auth_request: %w", err)
 	}
 	if n, err := r.RowsAffected(); err == nil {
 		result.AuthRequests = n
@@ -99,7 +99,7 @@ func (c *conn) GarbageCollect(ctc context.Context, now time.Time) (storage.GCRes
 
 	r, err = c.Exec(`delete from auth_code where expiry < $1`, now)
 	if err != nil {
-		return result, fmt.Errorf("gc auth_code: %v", err)
+		return result, fmt.Errorf("gc auth_code: %w", err)
 	}
 	if n, err := r.RowsAffected(); err == nil {
 		result.AuthCodes = n
@@ -107,7 +107,7 @@ func (c *conn) GarbageCollect(ctc context.Context, now time.Time) (storage.GCRes
 
 	r, err = c.Exec(`delete from device_request where expiry < $1`, now)
 	if err != nil {
-		return result, fmt.Errorf("gc device_request: %v", err)
+		return result, fmt.Errorf("gc device_request: %w", err)
 	}
 	if n, err := r.RowsAffected(); err == nil {
 		result.DeviceRequests = n
@@ -115,7 +115,7 @@ func (c *conn) GarbageCollect(ctc context.Context, now time.Time) (storage.GCRes
 
 	r, err = c.Exec(`delete from device_token where expiry < $1`, now)
 	if err != nil {
-		return result, fmt.Errorf("gc device_token: %v", err)
+		return result, fmt.Errorf("gc device_token: %w", err)
 	}
 	if n, err := r.RowsAffected(); err == nil {
 		result.DeviceTokens = n
@@ -123,7 +123,7 @@ func (c *conn) GarbageCollect(ctc context.Context, now time.Time) (storage.GCRes
 
 	r, err = c.Exec(`delete from auth_session where absolute_expiry < $1 OR idle_expiry < $2`, now, now)
 	if err != nil {
-		return result, fmt.Errorf("gc auth_session: %v", err)
+		return result, fmt.Errorf("gc auth_session: %w", err)
 	}
 	if n, err := r.RowsAffected(); err == nil {
 		result.AuthSessions = n
@@ -167,7 +167,7 @@ func (c *conn) CreateAuthRequest(ctx context.Context, a storage.AuthRequest) err
 		if c.alreadyExistsCheck(err) {
 			return storage.ErrAlreadyExists
 		}
-		return fmt.Errorf("insert auth request: %v", err)
+		return fmt.Errorf("insert auth request: %w", err)
 	}
 	return nil
 }
@@ -214,7 +214,7 @@ func (c *conn) UpdateAuthRequest(ctx context.Context, id string, updater func(a 
 			r.ID,
 		)
 		if err != nil {
-			return fmt.Errorf("update auth request: %v", err)
+			return fmt.Errorf("update auth request: %w", err)
 		}
 		return nil
 	})
@@ -253,7 +253,7 @@ func getAuthRequest(ctx context.Context, q querier, id string) (a storage.AuthRe
 		if err == sql.ErrNoRows {
 			return a, storage.ErrNotFound
 		}
-		return a, fmt.Errorf("select auth request: %v", err)
+		return a, fmt.Errorf("select auth request: %w", err)
 	}
 	return a, nil
 }
@@ -281,7 +281,7 @@ func (c *conn) CreateAuthCode(ctx context.Context, a storage.AuthCode) error {
 		if c.alreadyExistsCheck(err) {
 			return storage.ErrAlreadyExists
 		}
-		return fmt.Errorf("insert auth code: %v", err)
+		return fmt.Errorf("insert auth code: %w", err)
 	}
 	return nil
 }
@@ -308,7 +308,7 @@ func (c *conn) GetAuthCode(ctx context.Context, id string) (a storage.AuthCode, 
 		if err == sql.ErrNoRows {
 			return a, storage.ErrNotFound
 		}
-		return a, fmt.Errorf("select auth code: %v", err)
+		return a, fmt.Errorf("select auth code: %w", err)
 	}
 	return a, nil
 }
@@ -335,13 +335,13 @@ func (c *conn) CreateRefresh(ctx context.Context, r storage.RefreshToken) error 
 		if c.alreadyExistsCheck(err) {
 			return storage.ErrAlreadyExists
 		}
-		return fmt.Errorf("insert refresh_token: %v", err)
+		return fmt.Errorf("insert refresh_token: %w", err)
 	}
 	return nil
 }
 
 func (c *conn) UpdateRefreshToken(ctx context.Context, id string, updater func(old storage.RefreshToken) (storage.RefreshToken, error)) error {
-	return c.ExecTx(func(tx *trans) error {
+	return c.execTxWithRetry(func(tx *trans) error {
 		r, err := getRefresh(ctx, tx, id)
 		if err != nil {
 			return err
@@ -378,7 +378,7 @@ func (c *conn) UpdateRefreshToken(ctx context.Context, id string, updater func(o
 			r.Token, r.ObsoleteToken, r.CreatedAt, r.LastUsed, id,
 		)
 		if err != nil {
-			return fmt.Errorf("update refresh token: %v", err)
+			return fmt.Errorf("update refresh token: %w", err)
 		}
 		return nil
 	})
@@ -412,7 +412,7 @@ func (c *conn) ListRefreshTokens(ctx context.Context) ([]storage.RefreshToken, e
 		from refresh_token;
 	`)
 	if err != nil {
-		return nil, fmt.Errorf("query: %v", err)
+		return nil, fmt.Errorf("query: %w", err)
 	}
 	defer rows.Close()
 
@@ -425,7 +425,7 @@ func (c *conn) ListRefreshTokens(ctx context.Context) ([]storage.RefreshToken, e
 		tokens = append(tokens, r)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("scan: %v", err)
+		return nil, fmt.Errorf("scan: %w", err)
 	}
 	return tokens, nil
 }
@@ -443,7 +443,7 @@ func scanRefresh(s scanner) (r storage.RefreshToken, err error) {
 		if err == sql.ErrNoRows {
 			return r, storage.ErrNotFound
 		}
-		return r, fmt.Errorf("scan refresh_token: %v", err)
+		return r, fmt.Errorf("scan refresh_token: %w", err)
 	}
 	return r, nil
 }
@@ -456,7 +456,7 @@ func (c *conn) UpdateKeys(ctx context.Context, updater func(old storage.Keys) (s
 		old, err := getKeys(ctx, tx)
 		if err != nil {
 			if err != storage.ErrNotFound {
-				return fmt.Errorf("get keys: %v", err)
+				return fmt.Errorf("get keys: %w", err)
 			}
 			firstUpdate = true
 			old = storage.Keys{}
@@ -478,7 +478,7 @@ func (c *conn) UpdateKeys(ctx context.Context, updater func(old storage.Keys) (s
 				encoder(nk.SigningKeyPub), nk.NextRotation,
 			)
 			if err != nil {
-				return fmt.Errorf("insert: %v", err)
+				return fmt.Errorf("insert: %w", err)
 			}
 		} else {
 			_, err = tx.Exec(`
@@ -494,7 +494,7 @@ func (c *conn) UpdateKeys(ctx context.Context, updater func(old storage.Keys) (s
 				encoder(nk.SigningKeyPub), nk.NextRotation, keysRowID,
 			)
 			if err != nil {
-				return fmt.Errorf("update: %v", err)
+				return fmt.Errorf("update: %w", err)
 			}
 		}
 		return nil
@@ -519,7 +519,7 @@ func getKeys(ctx context.Context, q querier) (keys storage.Keys, err error) {
 		if err == sql.ErrNoRows {
 			return keys, storage.ErrNotFound
 		}
-		return keys, fmt.Errorf("query keys: %v", err)
+		return keys, fmt.Errorf("query keys: %w", err)
 	}
 	return keys, nil
 }
@@ -552,7 +552,7 @@ func (c *conn) UpdateClient(ctx context.Context, id string, updater func(old sto
 		`, nc.Secret, encoder(nc.RedirectURIs), encoder(nc.TrustedPeers), nc.Public, nc.Name, nc.LogoURL, encoder(nc.AllowedConnectors), encoder(nc.MFAChain), encoder(nc.PostLogoutRedirectURIs), encoder(nc.SSOSharedWith), id,
 		)
 		if err != nil {
-			return fmt.Errorf("update client: %v", err)
+			return fmt.Errorf("update client: %w", err)
 		}
 		return nil
 	})
@@ -572,7 +572,7 @@ func (c *conn) CreateClient(ctx context.Context, cli storage.Client) error {
 		if c.alreadyExistsCheck(err) {
 			return storage.ErrAlreadyExists
 		}
-		return fmt.Errorf("insert client: %v", err)
+		return fmt.Errorf("insert client: %w", err)
 	}
 	return nil
 }
@@ -627,26 +627,26 @@ func scanClient(s scanner) (cli storage.Client, err error) {
 		if err == sql.ErrNoRows {
 			return cli, storage.ErrNotFound
 		}
-		return cli, fmt.Errorf("get client: %v", err)
+		return cli, fmt.Errorf("get client: %w", err)
 	}
 	if len(allowedConnectors) > 0 {
 		if err := json.Unmarshal(allowedConnectors, &cli.AllowedConnectors); err != nil {
-			return cli, fmt.Errorf("unmarshal client allowed connectors: %v", err)
+			return cli, fmt.Errorf("unmarshal client allowed connectors: %w", err)
 		}
 	}
 	if len(mfaChain) > 0 {
 		if err := json.Unmarshal(mfaChain, &cli.MFAChain); err != nil {
-			return cli, fmt.Errorf("unmarshal client mfa chain: %v", err)
+			return cli, fmt.Errorf("unmarshal client mfa chain: %w", err)
 		}
 	}
 	if len(postLogoutRedirectURIs) > 0 {
 		if err := json.Unmarshal(postLogoutRedirectURIs, &cli.PostLogoutRedirectURIs); err != nil {
-			return cli, fmt.Errorf("unmarshal client post logout redirect uris: %v", err)
+			return cli, fmt.Errorf("unmarshal client post logout redirect uris: %w", err)
 		}
 	}
 	if len(ssoSharedWith) > 0 {
 		if err := json.Unmarshal(ssoSharedWith, &cli.SSOSharedWith); err != nil {
-			return cli, fmt.Errorf("unmarshal client sso shared with: %v", err)
+			return cli, fmt.Errorf("unmarshal client sso shared with: %w", err)
 		}
 	}
 	return cli, nil
@@ -668,7 +668,7 @@ func (c *conn) CreatePassword(ctx context.Context, p storage.Password) error {
 		if c.alreadyExistsCheck(err) {
 			return storage.ErrAlreadyExists
 		}
-		return fmt.Errorf("insert password: %v", err)
+		return fmt.Errorf("insert password: %w", err)
 	}
 	return nil
 }
@@ -693,7 +693,7 @@ func (c *conn) UpdatePassword(ctx context.Context, email string, updater func(p 
 			np.Hash, np.Username, np.PreferredUsername, np.UserID, encoder(np.Groups), np.Name, np.EmailVerified, p.Email,
 		)
 		if err != nil {
-			return fmt.Errorf("update password: %v", err)
+			return fmt.Errorf("update password: %w", err)
 		}
 		return nil
 	})
@@ -745,7 +745,7 @@ func scanPassword(s scanner) (p storage.Password, err error) {
 		if err == sql.ErrNoRows {
 			return p, storage.ErrNotFound
 		}
-		return p, fmt.Errorf("select password: %v", err)
+		return p, fmt.Errorf("select password: %w", err)
 	}
 	if emailVerified.Valid {
 		p.EmailVerified = &emailVerified.Bool
@@ -768,7 +768,7 @@ func (c *conn) CreateOfflineSessions(ctx context.Context, s storage.OfflineSessi
 		if c.alreadyExistsCheck(err) {
 			return storage.ErrAlreadyExists
 		}
-		return fmt.Errorf("insert offline session: %v", err)
+		return fmt.Errorf("insert offline session: %w", err)
 	}
 	return nil
 }
@@ -794,7 +794,7 @@ func (c *conn) UpdateOfflineSessions(ctx context.Context, userID string, connID 
 			encoder(newSession.Refresh), newSession.ConnectorData, s.UserID, s.ConnID,
 		)
 		if err != nil {
-			return fmt.Errorf("update offline session: %v", err)
+			return fmt.Errorf("update offline session: %w", err)
 		}
 		return nil
 	})
@@ -821,7 +821,7 @@ func scanOfflineSessions(s scanner) (o storage.OfflineSessions, err error) {
 		if err == sql.ErrNoRows {
 			return o, storage.ErrNotFound
 		}
-		return o, fmt.Errorf("select offline session: %v", err)
+		return o, fmt.Errorf("select offline session: %w", err)
 	}
 	return o, nil
 }
@@ -849,7 +849,7 @@ func (c *conn) CreateUserIdentity(ctx context.Context, u storage.UserIdentity) e
 		if c.alreadyExistsCheck(err) {
 			return storage.ErrAlreadyExists
 		}
-		return fmt.Errorf("insert user identity: %v", err)
+		return fmt.Errorf("insert user identity: %w", err)
 	}
 	return nil
 }
@@ -889,7 +889,7 @@ func (c *conn) UpdateUserIdentity(ctx context.Context, userID, connectorID strin
 			u.UserID, u.ConnectorID,
 		)
 		if err != nil {
-			return fmt.Errorf("update user identity: %v", err)
+			return fmt.Errorf("update user identity: %w", err)
 		}
 		return nil
 	})
@@ -923,7 +923,7 @@ func (c *conn) ListUserIdentities(ctx context.Context) ([]storage.UserIdentity, 
 		from user_identity;
 	`)
 	if err != nil {
-		return nil, fmt.Errorf("query: %v", err)
+		return nil, fmt.Errorf("query: %w", err)
 	}
 	defer rows.Close()
 
@@ -936,7 +936,7 @@ func (c *conn) ListUserIdentities(ctx context.Context) ([]storage.UserIdentity, 
 		identities = append(identities, u)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("scan: %v", err)
+		return nil, fmt.Errorf("scan: %w", err)
 	}
 	return identities, nil
 }
@@ -954,19 +954,19 @@ func scanUserIdentity(s scanner) (u storage.UserIdentity, err error) {
 		if err == sql.ErrNoRows {
 			return u, storage.ErrNotFound
 		}
-		return u, fmt.Errorf("select user identity: %v", err)
+		return u, fmt.Errorf("select user identity: %w", err)
 	}
 	if u.Consents == nil {
 		u.Consents = make(map[string][]string)
 	}
 	if len(mfaSecrets) > 0 {
 		if err := json.Unmarshal(mfaSecrets, &u.MFASecrets); err != nil {
-			return u, fmt.Errorf("unmarshal user identity mfa secrets: %v", err)
+			return u, fmt.Errorf("unmarshal user identity mfa secrets: %w", err)
 		}
 	}
 	if len(webauthnCreds) > 0 {
 		if err := json.Unmarshal(webauthnCreds, &u.WebAuthnCredentials); err != nil {
-			return u, fmt.Errorf("unmarshal user identity webauthn credentials: %v", err)
+			return u, fmt.Errorf("unmarshal user identity webauthn credentials: %w", err)
 		}
 	}
 	return u, nil
@@ -982,7 +982,7 @@ func (c *conn) DeleteUserIdentity(ctx context.Context, userID, connectorID strin
 	// a driver that doesn't implement this, we can run this in a transaction with a get beforehand.
 	n, err := result.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("rows affected: %v", err)
+		return fmt.Errorf("rows affected: %w", err)
 	}
 	if n < 1 {
 		return storage.ErrNotFound
@@ -1013,7 +1013,7 @@ func (c *conn) CreateAuthSession(ctx context.Context, s storage.AuthSession) err
 		if c.alreadyExistsCheck(err) {
 			return storage.ErrAlreadyExists
 		}
-		return fmt.Errorf("insert auth session: %v", err)
+		return fmt.Errorf("insert auth session: %w", err)
 	}
 	return nil
 }
@@ -1046,7 +1046,7 @@ func (c *conn) UpdateAuthSession(ctx context.Context, userID, connectorID string
 			userID, connectorID,
 		)
 		if err != nil {
-			return fmt.Errorf("update auth session: %v", err)
+			return fmt.Errorf("update auth session: %w", err)
 		}
 		return nil
 	})
@@ -1087,7 +1087,7 @@ func scanAuthSession(s scanner) (session storage.AuthSession, err error) {
 		if err == sql.ErrNoRows {
 			return session, storage.ErrNotFound
 		}
-		return session, fmt.Errorf("select auth session: %v", err)
+		return session, fmt.Errorf("select auth session: %w", err)
 	}
 	if session.ClientStates == nil {
 		session.ClientStates = make(map[string]*storage.ClientAuthState)
@@ -1095,7 +1095,7 @@ func scanAuthSession(s scanner) (session storage.AuthSession, err error) {
 	if len(logoutState) > 0 && string(logoutState) != "null" {
 		session.LogoutState = new(storage.LogoutState)
 		if err := json.Unmarshal(logoutState, session.LogoutState); err != nil {
-			return session, fmt.Errorf("unmarshal auth session logout state: %v", err)
+			return session, fmt.Errorf("unmarshal auth session logout state: %w", err)
 		}
 	}
 	return session, nil
@@ -1104,7 +1104,7 @@ func scanAuthSession(s scanner) (session storage.AuthSession, err error) {
 func (c *conn) ListAuthSessions(ctx context.Context) ([]storage.AuthSession, error) {
 	rows, err := c.Query(`select ` + authSessionColumns + ` from auth_session;`)
 	if err != nil {
-		return nil, fmt.Errorf("query: %v", err)
+		return nil, fmt.Errorf("query: %w", err)
 	}
 	defer rows.Close()
 
@@ -1117,7 +1117,7 @@ func (c *conn) ListAuthSessions(ctx context.Context) ([]storage.AuthSession, err
 		sessions = append(sessions, s)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("scan: %v", err)
+		return nil, fmt.Errorf("scan: %w", err)
 	}
 	return sessions, nil
 }
@@ -1130,7 +1130,7 @@ func (c *conn) DeleteAuthSession(ctx context.Context, userID, connectorID string
 
 	n, err := result.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("rows affected: %v", err)
+		return fmt.Errorf("rows affected: %w", err)
 	}
 	if n < 1 {
 		return storage.ErrNotFound
@@ -1141,7 +1141,7 @@ func (c *conn) DeleteAuthSession(ctx context.Context, userID, connectorID string
 func (c *conn) CreateConnector(ctx context.Context, connector storage.Connector) error {
 	grantTypes, err := json.Marshal(connector.GrantTypes)
 	if err != nil {
-		return fmt.Errorf("marshal connector grant types: %v", err)
+		return fmt.Errorf("marshal connector grant types: %w", err)
 	}
 	_, err = c.Exec(`
 		insert into connector (
@@ -1157,7 +1157,7 @@ func (c *conn) CreateConnector(ctx context.Context, connector storage.Connector)
 		if c.alreadyExistsCheck(err) {
 			return storage.ErrAlreadyExists
 		}
-		return fmt.Errorf("insert connector: %v", err)
+		return fmt.Errorf("insert connector: %w", err)
 	}
 	return nil
 }
@@ -1175,7 +1175,7 @@ func (c *conn) UpdateConnector(ctx context.Context, id string, updater func(s st
 		}
 		grantTypes, err := json.Marshal(newConn.GrantTypes)
 		if err != nil {
-			return fmt.Errorf("marshal connector grant types: %v", err)
+			return fmt.Errorf("marshal connector grant types: %w", err)
 		}
 		_, err = tx.Exec(`
 			update connector
@@ -1190,7 +1190,7 @@ func (c *conn) UpdateConnector(ctx context.Context, id string, updater func(s st
 			newConn.Type, newConn.Name, newConn.ResourceVersion, newConn.Config, grantTypes, connector.ID,
 		)
 		if err != nil {
-			return fmt.Errorf("update connector: %v", err)
+			return fmt.Errorf("update connector: %w", err)
 		}
 		return nil
 	})
@@ -1218,11 +1218,11 @@ func scanConnector(s scanner) (c storage.Connector, err error) {
 		if err == sql.ErrNoRows {
 			return c, storage.ErrNotFound
 		}
-		return c, fmt.Errorf("select connector: %v", err)
+		return c, fmt.Errorf("select connector: %w", err)
 	}
 	if len(grantTypes) > 0 {
 		if err := json.Unmarshal(grantTypes, &c.GrantTypes); err != nil {
-			return c, fmt.Errorf("unmarshal connector grant types: %v", err)
+			return c, fmt.Errorf("unmarshal connector grant types: %w", err)
 		}
 	}
 	return c, nil
@@ -1287,7 +1287,7 @@ func (c *conn) DeleteOfflineSessions(ctx context.Context, userID string, connID 
 	// a driver that doesn't implement this, we can run this in a transaction with a get beforehand.
 	n, err := result.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("rows affected: %v", err)
+		return fmt.Errorf("rows affected: %w", err)
 	}
 	if n < 1 {
 		return storage.ErrNotFound
@@ -1306,7 +1306,7 @@ func (c *conn) delete(table, field, id string) error {
 	// a driver that doesn't implement this, we can run this in a transaction with a get beforehand.
 	n, err := result.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("rows affected: %v", err)
+		return fmt.Errorf("rows affected: %w", err)
 	}
 	if n < 1 {
 		return storage.ErrNotFound
@@ -1328,7 +1328,7 @@ func (c *conn) CreateDeviceRequest(ctx context.Context, d storage.DeviceRequest)
 		if c.alreadyExistsCheck(err) {
 			return storage.ErrAlreadyExists
 		}
-		return fmt.Errorf("insert device request: %v", err)
+		return fmt.Errorf("insert device request: %w", err)
 	}
 	return nil
 }
@@ -1347,7 +1347,7 @@ func (c *conn) CreateDeviceToken(ctx context.Context, t storage.DeviceToken) err
 		if c.alreadyExistsCheck(err) {
 			return storage.ErrAlreadyExists
 		}
-		return fmt.Errorf("insert device token: %v", err)
+		return fmt.Errorf("insert device token: %w", err)
 	}
 	return nil
 }
@@ -1368,7 +1368,7 @@ func getDeviceRequest(ctx context.Context, q querier, userCode string) (d storag
 		if err == sql.ErrNoRows {
 			return d, storage.ErrNotFound
 		}
-		return d, fmt.Errorf("select device token: %v", err)
+		return d, fmt.Errorf("select device token: %w", err)
 	}
 	d.UserCode = userCode
 	return d, nil
@@ -1390,7 +1390,7 @@ func getDeviceToken(ctx context.Context, q querier, deviceCode string) (a storag
 		if err == sql.ErrNoRows {
 			return a, storage.ErrNotFound
 		}
-		return a, fmt.Errorf("select device token: %v", err)
+		return a, fmt.Errorf("select device token: %w", err)
 	}
 	a.DeviceCode = deviceCode
 	return a, nil
@@ -1420,7 +1420,7 @@ func (c *conn) UpdateDeviceToken(ctx context.Context, deviceCode string, updater
 			r.Status, r.Token, r.LastRequestTime, r.PollIntervalSeconds, r.PKCE.CodeChallenge, r.PKCE.CodeChallengeMethod, r.DeviceCode,
 		)
 		if err != nil {
-			return fmt.Errorf("update device token: %v", err)
+			return fmt.Errorf("update device token: %w", err)
 		}
 		return nil
 	})

--- a/storage/sql/crud.go
+++ b/storage/sql/crud.go
@@ -774,7 +774,7 @@ func (c *conn) CreateOfflineSessions(ctx context.Context, s storage.OfflineSessi
 }
 
 func (c *conn) UpdateOfflineSessions(ctx context.Context, userID string, connID string, updater func(s storage.OfflineSessions) (storage.OfflineSessions, error)) error {
-	return c.ExecTx(func(tx *trans) error {
+	return c.execTxWithRetry(func(tx *trans) error {
 		s, err := getOfflineSessions(ctx, tx, userID, connID)
 		if err != nil {
 			return err

--- a/storage/sql/migrate_test.go
+++ b/storage/sql/migrate_test.go
@@ -35,7 +35,7 @@ func TestMigrate(t *testing.T) {
 		}
 	}
 
-	c := &conn{db, &flavorSQLite3, logger, errCheck}
+	c := &conn{db, &flavorSQLite3, logger, errCheck, nil}
 	for _, want := range []int{len(sqliteMigrations), 0} {
 		got, err := c.migrate()
 		if err != nil {

--- a/storage/sql/sql.go
+++ b/storage/sql/sql.go
@@ -10,6 +10,8 @@ import (
 	// import third party drivers
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/dexidp/dex/storage/sqlretry"
 )
 
 // flavor represents a specific SQL implementation, and is used to translate query strings
@@ -132,6 +134,11 @@ type conn struct {
 	flavor             *flavor
 	logger             *slog.Logger
 	alreadyExistsCheck func(err error) bool
+
+	// txRetryCheck reports whether err is a transient transaction failure
+	// (serialization failure or deadlock) that is safe to retry by re-running
+	// the whole transaction. It is driver-specific and may be nil (no retries).
+	txRetryCheck func(err error) bool
 }
 
 func (c *conn) Close() error {
@@ -172,6 +179,20 @@ func (c *conn) ExecTx(fn func(tx *trans) error) error {
 		return err
 	}
 	return sqlTx.Commit()
+}
+
+// execTxWithRetry runs an ExecTx, retrying the whole transaction on transient
+// serialization/deadlock failures. Retrying is safe because the closure re-reads
+// current state in a fresh transaction on each attempt.
+func (c *conn) execTxWithRetry(fn func(tx *trans) error) error {
+	return sqlretry.Do(
+		func() error { return c.ExecTx(fn) },
+		c.txRetryCheck,
+		func(attempt int, err error) {
+			c.logger.Warn("retrying transaction after transient failure",
+				"attempt", attempt, "max_attempts", sqlretry.MaxRetries, "err", err)
+		},
+	)
 }
 
 type trans struct {

--- a/storage/sql/sql_retry_test.go
+++ b/storage/sql/sql_retry_test.go
@@ -1,0 +1,103 @@
+//go:build cgo
+// +build cgo
+
+package sql
+
+import (
+	"database/sql"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/dexidp/dex/storage/sqlretry"
+)
+
+// errRetryable is a sentinel used to drive the txRetryCheck in tests.
+var errRetryable = errors.New("retryable transient failure")
+
+func newRetryTestConn(t *testing.T) *conn {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	return &conn{
+		db:                 db,
+		flavor:             &flavorSQLite3,
+		logger:             slog.New(slog.DiscardHandler),
+		alreadyExistsCheck: func(error) bool { return false },
+		txRetryCheck:       func(err error) bool { return errors.Is(err, errRetryable) },
+	}
+}
+
+func TestExecTxWithRetryRetriesUntilSuccess(t *testing.T) {
+	c := newRetryTestConn(t)
+
+	attempts := 0
+	err := c.execTxWithRetry(func(*trans) error {
+		attempts++
+		if attempts <= 2 {
+			return errRetryable
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected success after retries, got: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts (2 retries), got %d", attempts)
+	}
+}
+
+func TestExecTxWithRetryGivesUpAfterMaxRetries(t *testing.T) {
+	c := newRetryTestConn(t)
+
+	attempts := 0
+	err := c.execTxWithRetry(func(*trans) error {
+		attempts++
+		return errRetryable
+	})
+	if !errors.Is(err, errRetryable) {
+		t.Fatalf("expected retryable error to be returned, got: %v", err)
+	}
+	// 1 initial attempt + sqlretry.MaxRetries retries.
+	if want := sqlretry.MaxRetries + 1; attempts != want {
+		t.Fatalf("expected %d attempts, got %d", want, attempts)
+	}
+}
+
+func TestExecTxWithRetryDoesNotRetryNonRetryableError(t *testing.T) {
+	c := newRetryTestConn(t)
+
+	sentinel := errors.New("permanent failure")
+	attempts := 0
+	err := c.execTxWithRetry(func(*trans) error {
+		attempts++
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error to be returned, got: %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("expected exactly 1 attempt for non-retryable error, got %d", attempts)
+	}
+}
+
+func TestExecTxWithRetryNilRetryCheckDoesNotRetry(t *testing.T) {
+	c := newRetryTestConn(t)
+	c.txRetryCheck = nil
+
+	attempts := 0
+	err := c.execTxWithRetry(func(*trans) error {
+		attempts++
+		return errRetryable
+	})
+	if !errors.Is(err, errRetryable) {
+		t.Fatalf("expected error to be returned, got: %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("expected exactly 1 attempt when txRetryCheck is nil, got %d", attempts)
+	}
+}

--- a/storage/sql/sqlite.go
+++ b/storage/sql/sqlite.go
@@ -45,7 +45,7 @@ func (s *SQLite3) open(logger *slog.Logger) (*conn, error) {
 		return sqlErr.ExtendedCode == sqlite3.ErrConstraintPrimaryKey
 	}
 
-	c := &conn{db, &flavorSQLite3, logger, errCheck}
+	c := &conn{db, &flavorSQLite3, logger, errCheck, nil}
 	if _, err := c.migrate(); err != nil {
 		return nil, fmt.Errorf("failed to perform migrations: %v", err)
 	}

--- a/storage/sqlretry/sqlretry.go
+++ b/storage/sqlretry/sqlretry.go
@@ -1,0 +1,84 @@
+// Package sqlretry provides a shared retry policy for transient SQL transaction
+// failures (serialization failures / deadlocks under SERIALIZABLE isolation).
+//
+// It is used by both SQL-backed storages — storage/sql (raw database/sql) and
+// storage/ent (the ent ORM) — which both run refresh-token rotation in a
+// SERIALIZABLE transaction and must be prepared to retry transactions the
+// database aborts under concurrency.
+package sqlretry
+
+import (
+	"errors"
+	"math/rand"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/lib/pq"
+)
+
+// MaxRetries is the maximum number of retries; the initial attempt is not
+// counted. Postgres requires applications to be prepared to retry transactions
+// aborted with SQLSTATE 40001; see
+// https://www.postgresql.org/docs/current/transaction-iso.html.
+//
+// 8 retries comfortably absorbs realistic refresh-token contention; combined
+// with jittered backoff — which de-synchronizes the retrying transactions so
+// effective concurrency at any instant stays low — it also survives pathological
+// high-contention conformance tests, while bounding worst-case latency.
+const MaxRetries = 8
+
+// backoffMs is the per-attempt base backoff in milliseconds. The last element is
+// reused for any attempt beyond its length; a random jitter of up to the same
+// magnitude is added on top to de-synchronize retrying transactions (avoid a
+// thundering herd).
+var backoffMs = []int{5, 10, 25, 50, 100}
+
+const (
+	pgErrSerializationFailure = "40001" // serialization_failure
+	pgErrDeadlockDetected     = "40P01" // deadlock_detected
+	mysqlErrLockDeadlock      = 1213    // ER_LOCK_DEADLOCK
+	mysqlErrLockWaitTimeout   = 1205    // ER_LOCK_WAIT_TIMEOUT
+)
+
+// IsSerializationFailure reports whether err is a transient transaction failure
+// (serialization failure or deadlock) that is safe to retry by re-running the
+// whole transaction. It understands both the lib/pq and go-sql-driver/mysql
+// error types, unwrapping the error chain with errors.As.
+func IsSerializationFailure(err error) bool {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return pqErr.Code == pgErrSerializationFailure || pqErr.Code == pgErrDeadlockDetected
+	}
+
+	var myErr *mysql.MySQLError
+	if errors.As(err, &myErr) {
+		return myErr.Number == mysqlErrLockDeadlock || myErr.Number == mysqlErrLockWaitTimeout
+	}
+
+	return false
+}
+
+// Do runs fn, retrying the whole operation on transient serialization/deadlock
+// failures with bounded, jittered backoff. Retrying is safe only when fn opens a
+// fresh transaction and re-reads current state on each attempt.
+//
+// isRetryable classifies an error as transient; if nil, no retries are performed
+// (used by backends, such as SQLite, that don't surface serialization failures).
+// onRetry, if non-nil, is called before each backoff sleep with the upcoming
+// (1-based) attempt number and the error that triggered the retry — e.g. for
+// logging.
+func Do(fn func() error, isRetryable func(error) bool, onRetry func(attempt int, err error)) error {
+	for attempt := 0; ; attempt++ {
+		err := fn()
+		if err == nil || isRetryable == nil || !isRetryable(err) || attempt >= MaxRetries {
+			return err
+		}
+
+		if onRetry != nil {
+			onRetry(attempt+1, err)
+		}
+
+		backoff := backoffMs[min(attempt, len(backoffMs)-1)]
+		time.Sleep(time.Duration(backoff+rand.Intn(backoff+1)) * time.Millisecond)
+	}
+}


### PR DESCRIPTION
#### Overview

When several clients call `UpdateRefreshToken` — which performs a read-modify-write inside a SERIALIZABLE transaction — concurrent rotation of the same token makes the database abort one transaction with a serialization failure, e.g.:

​```
time=2026-06-10T09:34:44.629Z level=ERROR msg="failed to update refresh token" err="update refresh token: pq: could not serialize access due to concurrent update"
​```

Neither SQL storage backend retried, so the abort surfaced to clients as a 500.

#### What this PR does / why we need it
Add a bounded, jittered retry around the refresh-token update in **both** SQL backends (`storage/sql` and `storage/ent`):
- Up to 8 retries with jittered backoff; each attempt re-runs the transaction in a fresh read-modify-write, so it's safe.
- Per-driver detection of transient failures via `errors.As`: Postgres `40001` / `40P01`, MySQL `1213` / `1205`.
- The retry is an application-level wrapper in both backends, since neither Go's `database/sql` nor [ent](https://github.com/ent/ent/issues/2341) retries transactions natively.
- Re-enables the refresh-token concurrency conformance tests for Postgres / MySQL (and MySQL 8 for ent).

#### Special notes for your reviewer

- I've decided to set reasonable hard coded values for the retries and backoff, but we can expose to be configurable if you folks think it is necessary
- Also, I've done this fix only for update refresh token as it is where I faced the issue and I think where the API is more vulnerable, but I can port to cover all the endpoints 

