### PR TITLE
add isConnectorAllowed check to handlePasswordGrant

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1617,6 +1617,10 @@ func (s *Server) handlePasswordGrant(w http.ResponseWriter, r *http.Request, cli
 
 	// Which connector
 	connID := s.passwordConnector
+	if !isConnectorAllowed(client.AllowedConnectors, connID) {
+		s.tokenErrHelper(w, errInvalidGrant, "Connector not allowed for this client.", http.StatusBadRequest)
+		return
+	}
 	conn, err := s.getConnector(ctx, connID)
 	if err != nil {
 		s.tokenErrHelper(w, errInvalidRequest, "Requested connector does not exist.", http.StatusBadRequest)


### PR DESCRIPTION
handlePasswordGrant uses s.passwordConnector directly without validating against client.AllowedConnectors. The other three handlers that deal with connector selection all call isConnectorAllowed() — this adds the same check.

- handleConnectorLogin (handlers.go:377): calls isConnectorAllowed
- handleAuthorization (oauth2.go:535): calls isConnectorAllowed
- handleTokenExchange (handlers.go:1835): calls isConnectorAllowed
- handlePasswordGrant (handlers.go:1619): was missing the check

A client with restricted AllowedConnectors could use the password grant against a connector it shouldn't have access to.