### PR TITLE
fix(server): enforce client AllowedConnectors on all token grants

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1634,6 +1634,10 @@ func (s *Server) handlePasswordGrant(w http.ResponseWriter, r *http.Request, cli
 
 	// Which connector
 	connID := s.passwordConnector
+	if !isConnectorAllowed(client.AllowedConnectors, connID) {
+		s.tokenErrHelper(w, errInvalidGrant, "Connector not allowed for this client.", http.StatusBadRequest)
+		return
+	}
 	conn, err := s.getConnector(ctx, connID)
 	if err != nil {
 		s.tokenErrHelper(w, errInvalidRequest, "Requested connector does not exist.", http.StatusBadRequest)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -327,6 +327,24 @@ func isConnectorAllowed(allowedConnectors []string, connectorID string) bool {
 	return false
 }
 
+// checkConnectorAllowed writes an OAuth2 token error and returns false if connID is
+// not in the client's AllowedConnectors. Token grant handlers call it before
+// resolving the connector, so a disallowed connector is rejected without being
+// instantiated and no grant can silently forget the check. The connector's own
+// grant-type policy (GrantTypes) is enforced separately, right after the connector
+// is resolved, because it needs the resolved connector and a grant-specific message.
+// Browser/auth-code paths enforce the same AllowedConnectors policy with their own
+// HTML/redirect error surface.
+func (s *Server) checkConnectorAllowed(w http.ResponseWriter, r *http.Request, client storage.Client, connID string) bool {
+	if isConnectorAllowed(client.AllowedConnectors, connID) {
+		return true
+	}
+	s.logger.WarnContext(r.Context(), "connector not allowed for client",
+		"client_id", client.ID, "connector_id", connID)
+	s.tokenErrHelper(w, errInvalidGrant, "Connector not allowed for this client.", http.StatusBadRequest)
+	return false
+}
+
 // getClientWithAuthError retrieves a client by ID and returns a displayedAuthErr on failure.
 // Invalid client_id is not treated as a redirect error per RFC 6749 §4.1.2.1.
 // https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1
@@ -1634,8 +1652,7 @@ func (s *Server) handlePasswordGrant(w http.ResponseWriter, r *http.Request, cli
 
 	// Which connector
 	connID := s.passwordConnector
-	if !isConnectorAllowed(client.AllowedConnectors, connID) {
-		s.tokenErrHelper(w, errInvalidGrant, "Connector not allowed for this client.", http.StatusBadRequest)
+	if !s.checkConnectorAllowed(w, r, client, connID) {
 		return
 	}
 	conn, err := s.getConnector(ctx, connID)
@@ -1853,13 +1870,9 @@ func (s *Server) handleTokenExchange(w http.ResponseWriter, r *http.Request, cli
 		return
 	}
 
-	if !isConnectorAllowed(client.AllowedConnectors, connID) {
-		s.logger.ErrorContext(r.Context(), "connector not allowed for client",
-			"connector_id", connID, "client_id", client.ID)
-		s.tokenErrHelper(w, errInvalidRequest, "Connector not allowed for this client.", http.StatusBadRequest)
+	if !s.checkConnectorAllowed(w, r, client, connID) {
 		return
 	}
-
 	conn, err := s.getConnector(ctx, connID)
 	if err != nil {
 		s.logger.ErrorContext(r.Context(), "failed to get connector", "err", err)

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -1893,6 +1893,61 @@ func TestHandleTokenExchangeAllowedConnectors(t *testing.T) {
 	}
 }
 
+// TestHandlePasswordAllowedConnectors verifies the password grant enforces the
+// client's AllowedConnectors (mirrors TestHandleTokenExchangeAllowedConnectors
+// and TestHandleRefreshTokenAllowedConnectors — every token grant must enforce it).
+func TestHandlePasswordAllowedConnectors(t *testing.T) {
+	tests := []struct {
+		name              string
+		allowedConnectors []string
+		expectedCode      int
+	}{
+		{"connector in allowed list", []string{"test"}, http.StatusOK},
+		{"connector matches non-first entry", []string{"other", "test"}, http.StatusOK},
+		{"connector not in allowed list", []string{"other"}, http.StatusBadRequest},
+		{"empty allowed list permits any connector", nil, http.StatusOK},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			httpServer, s := newTestServer(t, func(c *Config) {
+				c.PasswordConnector = "test"
+				c.Now = time.Now
+			})
+			defer httpServer.Close()
+
+			mockConnectorDataTestStorage(t, s.storage)
+			require.NoError(t, s.storage.UpdateClient(ctx, "test", func(c storage.Client) (storage.Client, error) {
+				c.AllowedConnectors = tc.allowedConnectors
+				return c, nil
+			}))
+
+			u, err := url.Parse(s.issuerURL.String())
+			require.NoError(t, err)
+			u.Path = path.Join(u.Path, "/token")
+
+			v := url.Values{}
+			v.Add("scope", "openid email")
+			v.Add("grant_type", "password")
+			v.Add("username", "test")
+			v.Add("password", "test")
+
+			req, _ := http.NewRequest("POST", u.String(), bytes.NewBufferString(v.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.SetBasicAuth("test", "barfoo")
+
+			rr := httptest.NewRecorder()
+			s.ServeHTTP(rr, req)
+			require.Equal(t, tc.expectedCode, rr.Code, rr.Body.String())
+			if tc.expectedCode == http.StatusBadRequest {
+				require.Contains(t, rr.Body.String(), "Connector not allowed",
+					"rejection must be for the connector policy, not an unrelated reason")
+			}
+		})
+	}
+}
+
 func TestHandleAuthorizationConnectorGrantTypeFiltering(t *testing.T) {
 	tests := []struct {
 		name string

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -1889,6 +1889,10 @@ func TestHandleTokenExchangeAllowedConnectors(t *testing.T) {
 			s.handleToken(rr, req)
 
 			require.Equal(t, tc.expectedCode, rr.Code, rr.Body.String())
+			if tc.expectedCode == http.StatusBadRequest {
+				require.Contains(t, rr.Body.String(), "Connector not allowed",
+					"rejection must be for the connector policy, not an unrelated reason")
+			}
 		})
 	}
 }

--- a/server/refreshhandlers.go
+++ b/server/refreshhandlers.go
@@ -440,6 +440,16 @@ func (s *Server) handleRefreshToken(w http.ResponseWriter, r *http.Request, clie
 		return
 	}
 
+	// The connector may have been removed from the client's allowed list after
+	// this refresh token was issued; re-check on every refresh so a tightened
+	// policy takes effect.
+	if !isConnectorAllowed(client.AllowedConnectors, rCtx.storageToken.ConnectorID) {
+		s.logger.WarnContext(r.Context(), "connector not allowed for client",
+			"client_id", client.ID, "connector_id", rCtx.storageToken.ConnectorID)
+		s.refreshTokenErrHelper(w, &refreshError{msg: errInvalidGrant, desc: "Connector not allowed for this client.", code: http.StatusBadRequest})
+		return
+	}
+
 	rCtx.scopes, rerr = s.getRefreshScopes(r, rCtx.storageToken)
 	if rerr != nil {
 		s.refreshTokenErrHelper(w, rerr)

--- a/server/refreshhandlers.go
+++ b/server/refreshhandlers.go
@@ -442,11 +442,9 @@ func (s *Server) handleRefreshToken(w http.ResponseWriter, r *http.Request, clie
 
 	// The connector may have been removed from the client's allowed list after
 	// this refresh token was issued; re-check on every refresh so a tightened
-	// policy takes effect.
-	if !isConnectorAllowed(client.AllowedConnectors, rCtx.storageToken.ConnectorID) {
-		s.logger.WarnContext(r.Context(), "connector not allowed for client",
-			"client_id", client.ID, "connector_id", rCtx.storageToken.ConnectorID)
-		s.refreshTokenErrHelper(w, &refreshError{msg: errInvalidGrant, desc: "Connector not allowed for this client.", code: http.StatusBadRequest})
+	// policy takes effect. (The connector's own refresh-grant policy is already
+	// enforced by getRefreshTokenFromStorage, which introspection shares.)
+	if !s.checkConnectorAllowed(w, r, client, rCtx.storageToken.ConnectorID) {
 		return
 	}
 

--- a/server/refreshhandlers_test.go
+++ b/server/refreshhandlers_test.go
@@ -508,3 +508,58 @@ func TestRefreshTokenPolicy(t *testing.T) {
 		require.Equal(t, true, r.CompletelyExpired(lastTime))
 	})
 }
+
+// TestHandleRefreshTokenAllowedConnectors verifies the refresh grant enforces
+// the client's AllowedConnectors (mirrors TestHandleTokenExchangeAllowedConnectors
+// and TestHandlePasswordAllowedConnectors — every token grant must enforce it).
+func TestHandleRefreshTokenAllowedConnectors(t *testing.T) {
+	tests := []struct {
+		name              string
+		allowedConnectors []string
+		expectedCode      int
+	}{
+		{"connector in allowed list", []string{"test"}, http.StatusOK},
+		{"connector matches non-first entry", []string{"other", "test"}, http.StatusOK},
+		{"connector not in allowed list", []string{"other"}, http.StatusBadRequest},
+		{"empty allowed list permits any connector", nil, http.StatusOK},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			httpServer, s := newTestServer(t, func(c *Config) {
+				c.RefreshTokenPolicy = &RefreshTokenPolicy{rotateRefreshTokens: true}
+			})
+			defer httpServer.Close()
+
+			mockRefreshTokenTestStorage(t, s.storage, false)
+			require.NoError(t, s.storage.UpdateClient(ctx, "test", func(c storage.Client) (storage.Client, error) {
+				c.AllowedConnectors = tc.allowedConnectors
+				return c, nil
+			}))
+
+			tokenData, err := internal.Marshal(&internal.RefreshToken{RefreshId: "test", Token: "bar"})
+			require.NoError(t, err)
+
+			u, err := url.Parse(s.issuerURL.String())
+			require.NoError(t, err)
+			u.Path = path.Join(u.Path, "/token")
+
+			v := url.Values{}
+			v.Add("grant_type", "refresh_token")
+			v.Add("refresh_token", tokenData)
+
+			req, _ := http.NewRequest("POST", u.String(), bytes.NewBufferString(v.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.SetBasicAuth("test", "barfoo")
+
+			rr := httptest.NewRecorder()
+			s.ServeHTTP(rr, req)
+			require.Equal(t, tc.expectedCode, rr.Code, rr.Body.String())
+			if tc.expectedCode == http.StatusBadRequest {
+				require.Contains(t, rr.Body.String(), "Connector not allowed",
+					"rejection must be for the connector policy, not an unrelated reason")
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Overview

Enforce the client's AllowedConnectors on the password and refresh grants, and route the check through one chokepoint so no token grant can forget it.

#### What this PR does / why we need it

The password grant (#4839 by @canolgun, cherry-picked here) and the refresh grant resolved a connector without checking the client's AllowedConnectors, so a client could obtain or refresh tokens through a connector it was not permitted to use. This adds `checkConnectorAllowed`, called before the connector is resolved by the password, refresh, and token-exchange grants, with AllowedConnectors table tests for each. Note: token-exchange's "connector not allowed" error code is unified from `invalid_request` to `invalid_grant` (RFC 6749 §5.2, matching the password and refresh grants).

#### Special notes for your reviewer

Cherry-picks and builds on #4839 (credit to @canolgun). Running the check before `getConnector` also avoids instantiating a connector the client is not allowed to use. Browser/auth-code paths keep their own check because they use HTML/redirect errors rather than the token-error surface; the helper comment notes this.