### PR TITLE
feat(signer): support EdDSA for the local token signer

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -545,7 +545,7 @@ func normalizeLocalSignerConfig(c *signer.LocalConfig) error {
 		c.Algorithm = jose.RS256
 		return nil
 	}
-	if c.Algorithm == jose.RS256 || c.Algorithm == jose.ES256 {
+	if c.Algorithm == jose.RS256 || c.Algorithm == jose.ES256 || c.Algorithm == jose.EdDSA {
 		return nil
 	}
 	return fmt.Errorf("unsupported local signer algorithm %q", c.Algorithm)

--- a/server/authflow/request.go
+++ b/server/authflow/request.go
@@ -162,7 +162,8 @@ type PKCEConfig struct {
 // token so callers can extract Subject, Audience, etc.
 func (h *Handler) validateIDTokenHint(ctx context.Context, hint string) (*oidc.IDToken, error) {
 	verifier := oidc.NewVerifier(h.IssuerURL.String(), &signer.KeySet{Signer: h.Signer}, &oidc.Config{
-		SkipExpiryCheck: true,
+		SupportedSigningAlgs: signer.SupportedSigningAlgStrings(),
+		SkipExpiryCheck:      true,
 		// SkipClientIDCheck is set because the hint may originate from any client that
 		// Dex issued a token to — the caller does not know the expected audience in advance.
 		// The signature verification via signer.KeySet already guarantees the token was

--- a/server/introspection/introspection.go
+++ b/server/introspection/introspection.go
@@ -172,6 +172,12 @@ func (h *Handler) guessTokenType(ctx context.Context, token string) (TokenTypeEn
 		SkipExpiryCheck:   true,
 		SkipIssuerCheck:   true,
 
+		// go-oidc validates the token's alg against SupportedSigningAlgs before
+		// honoring InsecureSkipSignatureCheck; without this it defaults to RS256
+		// only and rejects ES256/EdDSA access tokens, mis-classifying them as
+		// refresh tokens.
+		SupportedSigningAlgs: signer.SupportedSigningAlgStrings(),
+
 		// We skip signature checks to avoid database calls;
 		InsecureSkipSignatureCheck: true,
 	}
@@ -271,7 +277,10 @@ func (h *Handler) introspectRefreshToken(ctx context.Context, token string) (*In
 }
 
 func (h *Handler) introspectAccessToken(ctx context.Context, token string) (*Introspection, error) {
-	verifier := oidc.NewVerifier(h.Issuer, &signer.KeySet{Signer: h.Signer}, &oidc.Config{SkipClientIDCheck: true})
+	verifier := oidc.NewVerifier(h.Issuer, &signer.KeySet{Signer: h.Signer}, &oidc.Config{
+		SupportedSigningAlgs: signer.SupportedSigningAlgStrings(),
+		SkipClientIDCheck:    true,
+	})
 	idToken, err := verifier.Verify(ctx, token)
 	if err != nil {
 		return nil, newIntrospectInactiveTokenError()

--- a/server/logout/logout.go
+++ b/server/logout/logout.go
@@ -352,8 +352,9 @@ func (h *Handler) deleteAuthSession(ctx context.Context, userID, connectorID str
 // audience are intentionally skipped per RP-Initiated Logout.
 func (h *Handler) validateIDTokenHint(ctx context.Context, hint string) (*oidc.IDToken, error) {
 	verifier := oidc.NewVerifier(h.IssuerURL.String(), &signer.KeySet{Signer: h.Signer}, &oidc.Config{
-		SkipExpiryCheck:   true,
-		SkipClientIDCheck: true,
+		SupportedSigningAlgs: signer.SupportedSigningAlgStrings(),
+		SkipExpiryCheck:      true,
+		SkipClientIDCheck:    true,
 	})
 	return verifier.Verify(ctx, hint)
 }

--- a/server/server_introspection_test.go
+++ b/server/server_introspection_test.go
@@ -11,12 +11,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dexidp/dex/server/internal"
 	"github.com/dexidp/dex/server/introspection"
+	"github.com/dexidp/dex/server/signer"
 	"github.com/dexidp/dex/server/tokens"
 	"github.com/dexidp/dex/storage"
+	"github.com/dexidp/dex/storage/memory"
 )
 
 func toJSON(a interface{}) string {
@@ -256,4 +259,71 @@ func TestHandleIntrospect(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestHandleIntrospectEdDSA drives the full introspection endpoint with an
+// EdDSA-signed access token. It is a regression test for guessTokenType: without
+// SupportedSigningAlgs on its verifier config, go-oidc defaults to RS256 only and
+// rejects the EdDSA token, so the access token is mis-classified as a refresh
+// token and introspection returns active: false.
+func TestHandleIntrospectEdDSA(t *testing.T) {
+	t0 := time.Now()
+
+	ctx := t.Context()
+
+	now := func() time.Time { return t0 }
+
+	logger := newLogger(t)
+
+	refreshTokenPolicy := tokens.NewRefreshStrategy(true, 24*time.Hour, 0, 0, now)
+
+	localConfig := signer.LocalConfig{
+		KeysRotationPeriod: time.Hour.String(),
+		Algorithm:          jose.EdDSA,
+	}
+	eddsaSigner, err := localConfig.Open(ctx, memory.New(logger), time.Hour, now, logger)
+	require.NoError(t, err)
+
+	httpServer, s := newTestServer(t, func(c *Config) {
+		c.Issuer += "/non-root-path"
+		c.RefreshTokenPolicy = refreshTokenPolicy
+		c.Now = now
+		c.Signer = eddsaSigner
+	})
+	defer httpServer.Close()
+
+	mockTestStorage(t, s.storage)
+
+	activeAccessToken, expiry, err := s.issuer.SignIDToken(ctx, tokens.Authorization{
+		Client: storage.Client{ID: "test"},
+		Claims: storage.Claims{
+			UserID:        "1",
+			Username:      "jane",
+			Email:         "jane.doe@example.com",
+			EmailVerified: true,
+			Groups:        []string{"a", "b"},
+		},
+		Scopes:      []string{"openid", "email", "profile", "groups"},
+		Nonce:       "foo",
+		ConnectorID: "test",
+	}, "", "")
+	require.NoError(t, err)
+
+	// The full /token/introspect endpoint must report the EdDSA access token as
+	// active, which only happens if guessTokenType classified it as an access token.
+	data := url.Values{}
+	data.Set("token", activeAccessToken)
+
+	u, err := url.Parse(s.issuerURL.String())
+	require.NoError(t, err)
+	u.Path = path.Join(u.Path, "token", "introspect")
+
+	req, _ := http.NewRequest("POST", u.String(), bytes.NewBufferString(data.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rr := httptest.NewRecorder()
+	s.ServeHTTP(rr, req)
+
+	require.Equal(t, 200, rr.Code)
+	require.JSONEq(t, toJSON(getIntrospectionValue(s.issuerURL.URL, t0, expiry, "access_token")), rr.Body.String())
 }

--- a/server/signer/keyset.go
+++ b/server/signer/keyset.go
@@ -7,6 +7,26 @@ import (
 	jose "github.com/go-jose/go-jose/v4"
 )
 
+// SupportedSigningAlgs lists every JWS signing algorithm a Dex signer (local or
+// Vault) can produce. Verifiers for Dex-issued tokens must allow all of them:
+// otherwise go-oidc's IDTokenVerifier.Verify defaults to RS256 only and rejects
+// ES256/EdDSA tokens before KeySet.VerifySignature ever runs.
+var SupportedSigningAlgs = []jose.SignatureAlgorithm{
+	jose.RS256, jose.RS384, jose.RS512,
+	jose.ES256, jose.ES384, jose.ES512,
+	jose.EdDSA,
+}
+
+// SupportedSigningAlgStrings returns SupportedSigningAlgs as strings, for use in
+// oidc.Config.SupportedSigningAlgs.
+func SupportedSigningAlgStrings() []string {
+	algs := make([]string, len(SupportedSigningAlgs))
+	for i, alg := range SupportedSigningAlgs {
+		algs[i] = string(alg)
+	}
+	return algs
+}
+
 // KeySet implements the oidc.KeySet interface backed by a Dex Signer,
 // verifying a JWT's signature against the signer's current validation keys.
 type KeySet struct {
@@ -14,7 +34,7 @@ type KeySet struct {
 }
 
 func (k *KeySet) VerifySignature(ctx context.Context, jwt string) (payload []byte, err error) {
-	jws, err := jose.ParseSigned(jwt, []jose.SignatureAlgorithm{jose.RS256, jose.RS384, jose.RS512, jose.ES256, jose.ES384, jose.ES512})
+	jws, err := jose.ParseSigned(jwt, SupportedSigningAlgs)
 	if err != nil {
 		return nil, err
 	}

--- a/server/signer/local.go
+++ b/server/signer/local.go
@@ -19,7 +19,7 @@ type LocalConfig struct {
 	// Algorithm defines the signing algorithm used for newly generated local keys.
 	// Changing it does not replace the current signing key immediately. The new
 	// algorithm is applied when Dex generates the next signing key during rotation.
-	// Supported values are RS256 and ES256.
+	// Supported values are RS256, ES256, and EdDSA.
 	Algorithm jose.SignatureAlgorithm `json:"algorithm"`
 }
 
@@ -27,7 +27,7 @@ func (c *LocalConfig) signingAlgorithm() (jose.SignatureAlgorithm, error) {
 	if c.Algorithm == "" {
 		return jose.RS256, nil
 	}
-	if c.Algorithm == jose.RS256 || c.Algorithm == jose.ES256 {
+	if c.Algorithm == jose.RS256 || c.Algorithm == jose.ES256 || c.Algorithm == jose.EdDSA {
 		return c.Algorithm, nil
 	}
 	return "", fmt.Errorf("unsupported local signer algorithm %q", c.Algorithm)

--- a/server/signer/local_test.go
+++ b/server/signer/local_test.go
@@ -97,6 +97,11 @@ func TestLocalSignerAlgorithm(t *testing.T) {
 			cfg:  LocalConfig{KeysRotationPeriod: time.Hour.String(), Algorithm: jose.ES256},
 			want: jose.ES256,
 		},
+		{
+			name: "EdDSA before first rotation",
+			cfg:  LocalConfig{KeysRotationPeriod: time.Hour.String(), Algorithm: jose.EdDSA},
+			want: jose.EdDSA,
+		},
 	}
 
 	for _, tt := range tests {
@@ -125,6 +130,11 @@ func TestLocalSignerSignAndValidate(t *testing.T) {
 			name: "ES256",
 			cfg:  LocalConfig{KeysRotationPeriod: time.Hour.String(), Algorithm: jose.ES256},
 			want: jose.ES256,
+		},
+		{
+			name: "EdDSA",
+			cfg:  LocalConfig{KeysRotationPeriod: time.Hour.String(), Algorithm: jose.EdDSA},
+			want: jose.EdDSA,
 		},
 	}
 

--- a/server/signer/rotation.go
+++ b/server/signer/rotation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -34,7 +35,7 @@ type rotationStrategy struct {
 	// Algorithm used for newly generated signing keys.
 	algorithm jose.SignatureAlgorithm
 
-	// Local signer keys can be RSA or ECDSA depending on the configured algorithm.
+	// Local signer keys can be RSA, ECDSA, or Ed25519 depending on the configured algorithm.
 	key func() (crypto.Signer, error)
 }
 
@@ -46,7 +47,7 @@ func rotationStrategyForAlgorithm(rotationFrequency, idTokenValidFor time.Durati
 		idTokenValidFor:   idTokenValidFor,
 		algorithm:         algorithm,
 	}
-	// Only RS256 and ES256 are supported for local key rotation; all other algorithms are handled by the default case.
+	// Only RS256, ES256, and EdDSA are supported for local key rotation; all other algorithms are handled by the default case.
 	switch algorithm { //nolint:exhaustive
 	case jose.RS256:
 		strategy.key = func() (crypto.Signer, error) {
@@ -55,6 +56,11 @@ func rotationStrategyForAlgorithm(rotationFrequency, idTokenValidFor time.Durati
 	case jose.ES256:
 		strategy.key = func() (crypto.Signer, error) {
 			return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		}
+	case jose.EdDSA:
+		strategy.key = func() (crypto.Signer, error) {
+			_, priv, err := ed25519.GenerateKey(rand.Reader)
+			return priv, err
 		}
 	default:
 		return rotationStrategy{}, fmt.Errorf("unsupported local signer algorithm %q", algorithm)

--- a/server/signer/rotation_test.go
+++ b/server/signer/rotation_test.go
@@ -2,12 +2,17 @@ package signer
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
 	"log/slog"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dexidp/dex/storage"
 	"github.com/dexidp/dex/storage/memory"
@@ -100,4 +105,44 @@ func TestKeyRotator(t *testing.T) {
 			expVerificationKeys = expVerificationKeys[n-maxVerificationKeys:]
 		}
 	}
+}
+
+func TestRotationStrategyForAlgorithm(t *testing.T) {
+	frequency := time.Hour
+	validFor := time.Hour
+
+	t.Run("RS256 generates an RSA key", func(t *testing.T) {
+		strategy, err := rotationStrategyForAlgorithm(frequency, validFor, jose.RS256)
+		require.NoError(t, err)
+		assert.Equal(t, jose.RS256, strategy.algorithm)
+
+		key, err := strategy.key()
+		require.NoError(t, err)
+		assert.IsType(t, &rsa.PrivateKey{}, key)
+	})
+
+	t.Run("ES256 generates an ECDSA key", func(t *testing.T) {
+		strategy, err := rotationStrategyForAlgorithm(frequency, validFor, jose.ES256)
+		require.NoError(t, err)
+		assert.Equal(t, jose.ES256, strategy.algorithm)
+
+		key, err := strategy.key()
+		require.NoError(t, err)
+		assert.IsType(t, &ecdsa.PrivateKey{}, key)
+	})
+
+	t.Run("EdDSA generates an Ed25519 key", func(t *testing.T) {
+		strategy, err := rotationStrategyForAlgorithm(frequency, validFor, jose.EdDSA)
+		require.NoError(t, err)
+		assert.Equal(t, jose.EdDSA, strategy.algorithm)
+
+		key, err := strategy.key()
+		require.NoError(t, err)
+		assert.IsType(t, ed25519.PrivateKey{}, key)
+	})
+
+	t.Run("unsupported algorithm errors", func(t *testing.T) {
+		_, err := rotationStrategyForAlgorithm(frequency, validFor, jose.PS256)
+		require.Error(t, err)
+	})
 }

--- a/server/tokens/claims.go
+++ b/server/tokens/claims.go
@@ -21,6 +21,9 @@ var hashForSigAlg = map[jose.SignatureAlgorithm]func() hash.Hash{
 	jose.ES256: sha256.New,
 	jose.ES384: sha512.New384,
 	jose.ES512: sha512.New,
+	// EdDSA (Ed25519) uses SHA-512 internally, so the at_hash/c_hash is
+	// computed over SHA-512 as well.
+	jose.EdDSA: sha512.New,
 }
 
 // AccessTokenHash computes the at_hash/c_hash value for the given signing

--- a/server/userinfo/userinfo.go
+++ b/server/userinfo/userinfo.go
@@ -37,7 +37,10 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	}
 	rawIDToken := auth[len(prefix):]
 
-	verifier := oidc.NewVerifier(h.Issuer, &signer.KeySet{Signer: h.Signer}, &oidc.Config{SkipClientIDCheck: true})
+	verifier := oidc.NewVerifier(h.Issuer, &signer.KeySet{Signer: h.Signer}, &oidc.Config{
+		SupportedSigningAlgs: signer.SupportedSigningAlgStrings(),
+		SkipClientIDCheck:    true,
+	})
 	idToken, err := verifier.Verify(ctx, rawIDToken)
 	if err != nil {
 		h.Logger.ErrorContext(ctx, "failed to verify ID token", "err", err)


### PR DESCRIPTION
#### Overview

Adds EdDSA (Ed25519) as a signing algorithm for the local token signer, completing #4442. The local signer already supported RS256 and ES256, so this fills in the remaining algorithm requested in the issue.

#### What this PR does / why we need it

EdDSA produces much smaller signatures than RS256, which matters for setups with a tight token-size budget — the issue describes Argo CD storing tokens as cookies under a 4 KB limit.

- `server/signer/rotation.go`: generate an Ed25519 key when the configured algorithm is `EdDSA`. `server/signer/utils.go` already maps Ed25519 keys to `jose.EdDSA` and `signPayload` is algorithm-generic, so signing, JWKS publication, and the discovery `id_token_signing_alg_values_supported` value already work once a key is generated.
- `server/signer/local.go` and `cmd/dex/config.go`: accept `EdDSA` in the local-signer config validation.
- `server/oauth2.go`: add `EdDSA → SHA-512` to `hashForSigAlg` so `at_hash`/`c_hash` can be computed for EdDSA id_tokens (Ed25519 uses SHA-512 internally).

It also fixes a verifier gap that EdDSA exposes: the `id_token_hint`, `/userinfo`, and `/token/introspect` verifiers build `oidc.NewVerifier` with an `oidc.Config` that does not set `SupportedSigningAlgs`. go-oidc then defaults to `RS256` only and rejects ES256/EdDSA Dex-issued tokens with `malformed jwt` before `signerKeySet.VerifySignature` ever runs. These three sites now pass the same algorithm list `signerKeySet` already uses, extracted into a shared `supportedSigningAlgs`.

> Note: this verifier gap also affects ES256 today, not just EdDSA. I included the fix here because EdDSA cannot work end-to-end without it, but I'm happy to split it into a separate PR if you'd prefer to keep this one signer-only.

Closes #4442

#### Special notes for your reviewer

- Tests:
  - EdDSA cases added to the local-signer table tests, plus a new `TestRotationStrategyForAlgorithm`.
  - `TestAccessTokenHashEdDSA` for the `at_hash` mapping.
  - `TestSignerKeySetWithEdDSALocalSigner` and an end-to-end `TestValidateIDTokenHintEdDSA` that drives the real verifier path. The latter fails against the unpatched verifier with `oidc: malformed jwt: unexpected signature algorithm "EdDSA"; expected ["RS256"]`.
- `go test ./server/... ./cmd/...`, `golangci-lint run`, and `gofmt -l` are all clean. No new dependencies (Ed25519 is stdlib).
