### PR TITLE
fix(mfa): enforce WebAuthn clone detection, TOTP single-use, and account lockout

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -812,6 +812,21 @@ func (s *Server) handleConnectorCallback(w http.ResponseWriter, r *http.Request)
 // finalizeLogin associates the user's identity with the current AuthRequest, then returns
 // the approval page's path.
 func (s *Server) finalizeLogin(ctx context.Context, identity connector.Identity, authReq storage.AuthRequest, conn connector.Connector) (string, bool, error) {
+	// Refuse to complete login for a locked account. BlockedUntil lives on the
+	// persisted UserIdentity, so this only applies when identities are stored; a
+	// first-time login (no stored identity yet) cannot be blocked.
+	storedIdentity, err := s.storage.GetUserIdentity(ctx, identity.UserID, authReq.ConnectorID)
+	switch {
+	case err == nil:
+		if !storedIdentity.BlockedUntil.IsZero() && s.now().Before(storedIdentity.BlockedUntil) {
+			s.logger.WarnContext(ctx, "login rejected for locked account",
+				"connector_id", authReq.ConnectorID, "user_id", identity.UserID, "blocked_until", storedIdentity.BlockedUntil)
+			return "", false, fmt.Errorf("account is locked until %s", storedIdentity.BlockedUntil.Format(time.RFC3339))
+		}
+	case !errors.Is(err, storage.ErrNotFound):
+		return "", false, fmt.Errorf("failed to look up user identity: %w", err)
+	}
+
 	claims := storage.Claims{
 		UserID:            identity.UserID,
 		Username:          identity.Username,

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -813,18 +813,20 @@ func (s *Server) handleConnectorCallback(w http.ResponseWriter, r *http.Request)
 // the approval page's path.
 func (s *Server) finalizeLogin(ctx context.Context, identity connector.Identity, authReq storage.AuthRequest, conn connector.Connector) (string, bool, error) {
 	// Refuse to complete login for a locked account. BlockedUntil lives on the
-	// persisted UserIdentity, so this only applies when identities are stored; a
-	// first-time login (no stored identity yet) cannot be blocked.
-	storedIdentity, err := s.storage.GetUserIdentity(ctx, identity.UserID, authReq.ConnectorID)
-	switch {
-	case err == nil:
-		if !storedIdentity.BlockedUntil.IsZero() && s.now().Before(storedIdentity.BlockedUntil) {
-			s.logger.WarnContext(ctx, "login rejected for locked account",
-				"connector_id", authReq.ConnectorID, "user_id", identity.UserID, "blocked_until", storedIdentity.BlockedUntil)
-			return "", false, fmt.Errorf("account is locked until %s", storedIdentity.BlockedUntil.Format(time.RFC3339))
+	// persisted UserIdentity, which only exists when the sessions feature is on;
+	// a first-time login (no stored identity yet) cannot be blocked.
+	if featureflags.SessionsEnabled.Enabled() {
+		storedIdentity, err := s.storage.GetUserIdentity(ctx, identity.UserID, authReq.ConnectorID)
+		switch {
+		case err == nil:
+			if !storedIdentity.BlockedUntil.IsZero() && s.now().Before(storedIdentity.BlockedUntil) {
+				s.logger.WarnContext(ctx, "login rejected for locked account",
+					"connector_id", authReq.ConnectorID, "user_id", identity.UserID, "blocked_until", storedIdentity.BlockedUntil)
+				return "", false, fmt.Errorf("account is locked until %s", storedIdentity.BlockedUntil.Format(time.RFC3339))
+			}
+		case !errors.Is(err, storage.ErrNotFound):
+			return "", false, fmt.Errorf("failed to look up user identity: %w", err)
 		}
-	case !errors.Is(err, storage.ErrNotFound):
-		return "", false, fmt.Errorf("failed to look up user identity: %w", err)
 	}
 
 	claims := storage.Claims{

--- a/server/mfa.go
+++ b/server/mfa.go
@@ -3,17 +3,67 @@ package server
 import (
 	"bytes"
 	"context"
+	"crypto/subtle"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"image/png"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/pquerna/otp"
 	"github.com/pquerna/otp/totp"
 
 	"github.com/dexidp/dex/storage"
 )
+
+const (
+	totpPeriod = 30 // seconds per TOTP time step
+	totpSkew   = 1  // number of steps tolerated on either side of the current one
+)
+
+var (
+	// errTOTPReplay signals the presented code's time-step was already used.
+	errTOTPReplay = errors.New("totp code already used")
+	// errTOTPNotEnrolled signals the secret disappeared between validation and update.
+	errTOTPNotEnrolled = errors.New("totp not enrolled")
+)
+
+// validateTOTPCode checks code against secret around now (tolerating totpSkew
+// steps) and returns the matched TOTP time-step counter. It returns ok=false
+// when the code does not match, or when the matched counter is <= lastCounter —
+// the latter enforces single use so a captured code cannot be replayed within
+// its validity window.
+func validateTOTPCode(secret, code string, now time.Time, lastCounter int64) (ok bool, counter int64) {
+	opts := totp.ValidateOpts{
+		Period:    totpPeriod,
+		Skew:      totpSkew,
+		Digits:    otp.DigitsSix,
+		Algorithm: otp.AlgorithmSHA1,
+	}
+
+	base := now.Unix() / totpPeriod
+	// Walk the skew window newest-first so the returned counter is the highest
+	// matching step.
+	for d := int64(totpSkew); d >= -int64(totpSkew); d-- {
+		c := base + d
+		if c < 0 {
+			continue
+		}
+		candidate, err := totp.GenerateCodeCustom(secret, time.Unix(c*totpPeriod, 0), opts)
+		if err != nil {
+			continue
+		}
+		if subtle.ConstantTimeCompare([]byte(candidate), []byte(code)) == 1 {
+			if c <= lastCounter {
+				return false, c
+			}
+			return true, c
+		}
+	}
+	return false, 0
+}
 
 // MFAProvider is a pluggable multi-factor authentication method.
 type MFAProvider interface {
@@ -222,23 +272,37 @@ func (s *Server) handleTOTPVerify(w http.ResponseWriter, r *http.Request, ctx co
 			return
 		}
 
-		if !totp.Validate(code, generated.Secret()) {
+		ok, counter := validateTOTPCode(generated.Secret(), code, s.now(), secret.LastUsedCounter)
+		if !ok {
 			s.renderTOTPPage(secret, true, totpProvider.issuer, authReq.ConnectorID, w, r)
 			return
 		}
 
-		// Mark MFA secret as confirmed.
-		if !secret.Confirmed {
-			if err := s.storage.UpdateUserIdentity(ctx, authReq.Claims.UserID, authReq.ConnectorID, func(old storage.UserIdentity) (storage.UserIdentity, error) {
-				if s := old.MFASecrets[authenticatorID]; s != nil {
-					s.Confirmed = true
-				}
-				return old, nil
-			}); err != nil {
-				s.logger.ErrorContext(ctx, "failed to confirm MFA secret", "err", err)
-				s.renderError(r, w, http.StatusInternalServerError, "Internal server error.")
+		// Record the accepted time-step (single-use / replay protection) and
+		// confirm the secret on first successful use. The counter is re-checked
+		// against the latest stored value inside the updater so two concurrent
+		// requests with the same code cannot both succeed. This burn commits
+		// before completeMFAStep marks the challenge passed, so a code can never
+		// pass the challenge without its counter being recorded first.
+		if err := s.storage.UpdateUserIdentity(ctx, authReq.Claims.UserID, authReq.ConnectorID, func(old storage.UserIdentity) (storage.UserIdentity, error) {
+			sec := old.MFASecrets[authenticatorID]
+			if sec == nil {
+				return old, errTOTPNotEnrolled
+			}
+			if sec.LastUsedCounter >= counter {
+				return old, errTOTPReplay
+			}
+			sec.Confirmed = true
+			sec.LastUsedCounter = counter
+			return old, nil
+		}); err != nil {
+			if errors.Is(err, errTOTPReplay) || errors.Is(err, errTOTPNotEnrolled) {
+				s.renderTOTPPage(secret, true, totpProvider.issuer, authReq.ConnectorID, w, r)
 				return
 			}
+			s.logger.ErrorContext(ctx, "failed to update MFA secret", "err", err)
+			s.renderError(r, w, http.StatusInternalServerError, "Internal server error.")
+			return
 		}
 
 		redirectURL, err := s.completeMFAStep(ctx, authReq, authenticatorID)

--- a/server/mfa_test.go
+++ b/server/mfa_test.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dexidp/dex/connector"
+	"github.com/dexidp/dex/storage"
+)
+
+func totpOpts() totp.ValidateOpts {
+	return totp.ValidateOpts{Period: totpPeriod, Skew: totpSkew, Digits: otp.DigitsSix, Algorithm: otp.AlgorithmSHA1}
+}
+
+// TestValidateTOTPCode covers replay protection: a code is single-use per
+// time-step, while a code from a later step is still accepted.
+func TestValidateTOTPCode(t *testing.T) {
+	key, err := totp.Generate(totp.GenerateOpts{Issuer: "dex", AccountName: "user@example.com"})
+	require.NoError(t, err)
+	secret := key.Secret()
+
+	now := time.Unix(1700000000, 0)
+	code, err := totp.GenerateCodeCustom(secret, now, totpOpts())
+	require.NoError(t, err)
+
+	// First use is accepted and reports the matched counter.
+	ok, counter := validateTOTPCode(secret, code, now, 0)
+	require.True(t, ok)
+	require.Equal(t, now.Unix()/totpPeriod, counter)
+
+	// Replaying the same code with that counter recorded is rejected.
+	ok, _ = validateTOTPCode(secret, code, now, counter)
+	require.False(t, ok, "replayed code must be rejected")
+
+	// A wrong code is rejected.
+	ok, _ = validateTOTPCode(secret, "000000", now, 0)
+	require.False(t, ok)
+
+	// A code from the next step is accepted and advances the counter.
+	next := now.Add(totpPeriod * time.Second)
+	nextCode, err := totp.GenerateCodeCustom(secret, next, totpOpts())
+	require.NoError(t, err)
+	ok, nextCounter := validateTOTPCode(secret, nextCode, next, counter)
+	require.True(t, ok)
+	require.Greater(t, nextCounter, counter)
+}
+
+// TestFinalizeLoginBlockedAccount verifies that login finalization is refused
+// while the user identity's BlockedUntil is in the future, and proceeds once it
+// has elapsed.
+func TestFinalizeLoginBlockedAccount(t *testing.T) {
+	httpServer, server := newTestServer(t, func(c *Config) {
+		c.SessionConfig = &SessionConfig{AbsoluteLifetime: time.Hour, ValidIfNotUsedFor: time.Hour}
+	})
+	defer httpServer.Close()
+
+	ctx := t.Context()
+
+	ident := connector.Identity{UserID: "user-1", Email: "user@example.com"}
+	authReq := storage.AuthRequest{
+		ID:          "login-req",
+		ClientID:    "example-app",
+		Expiry:      time.Now().Add(time.Hour),
+		ConnectorID: "mock",
+	}
+	require.NoError(t, server.storage.CreateAuthRequest(ctx, authReq))
+	require.NoError(t, server.storage.CreateUserIdentity(ctx, storage.UserIdentity{
+		UserID:              "user-1",
+		ConnectorID:         "mock",
+		Claims:              storage.Claims{UserID: "user-1", Email: "user@example.com"},
+		Consents:            map[string][]string{},
+		MFASecrets:          map[string]*storage.MFASecret{},
+		WebAuthnCredentials: map[string][]storage.WebAuthnCredential{},
+		CreatedAt:           time.Now(),
+		LastLogin:           time.Now(),
+		BlockedUntil:        time.Now().Add(time.Hour),
+	}))
+
+	// Blocked: finalizeLogin must reject without marking the request logged in.
+	_, _, err := server.finalizeLogin(ctx, ident, authReq, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "locked")
+
+	updated, err := server.storage.GetAuthRequest(ctx, authReq.ID)
+	require.NoError(t, err)
+	require.False(t, updated.LoggedIn, "blocked account must not be logged in")
+
+	// Clear the block: login should now proceed.
+	require.NoError(t, server.storage.UpdateUserIdentity(ctx, "user-1", "mock", func(u storage.UserIdentity) (storage.UserIdentity, error) {
+		u.BlockedUntil = time.Time{}
+		return u, nil
+	}))
+	_, _, err = server.finalizeLogin(ctx, ident, authReq, nil)
+	require.NoError(t, err)
+}

--- a/server/mfa_test.go
+++ b/server/mfa_test.go
@@ -49,10 +49,35 @@ func TestValidateTOTPCode(t *testing.T) {
 	require.Greater(t, nextCounter, counter)
 }
 
+// TestBuildWebAuthnUserDropsCloneWarning verifies the stored CloneWarning flag
+// is not fed back into the credential, so a credential that once tripped clone
+// detection is not permanently locked out (go-webauthn never clears the flag).
+func TestBuildWebAuthnUserDropsCloneWarning(t *testing.T) {
+	identity := storage.UserIdentity{
+		UserID:      "user-1",
+		ConnectorID: "mock",
+		WebAuthnCredentials: map[string][]storage.WebAuthnCredential{
+			"webauthn-1": {{
+				CredentialID: []byte("cred"),
+				SignCount:    42,
+				CloneWarning: true,
+			}},
+		},
+	}
+
+	user := buildWebAuthnUser(identity, "webauthn-1")
+	creds := user.WebAuthnCredentials()
+	require.Len(t, creds, 1)
+	require.Equal(t, uint32(42), creds[0].Authenticator.SignCount, "sign count must be preserved")
+	require.False(t, creds[0].Authenticator.CloneWarning, "stored CloneWarning must not be loaded back")
+}
+
 // TestFinalizeLoginBlockedAccount verifies that login finalization is refused
 // while the user identity's BlockedUntil is in the future, and proceeds once it
 // has elapsed.
 func TestFinalizeLoginBlockedAccount(t *testing.T) {
+	t.Setenv("DEX_SESSIONS_ENABLED", "true")
+
 	httpServer, server := newTestServer(t, func(c *Config) {
 		c.SessionConfig = &SessionConfig{AbsoluteLifetime: time.Hour, ValidIfNotUsedFor: time.Hour}
 	})

--- a/server/mfa_webauthn.go
+++ b/server/mfa_webauthn.go
@@ -124,9 +124,13 @@ func buildWebAuthnUser(identity storage.UserIdentity, authenticatorID string) *w
 				BackupState:    c.BackupState,
 			},
 			Authenticator: webauthn.Authenticator{
-				AAGUID:       c.AAGUID,
-				SignCount:    c.SignCount,
-				CloneWarning: c.CloneWarning,
+				AAGUID:    c.AAGUID,
+				SignCount: c.SignCount,
+				// CloneWarning is intentionally not loaded from storage. go-webauthn
+				// only ever sets it true and never clears it, so feeding a stored
+				// true value back would make FinishLogin report a clone on every
+				// future login and permanently lock out the credential. Starting
+				// fresh makes clone detection evaluate the current assertion only.
 			},
 		})
 	}

--- a/server/mfa_webauthn.go
+++ b/server/mfa_webauthn.go
@@ -266,7 +266,9 @@ func (s *Server) handleWebAuthnLoginFinish(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Update sign count and clone warning for the matched credential.
+	// Update sign count and clone warning for the matched credential. The
+	// CloneWarning flag is persisted even when we reject below so it is visible
+	// to admins (e.g. via ListMFADevices).
 	if err := s.storage.UpdateUserIdentity(ctx, mfa.authReq.Claims.UserID, mfa.authReq.ConnectorID, func(old storage.UserIdentity) (storage.UserIdentity, error) {
 		creds := old.WebAuthnCredentials[mfa.authenticatorID]
 		for i := range creds {
@@ -281,6 +283,16 @@ func (s *Server) handleWebAuthnLoginFinish(w http.ResponseWriter, r *http.Reques
 	}); err != nil {
 		s.logger.ErrorContext(ctx, "failed to update credential", "err", err)
 		writeJSONError(w, http.StatusInternalServerError, "Internal server error.")
+		return
+	}
+
+	// go-webauthn sets CloneWarning when the presented signature counter did not
+	// advance past the stored value, which indicates a cloned authenticator (or a
+	// replayed assertion). Reject the assertion instead of completing the MFA step.
+	if credential.Authenticator.CloneWarning {
+		s.logger.ErrorContext(ctx, "webauthn: signature counter regression, possible cloned authenticator — rejecting",
+			"user_id", mfa.authReq.Claims.UserID, "connector_id", mfa.authReq.ConnectorID, "authenticator_id", mfa.authenticatorID)
+		writeJSONError(w, http.StatusUnauthorized, "Authentication failed.")
 		return
 	}
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -394,6 +394,11 @@ type MFASecret struct {
 	Secret          string    `json:"secret"`
 	Confirmed       bool      `json:"confirmed"`
 	CreatedAt       time.Time `json:"createdAt"`
+
+	// LastUsedCounter is the TOTP time-step counter of the most recently accepted
+	// code. Codes whose counter is <= this value are rejected to make each code
+	// single-use (replay protection). Zero means no code has been accepted yet.
+	LastUsedCounter int64 `json:"lastUsedCounter,omitempty"`
 }
 
 // WebAuthnCredential stores a registered WebAuthn credential for a user.


### PR DESCRIPTION
#### Overview

Hardens three MFA gaps in the auth-sessions feature found during a security review.

#### What this PR does / why we need it

Rejects cloned WebAuthn authenticators (sign-count regression / `CloneWarning`), makes TOTP codes single-use to prevent replay within their validity window, and enforces `UserIdentity.BlockedUntil` at login (it was never checked before).

#### Special notes for your reviewer

`MFASecret.LastUsedCounter` rides in the existing JSON blob, so no migration or ent regen is needed. Tests added in `server/mfa_test.go`.