### PR TITLE
GitHub Connector: Implement support for refresh tokens

### DIFF
--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -12,6 +12,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/github"
@@ -129,8 +131,11 @@ func (c *Config) Open(id string, logger *slog.Logger) (connector.Connector, erro
 }
 
 type connectorData struct {
-	// GitHub's OAuth2 tokens never expire. We don't need a refresh token.
-	AccessToken string `json:"accessToken"`
+	// GitHub OAuth Apps return long-lived access tokens. GitHub Apps can return
+	// expiring user access tokens with refresh tokens.
+	AccessToken  string    `json:"accessToken"`
+	RefreshToken string    `json:"refreshToken,omitempty"`
+	Expiry       time.Time `json:"expiry,omitempty"`
 }
 
 var (
@@ -268,7 +273,14 @@ func (c *githubConnector) HandleCallback(s connector.Scopes, connData []byte, r 
 	}
 
 	if s.OfflineAccess {
-		data := connectorData{AccessToken: token.AccessToken}
+		data := connectorData{
+			AccessToken:  token.AccessToken,
+			RefreshToken: token.RefreshToken,
+			Expiry:       token.Expiry,
+		}
+		if token.RefreshToken != "" && c.logger != nil {
+			c.logger.DebugContext(ctx, "github: received upstream refresh token", "access_token_expiry", token.Expiry)
+		}
 		connData, err := json.Marshal(data)
 		if err != nil {
 			return identity, fmt.Errorf("marshal connector data: %v", err)
@@ -277,6 +289,34 @@ func (c *githubConnector) HandleCallback(s connector.Scopes, connData []byte, r 
 	}
 
 	return identity, nil
+}
+
+// Refreshing tokens
+// https://github.com/golang/oauth2/issues/84#issuecomment-332860871
+type tokenNotifyFunc func(*oauth2.Token) error
+
+// notifyRefreshTokenSource is essentially `oauth2.ReuseTokenSource` with `TokenNotifyFunc` added.
+type notifyRefreshTokenSource struct {
+	new oauth2.TokenSource
+	mu  sync.Mutex // guards t
+	t   *oauth2.Token
+	f   tokenNotifyFunc // called when token refreshed so new refresh token can be persisted
+}
+
+// Token returns the current token if it's still valid, else will
+// refresh the current token and return the new one.
+func (s *notifyRefreshTokenSource) Token() (*oauth2.Token, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.t.Valid() {
+		return s.t, nil
+	}
+	t, err := s.new.Token()
+	if err != nil {
+		return nil, err
+	}
+	s.t = t
+	return t, s.f(t)
 }
 
 func (c *githubConnector) Refresh(ctx context.Context, s connector.Scopes, identity connector.Identity) (connector.Identity, error) {
@@ -289,7 +329,52 @@ func (c *githubConnector) Refresh(ctx context.Context, s connector.Scopes, ident
 		return identity, fmt.Errorf("github: unmarshal access token: %v", err)
 	}
 
-	client := c.oauth2Config(s).Client(ctx, &oauth2.Token{AccessToken: data.AccessToken})
+	if data.AccessToken == "" && data.RefreshToken == "" {
+		return identity, errors.New("no upstream access token found")
+	}
+
+	oauth2Config := c.oauth2Config(s)
+	if c.httpClient != nil {
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, c.httpClient)
+	}
+
+	tok := &oauth2.Token{
+		AccessToken:  data.AccessToken,
+		RefreshToken: data.RefreshToken,
+		Expiry:       data.Expiry,
+	}
+	oldRefreshToken := data.RefreshToken
+	if oldRefreshToken != "" && c.logger != nil {
+		c.logger.DebugContext(ctx, "github: upstream refresh token available",
+			"will_refresh_access_token", !tok.Valid(),
+			"access_token_expiry", data.Expiry,
+		)
+	}
+
+	client := oauth2.NewClient(ctx, &notifyRefreshTokenSource{
+		new: oauth2Config.TokenSource(ctx, tok),
+		t:   tok,
+		f: func(tok *oauth2.Token) error {
+			if c.logger != nil {
+				c.logger.DebugContext(ctx, "github: refreshed upstream access token with refresh token",
+					"access_token_expiry", tok.Expiry,
+					"refresh_token_rotated", oldRefreshToken != "" && tok.RefreshToken != "" && tok.RefreshToken != oldRefreshToken,
+				)
+			}
+
+			data := connectorData{
+				AccessToken:  tok.AccessToken,
+				RefreshToken: tok.RefreshToken,
+				Expiry:       tok.Expiry,
+			}
+			connData, err := json.Marshal(data)
+			if err != nil {
+				return fmt.Errorf("github: marshal connector data: %v", err)
+			}
+			identity.ConnectorData = connData
+			return nil
+		},
+	})
 	user, err := c.user(ctx, client)
 	if err != nil {
 		return identity, fmt.Errorf("github: get user: %v", err)

--- a/connector/github/github_test.go
+++ b/connector/github/github_test.go
@@ -12,7 +12,9 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/dexidp/dex/connector"
 )
@@ -198,6 +200,148 @@ func TestLoginUsedAsIDWhenConfigured(t *testing.T) {
 	expectNil(t, err)
 	expectEquals(t, identity.UserID, "some-login")
 	expectEquals(t, identity.Username, "Joe Bloggs")
+}
+
+func TestHandleCallbackStoresRefreshToken(t *testing.T) {
+	s := newTestServer(map[string]testResponse{
+		"/user": {data: user{Login: "some-login", ID: 12345678, Name: "Joe Bloggs", Email: "some@email.com"}},
+		"/login/oauth/access_token": {data: map[string]interface{}{
+			"access_token":  "access-token",
+			"refresh_token": "refresh-token",
+			"expires_in":    28800,
+		}},
+	})
+	defer s.Close()
+
+	hostURL, err := url.Parse(s.URL)
+	expectNil(t, err)
+
+	req, err := http.NewRequest("GET", hostURL.String(), nil)
+	expectNil(t, err)
+
+	c := githubConnector{apiURL: s.URL, hostName: hostURL.Host, httpClient: newClient()}
+	identity, err := c.HandleCallback(connector.Scopes{OfflineAccess: true}, nil, req)
+	expectNil(t, err)
+
+	var data connectorData
+	if err := json.Unmarshal(identity.ConnectorData, &data); err != nil {
+		t.Fatalf("failed to unmarshal connector data: %v", err)
+	}
+	expectEquals(t, data.AccessToken, "access-token")
+	expectEquals(t, data.RefreshToken, "refresh-token")
+	if data.Expiry.IsZero() || !data.Expiry.After(time.Now()) {
+		t.Fatalf("expected future token expiry, got %v", data.Expiry)
+	}
+}
+
+func TestRefreshUsesRefreshToken(t *testing.T) {
+	var tokenRefreshCalled atomic.Bool
+	s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/login/oauth/access_token":
+			tokenRefreshCalled.Store(true)
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("failed to parse token refresh form: %v", err)
+			}
+			if got := r.Form.Get("grant_type"); got != "refresh_token" {
+				t.Fatalf("expected refresh_token grant type, got %q", got)
+			}
+			if got := r.Form.Get("refresh_token"); got != "old-refresh-token" {
+				t.Fatalf("expected old refresh token, got %q", got)
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token":  "new-access-token",
+				"refresh_token": "new-refresh-token",
+				"expires_in":    28800,
+			})
+		case "/user":
+			if got := r.Header.Get("Authorization"); got != "Bearer new-access-token" {
+				t.Fatalf("expected refreshed access token, got %q", got)
+			}
+			json.NewEncoder(w).Encode(user{Login: "new-login", ID: 12345678, Name: "New User", Email: "new@email.com"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer s.Close()
+
+	hostURL, err := url.Parse(s.URL)
+	expectNil(t, err)
+
+	connData, err := json.Marshal(connectorData{
+		AccessToken:  "old-access-token",
+		RefreshToken: "old-refresh-token",
+		Expiry:       time.Now().Add(-time.Hour),
+	})
+	expectNil(t, err)
+
+	c := githubConnector{
+		apiURL:       s.URL,
+		hostName:     hostURL.Host,
+		httpClient:   newClient(),
+		clientID:     "client-id",
+		clientSecret: "client-secret",
+	}
+	identity, err := c.Refresh(context.Background(), connector.Scopes{OfflineAccess: true}, connector.Identity{ConnectorData: connData})
+	expectNil(t, err)
+
+	if !tokenRefreshCalled.Load() {
+		t.Fatal("expected refresh token request")
+	}
+	expectEquals(t, identity.Username, "New User")
+	expectEquals(t, identity.PreferredUsername, "new-login")
+	expectEquals(t, identity.Email, "new@email.com")
+
+	var data connectorData
+	if err := json.Unmarshal(identity.ConnectorData, &data); err != nil {
+		t.Fatalf("failed to unmarshal connector data: %v", err)
+	}
+	expectEquals(t, data.AccessToken, "new-access-token")
+	expectEquals(t, data.RefreshToken, "new-refresh-token")
+	if data.Expiry.IsZero() || !data.Expiry.After(time.Now()) {
+		t.Fatalf("expected future token expiry, got %v", data.Expiry)
+	}
+}
+
+func TestRefreshWithAccessTokenOnlyConnectorData(t *testing.T) {
+	var tokenEndpointCalled atomic.Bool
+	s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/login/oauth/access_token":
+			tokenEndpointCalled.Store(true)
+			http.Error(w, "unexpected token refresh", http.StatusInternalServerError)
+		case "/user":
+			if got := r.Header.Get("Authorization"); got != "Bearer old-access-token" {
+				t.Fatalf("expected old access token, got %q", got)
+			}
+			json.NewEncoder(w).Encode(user{Login: "some-login", ID: 12345678, Name: "Some User", Email: "some@email.com"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer s.Close()
+
+	hostURL, err := url.Parse(s.URL)
+	expectNil(t, err)
+
+	connData, err := json.Marshal(connectorData{AccessToken: "old-access-token"})
+	expectNil(t, err)
+
+	c := githubConnector{apiURL: s.URL, hostName: hostURL.Host, httpClient: newClient()}
+	identity, err := c.Refresh(context.Background(), connector.Scopes{}, connector.Identity{ConnectorData: connData})
+	expectNil(t, err)
+
+	if tokenEndpointCalled.Load() {
+		t.Fatal("did not expect token refresh request")
+	}
+	expectEquals(t, identity.Username, "Some User")
+	expectEquals(t, identity.PreferredUsername, "some-login")
+	expectEquals(t, identity.Email, "some@email.com")
+	expectEquals(t, identity.ConnectorData, connData)
 }
 
 func TestPreferredEmailDomainConfigured(t *testing.T) {


### PR DESCRIPTION
Closes:  #4843
Closes: https://github.com/controlplaneio-fluxcd/flux-operator/issues/918

Store refresh token on callback. On Dex refresh, if connector data has a refresh token and the stored access token is expired, use the refresh token. Otherwise, fallback to the existing behavior (assume access token is long-lived and use it).

I tested both the refresh token and the fallback behavior in my EKS cluster using the Flux Operator Web UI. I verified with the debug logs I added.