### PR TITLE
fix(sessions): make SSO sharing non-transitive; drop redirect_uri double-decode

### DIFF
--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -480,10 +480,9 @@ func (s *Server) parseAuthorizationRequest(r *http.Request) (*storage.AuthReques
 		return nil, "", newDisplayedErr(http.StatusBadRequest, "Failed to parse request.")
 	}
 	q := r.Form
-	redirectURI, err := url.QueryUnescape(q.Get("redirect_uri"))
-	if err != nil {
-		return nil, "", newDisplayedErr(http.StatusBadRequest, "No redirect_uri provided.")
-	}
+	// r.ParseForm already URL-decodes query values once; decoding redirect_uri a
+	// second time created a normalization differential with the token endpoint.
+	redirectURI := q.Get("redirect_uri")
 
 	clientID := q.Get("client_id")
 	state := q.Get("state")

--- a/server/session.go
+++ b/server/session.go
@@ -353,6 +353,14 @@ func (s *Server) findSSOSession(ctx context.Context, session *storage.AuthSessio
 			continue
 		}
 
+		// Only directly-authenticated states may act as SSO sources. Skipping
+		// SSO-derived states keeps sharing unidirectional and prevents transitive
+		// A->B->C chains (a user authenticated only to A must not be SSO'd into C
+		// just because B shares with C).
+		if state.ViaSSO {
+			continue
+		}
+
 		sourceClient, err := s.storage.GetClient(ctx, sourceClientID)
 		if err != nil {
 			s.logger.DebugContext(ctx, "session: SSO lookup failed to get source client",
@@ -403,6 +411,7 @@ func (s *Server) trySessionLoginWithSession(ctx context.Context, r *http.Request
 				Active:       true,
 				ExpiresAt:    expiresAt,
 				LastActivity: now,
+				ViaSSO:       true,
 			}
 			old.LastActivity = now
 			old.IdleExpiry = now.Add(s.sessionConfig.ValidIfNotUsedFor)

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -2099,8 +2099,16 @@ func TestSSO_TransitiveTrustChain(t *testing.T) {
 	// Hop 1: A→B succeeds and records an SSO-derived state for B.
 	require.True(t, tryLogin("client-b"), "A→B SSO should succeed")
 
-	// Hop 2: B→C must be denied — B's state is SSO-derived (not an eligible SSO
-	// source) and A never shared with C.
+	// The derived B state must be marked ViaSSO, which is what makes it ineligible
+	// as a source below — assert it directly so a regression localizes here.
+	sess, err := s.storage.GetAuthSession(ctx, "user-1", "mock")
+	require.NoError(t, err)
+	require.NotNil(t, sess.ClientStates["client-b"])
+	assert.True(t, sess.ClientStates["client-b"].ViaSSO, "B's SSO-derived state must be marked ViaSSO")
+
+	// Hop 2: C has no eligible SSO source — A does not share with C and B's state
+	// is SSO-derived. Pin the exact invariant, then the login outcome.
+	assert.Nil(t, s.findSSOSession(ctx, &sess, "client-c"), "no eligible SSO source for C")
 	assert.False(t, tryLogin("client-c"), "transitive A→B→C SSO must be denied")
 }
 

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -2045,6 +2045,65 @@ func TestSSO_Unidirectional(t *testing.T) {
 	})
 }
 
+// TestSSO_TransitiveTrustChain verifies SSO sharing does not chain: A shares
+// only with B and B shares only with C (A never shares with C), so a user
+// authenticated only to A must not be SSO'd into C via B.
+func TestSSO_TransitiveTrustChain(t *testing.T) {
+	ctx := t.Context()
+
+	s := newTestSessionServer(t)
+	s.skipApproval = true
+	now := s.now()
+
+	require.NoError(t, s.storage.CreateClient(ctx, storage.Client{
+		ID: "client-a", Secret: "s", Name: "A", SSOSharedWith: []string{"client-b"},
+	}))
+	require.NoError(t, s.storage.CreateClient(ctx, storage.Client{
+		ID: "client-b", Secret: "s", Name: "B", SSOSharedWith: []string{"client-c"},
+	}))
+	require.NoError(t, s.storage.CreateClient(ctx, storage.Client{
+		ID: "client-c", Secret: "s", Name: "C", SSOSharedWith: []string{},
+	}))
+
+	// User authenticated only to A.
+	require.NoError(t, s.storage.CreateAuthSession(ctx, storage.AuthSession{
+		UserID: "user-1", ConnectorID: "mock", Nonce: "test-nonce",
+		ClientStates: map[string]*storage.ClientAuthState{
+			"client-a": {Active: true, ExpiresAt: now.Add(24 * time.Hour), LastActivity: now.Add(-1 * time.Minute)},
+		},
+		CreatedAt: now.Add(-30 * time.Minute), LastActivity: now.Add(-1 * time.Minute),
+		AbsoluteExpiry: now.Add(24 * time.Hour), IdleExpiry: now.Add(59 * time.Minute),
+	}))
+	require.NoError(t, s.storage.CreateUserIdentity(ctx, storage.UserIdentity{
+		UserID: "user-1", ConnectorID: "mock",
+		Claims:    storage.Claims{UserID: "user-1", Username: "testuser", Email: "test@example.com"},
+		Consents:  map[string][]string{},
+		CreatedAt: now.Add(-1 * time.Hour), LastLogin: now.Add(-30 * time.Minute),
+	}))
+
+	tryLogin := func(target string) bool {
+		req := storage.AuthRequest{
+			ID: storage.NewID(), ClientID: target, ConnectorID: "mock",
+			Scopes: []string{"openid"}, RedirectURI: "http://localhost/callback",
+			MaxAge: -1, HMACKey: storage.NewHMACKey(crypto.SHA256), Expiry: now.Add(10 * time.Minute),
+		}
+		require.NoError(t, s.storage.CreateAuthRequest(ctx, req))
+		r := sessionCookieRequest("user-1", "mock", "test-nonce")
+		w := httptest.NewRecorder()
+		session := s.getValidAuthSession(ctx, w, r, &req)
+		require.NotNil(t, session)
+		_, ok := s.trySessionLoginWithSession(ctx, r, w, &req, session)
+		return ok
+	}
+
+	// Hop 1: A→B succeeds and records an SSO-derived state for B.
+	require.True(t, tryLogin("client-b"), "A→B SSO should succeed")
+
+	// Hop 2: B→C must be denied — B's state is SSO-derived (not an eligible SSO
+	// source) and A never shared with C.
+	assert.False(t, tryLogin("client-c"), "transitive A→B→C SSO must be denied")
+}
+
 // TestRememberMeDefault tests that the rememberMeDefault helper
 // returns the correct value based on session configuration.
 func TestRememberMeDefault(t *testing.T) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -435,6 +435,12 @@ type ClientAuthState struct {
 	ExpiresAt         time.Time
 	LastActivity      time.Time
 	LastTokenIssuedAt time.Time
+
+	// ViaSSO is true when this state was derived from another client's session
+	// via ssoSharedWith rather than a direct authentication. SSO-derived states
+	// are not eligible as SSO sources themselves, which keeps sharing
+	// unidirectional and prevents transitive A->B->C chains.
+	ViaSSO bool
 }
 
 // LogoutState holds RP parameters saved in the auth session during logout.


### PR DESCRIPTION
#### Overview

Fixes two issues reported by Kai Aizen (SnailSploit): a transitive SSO session-trust bypass, and a redundant double URL-decode of redirect_uri.

#### What this PR does / why we need it

SSO session sharing was transitive — with A sharing to B and B sharing to C, a user authenticated only to A was silently SSO'd into C, contrary to the documented unidirectional behavior. SSO-derived client states are now marked (`ClientAuthState.ViaSSO`) and skipped as SSO sources, so a session propagates one hop only. Separately, `redirect_uri` was URL-decoded twice in `parseAuthorizationRequest` (once by `ParseForm`, once by `url.QueryUnescape`), creating a normalization differential with the token endpoint; the extra decode is removed. The transitive-SSO code is behind the experimental sessions flag and not in any release; the decode issue is not exploitable (redirect URIs are matched exactly).

#### Special notes for your reviewer

`ViaSSO` rides in the existing AuthSession JSON blob, so there is no migration. Added `TestSSO_TransitiveTrustChain` with a negative control confirming the chain is denied only because of the fix. Thanks to Kai Aizen / SnailSploit for the report.