### PR TITLE
feat(server): introduce a token issuer abstraction

### DIFF
--- a/server/approval.go
+++ b/server/approval.go
@@ -182,7 +182,14 @@ func (s *Server) sendCodeResponse(w http.ResponseWriter, r *http.Request, authRe
 			implicitOrHybrid = true
 			var err error
 
-			accessToken, _, err = s.newAccessToken(r.Context(), authReq.ClientID, authReq.Claims, authReq.Scopes, authReq.Nonce, authReq.ConnectorID, authReq.AuthTime)
+			accessToken, _, err = s.issuer.signer.signAccessToken(r.Context(), Authorization{
+				Client:      storage.Client{ID: authReq.ClientID},
+				Claims:      authReq.Claims,
+				Scopes:      authReq.Scopes,
+				ConnectorID: authReq.ConnectorID,
+				Nonce:       authReq.Nonce,
+				AuthTime:    authReq.AuthTime,
+			})
 			if err != nil {
 				s.logger.ErrorContext(r.Context(), "failed to create new access token", "err", err)
 				s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
@@ -192,7 +199,14 @@ func (s *Server) sendCodeResponse(w http.ResponseWriter, r *http.Request, authRe
 			implicitOrHybrid = true
 			var err error
 
-			idToken, idTokenExpiry, err = s.newIDToken(r.Context(), authReq.ClientID, authReq.Claims, authReq.Scopes, authReq.Nonce, accessToken, code.ID, authReq.ConnectorID, authReq.AuthTime)
+			idToken, idTokenExpiry, err = s.issuer.signer.signIDToken(r.Context(), Authorization{
+				Client:      storage.Client{ID: authReq.ClientID},
+				Claims:      authReq.Claims,
+				Scopes:      authReq.Scopes,
+				ConnectorID: authReq.ConnectorID,
+				Nonce:       authReq.Nonce,
+				AuthTime:    authReq.AuthTime,
+			}, accessToken, code.ID)
 			if err != nil {
 				s.logger.ErrorContext(r.Context(), "failed to create ID token", "err", err)
 				s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)

--- a/server/grant_authcode.go
+++ b/server/grant_authcode.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/dexidp/dex/connector"
-	"github.com/dexidp/dex/server/internal"
 	"github.com/dexidp/dex/storage"
 )
 
@@ -73,14 +72,24 @@ func (s *Server) handleAuthCode(w http.ResponseWriter, r *http.Request, client s
 }
 
 func (s *Server) exchangeAuthCode(ctx context.Context, w http.ResponseWriter, authCode storage.AuthCode, client storage.Client) (*accessTokenResponse, error) {
-	accessToken, _, err := s.newAccessToken(ctx, client.ID, authCode.Claims, authCode.Scopes, authCode.Nonce, authCode.ConnectorID, authCode.AuthTime)
+	auth := Authorization{
+		Client:        client,
+		Claims:        authCode.Claims,
+		Scopes:        authCode.Scopes,
+		ConnectorID:   authCode.ConnectorID,
+		Nonce:         authCode.Nonce,
+		AuthTime:      authCode.AuthTime,
+		ConnectorData: authCode.ConnectorData,
+	}
+
+	accessToken, _, err := s.issuer.signer.signAccessToken(ctx, auth)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "failed to create new access token", "err", err)
 		s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
 		return nil, err
 	}
 
-	idToken, expiry, err := s.newIDToken(ctx, client.ID, authCode.Claims, authCode.Scopes, authCode.Nonce, accessToken, authCode.ID, authCode.ConnectorID, authCode.AuthTime)
+	idToken, expiry, err := s.issuer.signer.signIDToken(ctx, auth, accessToken, authCode.ID)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "failed to create ID token", "err", err)
 		s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
@@ -127,107 +136,16 @@ func (s *Server) exchangeAuthCode(ctx context.Context, w http.ResponseWriter, au
 		}
 		return false
 	}()
+
 	var refreshToken string
 	if reqRefresh {
-		refresh := storage.RefreshToken{
-			ID:            storage.NewID(),
-			Token:         storage.NewID(),
-			ClientID:      authCode.ClientID,
-			ConnectorID:   authCode.ConnectorID,
-			Scopes:        authCode.Scopes,
-			Claims:        authCode.Claims,
-			Nonce:         authCode.Nonce,
-			ConnectorData: authCode.ConnectorData,
-			CreatedAt:     s.now(),
-			LastUsed:      s.now(),
-		}
-		token := &internal.RefreshToken{
-			RefreshId: refresh.ID,
-			Token:     refresh.Token,
-		}
-		if refreshToken, err = internal.Marshal(token); err != nil {
-			s.logger.ErrorContext(ctx, "failed to marshal refresh token", "err", err)
-			s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
-			return nil, err
-		}
-
-		if err := s.storage.CreateRefresh(ctx, refresh); err != nil {
+		refreshToken, err = s.issuer.refresh.create(ctx, auth)
+		if err != nil {
 			s.logger.ErrorContext(ctx, "failed to create refresh token", "err", err)
 			s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
 			return nil, err
 		}
-
-		// deleteToken determines if we need to delete the newly created refresh token
-		// due to a failure in updating/creating the OfflineSession object for the
-		// corresponding user.
-		var deleteToken bool
-		defer func() {
-			if deleteToken {
-				// Delete newly created refresh token from storage.
-				if err := s.storage.DeleteRefresh(ctx, refresh.ID); err != nil {
-					s.logger.ErrorContext(ctx, "failed to delete refresh token", "err", err)
-					s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
-					return
-				}
-			}
-		}()
-
-		tokenRef := storage.RefreshTokenRef{
-			ID:        refresh.ID,
-			ClientID:  refresh.ClientID,
-			CreatedAt: refresh.CreatedAt,
-			LastUsed:  refresh.LastUsed,
-		}
-
-		// Try to retrieve an existing OfflineSession object for the corresponding user.
-		if session, err := s.storage.GetOfflineSessions(ctx, refresh.Claims.UserID, refresh.ConnectorID); err != nil {
-			if err != storage.ErrNotFound {
-				s.logger.ErrorContext(ctx, "failed to get offline session", "err", err)
-				s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
-				deleteToken = true
-				return nil, err
-			}
-			offlineSessions := storage.OfflineSessions{
-				UserID:        refresh.Claims.UserID,
-				ConnID:        refresh.ConnectorID,
-				Refresh:       make(map[string]*storage.RefreshTokenRef),
-				ConnectorData: refresh.ConnectorData,
-			}
-			offlineSessions.Refresh[tokenRef.ClientID] = &tokenRef
-
-			// Create a new OfflineSession object for the user and add a reference object for
-			// the newly received refreshtoken.
-			if err := s.storage.CreateOfflineSessions(ctx, offlineSessions); err != nil {
-				s.logger.ErrorContext(ctx, "failed to create offline session", "err", err)
-				s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
-				deleteToken = true
-				return nil, err
-			}
-		} else {
-			if oldTokenRef, ok := session.Refresh[tokenRef.ClientID]; ok {
-				// Delete old refresh token from storage.
-				if err := s.storage.DeleteRefresh(ctx, oldTokenRef.ID); err != nil && err != storage.ErrNotFound {
-					s.logger.ErrorContext(ctx, "failed to delete refresh token", "err", err)
-					s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
-					deleteToken = true
-					return nil, err
-				}
-			}
-
-			// Update existing OfflineSession obj with new RefreshTokenRef.
-			if err := s.storage.UpdateOfflineSessions(ctx, session.UserID, session.ConnID, func(old storage.OfflineSessions) (storage.OfflineSessions, error) {
-				old.Refresh[tokenRef.ClientID] = &tokenRef
-				if len(refresh.ConnectorData) > 0 {
-					old.ConnectorData = refresh.ConnectorData
-				}
-				return old, nil
-			}); err != nil {
-				s.logger.ErrorContext(ctx, "failed to update offline session", "err", err)
-				s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
-				deleteToken = true
-				return nil, err
-			}
-		}
 	}
+
 	return s.toAccessTokenResponse(idToken, accessToken, refreshToken, expiry), nil
 }

--- a/server/grant_clientcredentials.go
+++ b/server/grant_clientcredentials.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/dexidp/dex/storage"
 )
@@ -96,7 +95,15 @@ func (s *Server) handleClientCredentialsGrant(w http.ResponseWriter, r *http.Req
 	// Creating connectors with an empty ID with the config and API is prohibited
 	connID := ""
 
-	accessToken, expiry, err := s.newAccessToken(ctx, client.ID, claims, scopes, nonce, connID, time.Time{})
+	auth := Authorization{
+		Client:      client,
+		Claims:      claims,
+		Scopes:      scopes,
+		ConnectorID: connID,
+		Nonce:       nonce,
+	}
+
+	accessToken, expiry, err := s.issuer.signer.signAccessToken(ctx, auth)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "client_credentials grant failed to create new access token", "err", err)
 		s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
@@ -105,7 +112,7 @@ func (s *Server) handleClientCredentialsGrant(w http.ResponseWriter, r *http.Req
 
 	var idToken string
 	if hasOpenIDScope {
-		idToken, expiry, err = s.newIDToken(ctx, client.ID, claims, scopes, nonce, accessToken, "", connID, time.Time{})
+		idToken, expiry, err = s.issuer.signer.signIDToken(ctx, auth, accessToken, "")
 		if err != nil {
 			s.logger.ErrorContext(ctx, "client_credentials grant failed to create new ID token", "err", err)
 			s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
@@ -113,6 +120,9 @@ func (s *Server) handleClientCredentialsGrant(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	resp := s.toAccessTokenResponse(idToken, accessToken, "", expiry)
-	s.writeAccessToken(w, resp)
+	if err := writeTokenResponse(w, TokenSet{AccessToken: accessToken, IDToken: idToken, Expiry: expiry}, s.now()); err != nil {
+		s.logger.ErrorContext(ctx, "failed to write token response", "err", err)
+		s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
+		return
+	}
 }

--- a/server/grant_password.go
+++ b/server/grant_password.go
@@ -5,11 +5,10 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
-	"time"
 
 	"github.com/dexidp/dex/connector"
-	"github.com/dexidp/dex/server/internal"
 	"github.com/dexidp/dex/storage"
 )
 
@@ -114,145 +113,30 @@ func (s *Server) handlePasswordGrant(w http.ResponseWriter, r *http.Request, cli
 		Groups:            identity.Groups,
 	}
 
-	accessToken, _, err := s.newAccessToken(ctx, client.ID, claims, scopes, nonce, connID, time.Time{})
+	// A refresh token is issued only when the connector supports it, the grant type
+	// is allowed, and offline_access was requested (RFC 6749 §1.5, never mandatory).
+	wantRefresh := false
+	if _, ok := conn.Connector.(connector.RefreshConnector); ok && GrantTypeAllowed(conn.GrantTypes, grantTypeRefreshToken) {
+		wantRefresh = slices.Contains(scopes, scopeOfflineAccess)
+	}
+
+	tokens, err := s.issuer.Issue(ctx, Authorization{
+		Client:        client,
+		Claims:        claims,
+		Scopes:        scopes,
+		ConnectorID:   connID,
+		Nonce:         nonce,
+		ConnectorData: identity.ConnectorData,
+	}, wantRefresh)
 	if err != nil {
-		s.logger.ErrorContext(r.Context(), "password grant failed to create new access token", "err", err)
+		s.logger.ErrorContext(r.Context(), "password grant failed to issue tokens", "err", err)
 		s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
 		return
 	}
 
-	idToken, expiry, err := s.newIDToken(ctx, client.ID, claims, scopes, nonce, accessToken, "", connID, time.Time{})
-	if err != nil {
-		s.logger.ErrorContext(r.Context(), "password grant failed to create new ID token", "err", err)
+	if err := writeTokenResponse(w, tokens, s.now()); err != nil {
+		s.logger.ErrorContext(r.Context(), "failed to write token response", "err", err)
 		s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
 		return
 	}
-
-	reqRefresh := func() bool {
-		// Same logic as in exchangeAuthCode: silently omit refresh token
-		// when the connector doesn't support it or grantTypes forbids it.
-		// See RFC 6749 §1.5 — refresh tokens are never mandatory.
-		// https://datatracker.ietf.org/doc/html/rfc6749#section-1.5
-		if _, ok := conn.Connector.(connector.RefreshConnector); !ok {
-			return false
-		}
-
-		if !GrantTypeAllowed(conn.GrantTypes, grantTypeRefreshToken) {
-			return false
-		}
-
-		for _, scope := range scopes {
-			if scope == scopeOfflineAccess {
-				return true
-			}
-		}
-		return false
-	}()
-	var refreshToken string
-	if reqRefresh {
-		refresh := storage.RefreshToken{
-			ID:          storage.NewID(),
-			Token:       storage.NewID(),
-			ClientID:    client.ID,
-			ConnectorID: connID,
-			Scopes:      scopes,
-			Claims:      claims,
-			Nonce:       nonce,
-			// ConnectorData: authCode.ConnectorData,
-			CreatedAt: s.now(),
-			LastUsed:  s.now(),
-		}
-		token := &internal.RefreshToken{
-			RefreshId: refresh.ID,
-			Token:     refresh.Token,
-		}
-		if refreshToken, err = internal.Marshal(token); err != nil {
-			s.logger.ErrorContext(r.Context(), "failed to marshal refresh token", "err", err)
-			s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
-			return
-		}
-
-		if err := s.storage.CreateRefresh(ctx, refresh); err != nil {
-			s.logger.ErrorContext(r.Context(), "failed to create refresh token", "err", err)
-			s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
-			return
-		}
-
-		// deleteToken determines if we need to delete the newly created refresh token
-		// due to a failure in updating/creating the OfflineSession object for the
-		// corresponding user.
-		var deleteToken bool
-		defer func() {
-			if deleteToken {
-				// Delete newly created refresh token from storage.
-				if err := s.storage.DeleteRefresh(ctx, refresh.ID); err != nil {
-					s.logger.ErrorContext(r.Context(), "failed to delete refresh token", "err", err)
-					s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
-					return
-				}
-			}
-		}()
-
-		tokenRef := storage.RefreshTokenRef{
-			ID:        refresh.ID,
-			ClientID:  refresh.ClientID,
-			CreatedAt: refresh.CreatedAt,
-			LastUsed:  refresh.LastUsed,
-		}
-
-		// Try to retrieve an existing OfflineSession object for the corresponding user.
-		if session, err := s.storage.GetOfflineSessions(ctx, refresh.Claims.UserID, refresh.ConnectorID); err != nil {
-			if err != storage.ErrNotFound {
-				s.logger.ErrorContext(r.Context(), "failed to get offline session", "err", err)
-				s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
-				deleteToken = true
-				return
-			}
-			offlineSessions := storage.OfflineSessions{
-				UserID:        refresh.Claims.UserID,
-				ConnID:        refresh.ConnectorID,
-				Refresh:       make(map[string]*storage.RefreshTokenRef),
-				ConnectorData: identity.ConnectorData,
-			}
-			offlineSessions.Refresh[tokenRef.ClientID] = &tokenRef
-
-			// Create a new OfflineSession object for the user and add a reference object for
-			// the newly received refreshtoken.
-			if err := s.storage.CreateOfflineSessions(ctx, offlineSessions); err != nil {
-				s.logger.ErrorContext(r.Context(), "failed to create offline session", "err", err)
-				s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
-				deleteToken = true
-				return
-			}
-		} else {
-			if oldTokenRef, ok := session.Refresh[tokenRef.ClientID]; ok {
-				// Delete old refresh token from storage.
-				if err := s.storage.DeleteRefresh(ctx, oldTokenRef.ID); err != nil {
-					if err == storage.ErrNotFound {
-						s.logger.Warn("database inconsistent, refresh token missing", "token_id", oldTokenRef.ID)
-					} else {
-						s.logger.ErrorContext(r.Context(), "failed to delete refresh token", "err", err)
-						s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
-						deleteToken = true
-						return
-					}
-				}
-			}
-
-			// Update existing OfflineSession obj with new RefreshTokenRef.
-			if err := s.storage.UpdateOfflineSessions(ctx, session.UserID, session.ConnID, func(old storage.OfflineSessions) (storage.OfflineSessions, error) {
-				old.Refresh[tokenRef.ClientID] = &tokenRef
-				old.ConnectorData = identity.ConnectorData
-				return old, nil
-			}); err != nil {
-				s.logger.ErrorContext(r.Context(), "failed to update offline session", "err", err)
-				s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
-				deleteToken = true
-				return
-			}
-		}
-	}
-
-	resp := s.toAccessTokenResponse(idToken, accessToken, refreshToken, expiry)
-	s.writeAccessToken(w, resp)
 }

--- a/server/grant_refresh.go
+++ b/server/grant_refresh.go
@@ -488,14 +488,23 @@ func (s *Server) handleRefreshToken(w http.ResponseWriter, r *http.Request, clie
 		Groups:            ident.Groups,
 	}
 
-	accessToken, _, err := s.newAccessToken(r.Context(), client.ID, claims, rCtx.scopes, rCtx.storageToken.Nonce, rCtx.storageToken.ConnectorID, authTime)
+	auth := Authorization{
+		Client:      client,
+		Claims:      claims,
+		Scopes:      rCtx.scopes,
+		ConnectorID: rCtx.storageToken.ConnectorID,
+		Nonce:       rCtx.storageToken.Nonce,
+		AuthTime:    authTime,
+	}
+
+	accessToken, _, err := s.issuer.signer.signAccessToken(r.Context(), auth)
 	if err != nil {
 		s.logger.ErrorContext(r.Context(), "failed to create new access token", "err", err)
 		s.refreshTokenErrHelper(w, newInternalServerError())
 		return
 	}
 
-	idToken, expiry, err := s.newIDToken(r.Context(), client.ID, claims, rCtx.scopes, rCtx.storageToken.Nonce, accessToken, "", rCtx.storageToken.ConnectorID, authTime)
+	idToken, expiry, err := s.issuer.signer.signIDToken(r.Context(), auth, accessToken, "")
 	if err != nil {
 		s.logger.ErrorContext(r.Context(), "failed to create ID token", "err", err)
 		s.refreshTokenErrHelper(w, newInternalServerError())

--- a/server/grant_tokenexchange.go
+++ b/server/grant_tokenexchange.go
@@ -94,12 +94,18 @@ func (s *Server) handleTokenExchange(w http.ResponseWriter, r *http.Request, cli
 		IssuedTokenType: requestedTokenType,
 		TokenType:       "bearer",
 	}
+	auth := Authorization{
+		Client:      client,
+		Claims:      claims,
+		Scopes:      scopes,
+		ConnectorID: connID,
+	}
 	var expiry time.Time
 	switch requestedTokenType {
 	case tokenTypeID:
-		resp.AccessToken, expiry, err = s.newIDToken(r.Context(), client.ID, claims, scopes, "", "", "", connID, time.Time{})
+		resp.AccessToken, expiry, err = s.issuer.signer.signIDToken(r.Context(), auth, "", "")
 	case tokenTypeAccess:
-		resp.AccessToken, expiry, err = s.newAccessToken(r.Context(), client.ID, claims, scopes, "", connID, time.Time{})
+		resp.AccessToken, expiry, err = s.issuer.signer.signAccessToken(r.Context(), auth)
 	default:
 		s.tokenErrHelper(w, errRequestNotSupported, "Invalid requested_token_type.", http.StatusBadRequest)
 		return

--- a/server/introspectionhandler_test.go
+++ b/server/introspectionhandler_test.go
@@ -149,10 +149,13 @@ func TestGetTokenFromRequestSuccess(t *testing.T) {
 	mockTestStorage(t, s.storage)
 
 	// Generate a valid RS256-signed access token
-	accessToken, _, err := s.newIDToken(ctx, "test", storage.Claims{
-		UserID:   "1",
-		Username: "jane",
-	}, []string{"openid"}, "nonce", "", "", "test", time.Time{})
+	accessToken, _, err := s.issuer.signer.signIDToken(ctx, Authorization{
+		Client:      storage.Client{ID: "test"},
+		Claims:      storage.Claims{UserID: "1", Username: "jane"},
+		Scopes:      []string{"openid"},
+		Nonce:       "nonce",
+		ConnectorID: "test",
+	}, "", "")
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -264,13 +267,19 @@ func TestHandleIntrospect(t *testing.T) {
 
 	mockTestStorage(t, s.storage)
 
-	activeAccessToken, expiry, err := s.newIDToken(ctx, "test", storage.Claims{
-		UserID:        "1",
-		Username:      "jane",
-		Email:         "jane.doe@example.com",
-		EmailVerified: true,
-		Groups:        []string{"a", "b"},
-	}, []string{"openid", "email", "profile", "groups"}, "foo", "", "", "test", time.Time{})
+	activeAccessToken, expiry, err := s.issuer.signer.signIDToken(ctx, Authorization{
+		Client: storage.Client{ID: "test"},
+		Claims: storage.Claims{
+			UserID:        "1",
+			Username:      "jane",
+			Email:         "jane.doe@example.com",
+			EmailVerified: true,
+			Groups:        []string{"a", "b"},
+		},
+		Scopes:      []string{"openid", "email", "profile", "groups"},
+		Nonce:       "foo",
+		ConnectorID: "test",
+	}, "", "")
 	require.NoError(t, err)
 
 	activeRefreshToken, err := internal.Marshal(&internal.RefreshToken{RefreshId: "test", Token: "bar"})

--- a/server/logout_test.go
+++ b/server/logout_test.go
@@ -127,9 +127,13 @@ func TestHandleLogoutWithValidHint(t *testing.T) {
 		LastActivity: time.Now(),
 	}))
 
-	idToken, _, err := server.newIDToken(ctx, clientID, storage.Claims{
-		UserID: userID, Username: "testuser", Email: "test@example.com",
-	}, []string{"openid"}, "", "", "", connectorID, time.Now())
+	idToken, _, err := server.issuer.signer.signIDToken(ctx, Authorization{
+		Client:      storage.Client{ID: clientID},
+		Claims:      storage.Claims{UserID: userID, Username: "testuser", Email: "test@example.com"},
+		Scopes:      []string{"openid"},
+		ConnectorID: connectorID,
+		AuthTime:    time.Now(),
+	}, "", "")
 	require.NoError(t, err)
 
 	logoutURL := fmt.Sprintf("/logout?id_token_hint=%s&post_logout_redirect_uri=%s&state=mystate",
@@ -170,9 +174,13 @@ func TestHandleLogoutUnregisteredRedirectURI(t *testing.T) {
 		PostLogoutRedirectURIs: []string{"https://example.com/done"},
 	}))
 
-	idToken, _, err := server.newIDToken(ctx, clientID, storage.Claims{
-		UserID: "user1", Username: "testuser", Email: "test@example.com",
-	}, []string{"openid"}, "", "", "", "mock", time.Now())
+	idToken, _, err := server.issuer.signer.signIDToken(ctx, Authorization{
+		Client:      storage.Client{ID: clientID},
+		Claims:      storage.Claims{UserID: "user1", Username: "testuser", Email: "test@example.com"},
+		Scopes:      []string{"openid"},
+		ConnectorID: "mock",
+		AuthTime:    time.Now(),
+	}, "", "")
 	require.NoError(t, err)
 
 	logoutURL := fmt.Sprintf("/logout?id_token_hint=%s&post_logout_redirect_uri=%s",
@@ -236,9 +244,13 @@ func TestHandleLogoutRevokesRefreshTokens(t *testing.T) {
 		CreatedAt: time.Now(), LastActivity: time.Now(),
 	}))
 
-	idToken, _, err := server.newIDToken(ctx, clientID, storage.Claims{
-		UserID: userID, Username: "testuser", Email: "test@example.com",
-	}, []string{"openid"}, "", "", "", connectorID, time.Now())
+	idToken, _, err := server.issuer.signer.signIDToken(ctx, Authorization{
+		Client:      storage.Client{ID: clientID},
+		Claims:      storage.Claims{UserID: userID, Username: "testuser", Email: "test@example.com"},
+		Scopes:      []string{"openid"},
+		ConnectorID: connectorID,
+		AuthTime:    time.Now(),
+	}, "", "")
 	require.NoError(t, err)
 
 	logoutURL := fmt.Sprintf("/logout?id_token_hint=%s&post_logout_redirect_uri=%s",
@@ -277,9 +289,13 @@ func TestHandleLogoutRepeat(t *testing.T) {
 		CreatedAt: time.Now(), LastActivity: time.Now(),
 	}))
 
-	idToken, _, err := server.newIDToken(ctx, clientID, storage.Claims{
-		UserID: userID, Username: "testuser", Email: "test@example.com",
-	}, []string{"openid"}, "", "", "", connectorID, time.Now())
+	idToken, _, err := server.issuer.signer.signIDToken(ctx, Authorization{
+		Client:      storage.Client{ID: clientID},
+		Claims:      storage.Claims{UserID: userID, Username: "testuser", Email: "test@example.com"},
+		Scopes:      []string{"openid"},
+		ConnectorID: connectorID,
+		AuthTime:    time.Now(),
+	}, "", "")
 	require.NoError(t, err)
 
 	logoutURL := fmt.Sprintf("/logout?id_token_hint=%s&post_logout_redirect_uri=%s",

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -17,11 +17,9 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/go-jose/go-jose/v4"
-	"github.com/google/uuid"
 
 	"github.com/dexidp/dex/connector"
 	"github.com/dexidp/dex/server/internal"
@@ -296,10 +294,6 @@ type federatedIDClaims struct {
 	UserID      string `json:"user_id,omitempty"`
 }
 
-func (s *Server) newAccessToken(ctx context.Context, clientID string, claims storage.Claims, scopes []string, nonce, connID string, authTime time.Time) (accessToken string, expiry time.Time, err error) {
-	return s.newIDToken(ctx, clientID, claims, scopes, nonce, storage.NewID(), "", connID, authTime)
-}
-
 func getClientID(aud audience, azp string) (string, error) {
 	switch len(aud) {
 	case 0:
@@ -341,105 +335,6 @@ func genSubject(userID string, connID string) (string, error) {
 	}
 
 	return internal.Marshal(sub)
-}
-
-func (s *Server) newIDToken(ctx context.Context, clientID string, claims storage.Claims, scopes []string, nonce, accessToken, code, connID string, authTime time.Time) (idToken string, expiry time.Time, err error) {
-	issuedAt := s.now()
-	expiry = issuedAt.Add(s.idTokensValidFor)
-
-	subjectString, err := genSubject(claims.UserID, connID)
-	if err != nil {
-		s.logger.ErrorContext(ctx, "failed to marshal offline session ID", "err", err)
-		return "", expiry, fmt.Errorf("failed to marshal offline session ID: %v", err)
-	}
-
-	tok := idTokenClaims{
-		Issuer:   s.issuerURL.String(),
-		Subject:  subjectString,
-		Nonce:    nonce,
-		Expiry:   expiry.Unix(),
-		IssuedAt: issuedAt.Unix(),
-		JWTID:    uuid.New().String(),
-	}
-
-	// Include auth_time when sessions are enabled and the value is available.
-	if !authTime.IsZero() {
-		tok.AuthTime = authTime.Unix()
-	}
-
-	// Determine signing algorithm from signer
-	signingAlg, err := s.signer.Algorithm(ctx)
-	if err != nil {
-		s.logger.ErrorContext(ctx, "failed to get signing algorithm", "err", err)
-		return "", expiry, fmt.Errorf("failed to get signing algorithm: %v", err)
-	}
-
-	if accessToken != "" {
-		atHash, err := accessTokenHash(signingAlg, accessToken)
-		if err != nil {
-			s.logger.ErrorContext(ctx, "error computing at_hash", "err", err)
-			return "", expiry, fmt.Errorf("error computing at_hash: %v", err)
-		}
-		tok.AccessTokenHash = atHash
-	}
-
-	if code != "" {
-		cHash, err := accessTokenHash(signingAlg, code)
-		if err != nil {
-			s.logger.ErrorContext(ctx, "error computing c_hash", "err", err)
-			return "", expiry, fmt.Errorf("error computing c_hash: #{err}")
-		}
-		tok.CodeHash = cHash
-	}
-
-	for _, scope := range scopes {
-		switch {
-		case scope == scopeEmail:
-			tok.Email = claims.Email
-			tok.EmailVerified = &claims.EmailVerified
-		case scope == scopeGroups:
-			tok.Groups = claims.Groups
-		case scope == scopeProfile:
-			tok.Name = claims.Username
-			tok.PreferredUsername = claims.PreferredUsername
-		case scope == scopeFederatedID:
-			tok.FederatedIDClaims = &federatedIDClaims{
-				ConnectorID: connID,
-				UserID:      claims.UserID,
-			}
-		default:
-			peerID, ok := parseCrossClientScope(scope)
-			if !ok {
-				// Ignore unknown scopes. These are already validated during the
-				// initial auth request.
-				continue
-			}
-			isTrusted, err := s.validateCrossClientTrust(ctx, clientID, peerID)
-			if err != nil {
-				return "", expiry, err
-			}
-			if !isTrusted {
-				// TODO(ericchiang): propagate this error to the client.
-				return "", expiry, fmt.Errorf("peer (%s) does not trust client", peerID)
-			}
-		}
-	}
-
-	tok.Audience = getAudience(clientID, scopes)
-	if len(tok.Audience) > 1 {
-		// The current client becomes the authorizing party.
-		tok.AuthorizingParty = clientID
-	}
-
-	payload, err := json.Marshal(tok)
-	if err != nil {
-		return "", expiry, fmt.Errorf("could not serialize claims: %v", err)
-	}
-
-	if idToken, err = s.signer.Sign(ctx, payload); err != nil {
-		return "", expiry, fmt.Errorf("failed to sign payload: %v", err)
-	}
-	return idToken, expiry, nil
 }
 
 // validateIDTokenHint verifies the signature and issuer of an id_token_hint.

--- a/server/oauth2_test.go
+++ b/server/oauth2_test.go
@@ -1056,19 +1056,17 @@ func TestNewIDTokenUsesStoredAlgorithmUntilNextRotation(t *testing.T) {
 		idTokensValidFor: time.Hour,
 	}
 
+	s.issuer = newTokenIssuer(s)
+
 	accessToken := "test-access-token"
 	code := "test-auth-code"
-	idToken, _, err := s.newIDToken(
-		ctx,
-		"test-client",
-		storage.Claims{UserID: "1", Username: "jane"},
-		[]string{"openid"},
-		"nonce",
-		accessToken,
-		code,
-		"test",
-		time.Time{},
-	)
+	idToken, _, err := s.issuer.signer.signIDToken(ctx, Authorization{
+		Client:      storage.Client{ID: "test-client"},
+		Claims:      storage.Claims{UserID: "1", Username: "jane"},
+		Scopes:      []string{"openid"},
+		Nonce:       "nonce",
+		ConnectorID: "test",
+	}, accessToken, code)
 	require.NoError(t, err)
 
 	keys, err := sig.ValidationKeys(ctx)
@@ -1145,6 +1143,8 @@ func TestNewIDTokenContainsJTI(t *testing.T) {
 		idTokensValidFor: time.Hour,
 	}
 
+	s.issuer = newTokenIssuer(s)
+
 	keys, err := sig.ValidationKeys(ctx)
 	require.NoError(t, err)
 	require.NotEmpty(t, keys)
@@ -1163,11 +1163,20 @@ func TestNewIDTokenContainsJTI(t *testing.T) {
 		return claims.JTI
 	}
 
-	token1, _, err := s.newIDToken(ctx, "client", storage.Claims{UserID: "1", Username: "alice"}, []string{"openid"}, "n1", "", "", "mock", time.Time{})
-	require.NoError(t, err)
-
-	token2, _, err := s.newIDToken(ctx, "client", storage.Claims{UserID: "1", Username: "alice"}, []string{"openid"}, "n2", "", "", "mock", time.Time{})
-	require.NoError(t, err)
+	mint := func(nonce string) string {
+		t.Helper()
+		token, _, err := s.issuer.signer.signIDToken(ctx, Authorization{
+			Client:      storage.Client{ID: "client"},
+			Claims:      storage.Claims{UserID: "1", Username: "alice"},
+			Scopes:      []string{"openid"},
+			Nonce:       nonce,
+			ConnectorID: "mock",
+		}, "", "")
+		require.NoError(t, err)
+		return token
+	}
+	token1 := mint("n1")
+	token2 := mint("n2")
 
 	jti1 := extractJTI(t, token1)
 	jti2 := extractJTI(t, token2)

--- a/server/server.go
+++ b/server/server.go
@@ -249,6 +249,9 @@ type Server struct {
 
 	signer signer.Signer
 
+	// issuer turns an Authorization into a TokenSet (see token_issuer.go).
+	issuer *tokenIssuer
+
 	sessionConfig *SessionConfig
 
 	mfaProviders    map[string]MFAProvider
@@ -380,6 +383,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		mfaProviders:           c.MFAProviders,
 		defaultMFAChain:        c.DefaultMFAChain,
 	}
+	s.issuer = newTokenIssuer(s)
 
 	// Retrieves connector objects in backend storage. This list includes the static connectors
 	// defined in the ConfigMap and dynamic connectors retrieved from the storage.

--- a/server/token_issuer.go
+++ b/server/token_issuer.go
@@ -1,0 +1,340 @@
+package server
+
+// token_issuer.go is the token-issuance core. Every grant reduces to producing an
+// Authorization (an authenticated subject's permission for a client); the issuer
+// turns that uniformly into a TokenSet. Signing (tokenSigner) and refresh-token
+// persistence (refreshTokens) are the two collaborators; writing the HTTP response
+// is a separate transport concern (writeTokenResponse).
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/dexidp/dex/server/internal"
+	"github.com/dexidp/dex/server/signer"
+	"github.com/dexidp/dex/storage"
+)
+
+// Authorization is the result of any grant: an authenticated subject and the
+// permission it grants a client. The issuer turns an Authorization into a TokenSet.
+type Authorization struct {
+	Client        storage.Client
+	Claims        storage.Claims
+	Scopes        []string
+	ConnectorID   string
+	Nonce         string
+	AuthTime      time.Time
+	ConnectorData []byte
+}
+
+// TokenSet is what the /token endpoint returns for an Authorization.
+type TokenSet struct {
+	AccessToken  string
+	IDToken      string
+	RefreshToken string
+	Expiry       time.Time
+}
+
+// tokenIssuer turns an Authorization into a TokenSet. It composes the signer and
+// the refresh-token store; it holds no HTTP or grant-specific logic.
+type tokenIssuer struct {
+	signer  *tokenSigner
+	refresh *refreshTokens
+}
+
+func newTokenIssuer(s *Server) *tokenIssuer {
+	return &tokenIssuer{
+		signer: &tokenSigner{
+			storage:          s.storage,
+			signer:           s.signer,
+			issuerURL:        s.issuerURL,
+			idTokensValidFor: s.idTokensValidFor,
+			now:              s.now,
+			logger:           s.logger,
+		},
+		refresh: &refreshTokens{
+			storage: s.storage,
+			now:     s.now,
+			logger:  s.logger,
+		},
+	}
+}
+
+// Issue mints an access and ID token for the authorization, and a refresh token
+// when withRefresh is true. Whether a refresh token is wanted (connector support,
+// grant-type policy, offline_access scope) is a grant decision, so the caller
+// passes it in.
+func (i *tokenIssuer) Issue(ctx context.Context, auth Authorization, withRefresh bool) (TokenSet, error) {
+	accessToken, _, err := i.signer.signAccessToken(ctx, auth)
+	if err != nil {
+		return TokenSet{}, fmt.Errorf("create access token: %w", err)
+	}
+
+	idToken, expiry, err := i.signer.signIDToken(ctx, auth, accessToken, "")
+	if err != nil {
+		return TokenSet{}, fmt.Errorf("create id token: %w", err)
+	}
+
+	ts := TokenSet{AccessToken: accessToken, IDToken: idToken, Expiry: expiry}
+
+	if withRefresh {
+		ts.RefreshToken, err = i.refresh.create(ctx, auth)
+		if err != nil {
+			return TokenSet{}, fmt.Errorf("create refresh token: %w", err)
+		}
+	}
+	return ts, nil
+}
+
+// tokenSigner mints signed access and ID tokens. It owns the OIDC claim assembly,
+// including cross-client audience resolution.
+type tokenSigner struct {
+	storage          storage.Storage
+	signer           signer.Signer
+	issuerURL        url.URL
+	idTokensValidFor time.Duration
+	now              func() time.Time
+	logger           *slog.Logger
+}
+
+// signAccessToken mints an opaque-looking JWT access token. Dex's access token is an
+// ID token bound to a random value, so each access token is unique.
+func (t *tokenSigner) signAccessToken(ctx context.Context, auth Authorization) (string, time.Time, error) {
+	return t.signIDToken(ctx, auth, storage.NewID(), "")
+}
+
+// signIDToken mints an ID token. accessToken/code, when set, contribute at_hash/c_hash.
+func (t *tokenSigner) signIDToken(ctx context.Context, auth Authorization, accessToken, code string) (string, time.Time, error) {
+	issuedAt := t.now()
+	expiry := issuedAt.Add(t.idTokensValidFor)
+
+	subjectString, err := genSubject(auth.Claims.UserID, auth.ConnectorID)
+	if err != nil {
+		t.logger.ErrorContext(ctx, "failed to marshal offline session ID", "err", err)
+		return "", expiry, fmt.Errorf("failed to marshal offline session ID: %v", err)
+	}
+
+	tok := idTokenClaims{
+		Issuer:   t.issuerURL.String(),
+		Subject:  subjectString,
+		Nonce:    auth.Nonce,
+		Expiry:   expiry.Unix(),
+		IssuedAt: issuedAt.Unix(),
+		JWTID:    uuid.New().String(),
+	}
+
+	if !auth.AuthTime.IsZero() {
+		tok.AuthTime = auth.AuthTime.Unix()
+	}
+
+	signingAlg, err := t.signer.Algorithm(ctx)
+	if err != nil {
+		t.logger.ErrorContext(ctx, "failed to get signing algorithm", "err", err)
+		return "", expiry, fmt.Errorf("failed to get signing algorithm: %v", err)
+	}
+
+	if accessToken != "" {
+		atHash, err := accessTokenHash(signingAlg, accessToken)
+		if err != nil {
+			t.logger.ErrorContext(ctx, "error computing at_hash", "err", err)
+			return "", expiry, fmt.Errorf("error computing at_hash: %v", err)
+		}
+		tok.AccessTokenHash = atHash
+	}
+
+	if code != "" {
+		cHash, err := accessTokenHash(signingAlg, code)
+		if err != nil {
+			t.logger.ErrorContext(ctx, "error computing c_hash", "err", err)
+			return "", expiry, fmt.Errorf("error computing c_hash: %v", err)
+		}
+		tok.CodeHash = cHash
+	}
+
+	clientID := auth.Client.ID
+	for _, scope := range auth.Scopes {
+		switch {
+		case scope == scopeEmail:
+			tok.Email = auth.Claims.Email
+			tok.EmailVerified = &auth.Claims.EmailVerified
+		case scope == scopeGroups:
+			tok.Groups = auth.Claims.Groups
+		case scope == scopeProfile:
+			tok.Name = auth.Claims.Username
+			tok.PreferredUsername = auth.Claims.PreferredUsername
+		case scope == scopeFederatedID:
+			tok.FederatedIDClaims = &federatedIDClaims{
+				ConnectorID: auth.ConnectorID,
+				UserID:      auth.Claims.UserID,
+			}
+		default:
+			peerID, ok := parseCrossClientScope(scope)
+			if !ok {
+				continue
+			}
+			isTrusted, err := t.crossClientTrusted(ctx, clientID, peerID)
+			if err != nil {
+				return "", expiry, err
+			}
+			if !isTrusted {
+				return "", expiry, fmt.Errorf("peer (%s) does not trust client", peerID)
+			}
+		}
+	}
+
+	tok.Audience = getAudience(clientID, auth.Scopes)
+	if len(tok.Audience) > 1 {
+		tok.AuthorizingParty = clientID
+	}
+
+	payload, err := json.Marshal(tok)
+	if err != nil {
+		return "", expiry, fmt.Errorf("could not serialize claims: %v", err)
+	}
+
+	idToken, err := t.signer.Sign(ctx, payload)
+	if err != nil {
+		return "", expiry, fmt.Errorf("failed to sign payload: %v", err)
+	}
+	return idToken, expiry, nil
+}
+
+// crossClientTrusted reports whether peerID's client trusts clientID as a peer.
+func (t *tokenSigner) crossClientTrusted(ctx context.Context, clientID, peerID string) (bool, error) {
+	if peerID == clientID {
+		return true, nil
+	}
+	peer, err := t.storage.GetClient(ctx, peerID)
+	if err != nil {
+		if err != storage.ErrNotFound {
+			t.logger.ErrorContext(ctx, "failed to get client", "err", err)
+			return false, err
+		}
+		return false, nil
+	}
+	for _, id := range peer.TrustedPeers {
+		if id == clientID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// refreshTokens creates and rotates refresh tokens, keeping the offline-session
+// references in sync. It is the single owner of refresh-token persistence.
+type refreshTokens struct {
+	storage storage.Storage
+	now     func() time.Time
+	logger  *slog.Logger
+}
+
+// create issues a new refresh token for the authorization and records it in the
+// user's offline session. On any offline-session failure the refresh token is
+// rolled back so no orphaned token is left behind.
+func (rt *refreshTokens) create(ctx context.Context, auth Authorization) (string, error) {
+	refresh := storage.RefreshToken{
+		ID:            storage.NewID(),
+		Token:         storage.NewID(),
+		ClientID:      auth.Client.ID,
+		ConnectorID:   auth.ConnectorID,
+		Scopes:        auth.Scopes,
+		Claims:        auth.Claims,
+		Nonce:         auth.Nonce,
+		ConnectorData: auth.ConnectorData,
+		CreatedAt:     rt.now(),
+		LastUsed:      rt.now(),
+	}
+
+	rawToken, err := internal.Marshal(&internal.RefreshToken{RefreshId: refresh.ID, Token: refresh.Token})
+	if err != nil {
+		return "", fmt.Errorf("marshal refresh token: %w", err)
+	}
+
+	if err := rt.storage.CreateRefresh(ctx, refresh); err != nil {
+		return "", fmt.Errorf("create refresh token: %w", err)
+	}
+
+	// Roll back the just-created refresh token if wiring it into the offline
+	// session fails, so we never leave an orphaned token.
+	rollback := func() {
+		if err := rt.storage.DeleteRefresh(ctx, refresh.ID); err != nil && err != storage.ErrNotFound {
+			rt.logger.ErrorContext(ctx, "failed to roll back refresh token", "err", err)
+		}
+	}
+
+	tokenRef := storage.RefreshTokenRef{
+		ID:        refresh.ID,
+		ClientID:  refresh.ClientID,
+		CreatedAt: refresh.CreatedAt,
+		LastUsed:  refresh.LastUsed,
+	}
+
+	session, err := rt.storage.GetOfflineSessions(ctx, refresh.Claims.UserID, refresh.ConnectorID)
+	switch {
+	case err != nil && err != storage.ErrNotFound:
+		rollback()
+		return "", fmt.Errorf("get offline session: %w", err)
+	case err != nil: // ErrNotFound: create a fresh offline session.
+		offlineSessions := storage.OfflineSessions{
+			UserID:        refresh.Claims.UserID,
+			ConnID:        refresh.ConnectorID,
+			Refresh:       map[string]*storage.RefreshTokenRef{tokenRef.ClientID: &tokenRef},
+			ConnectorData: auth.ConnectorData,
+		}
+		if err := rt.storage.CreateOfflineSessions(ctx, offlineSessions); err != nil {
+			rollback()
+			return "", fmt.Errorf("create offline session: %w", err)
+		}
+	default:
+		// Replace any existing refresh token for this client.
+		if oldRef, ok := session.Refresh[tokenRef.ClientID]; ok {
+			if err := rt.storage.DeleteRefresh(ctx, oldRef.ID); err != nil && err != storage.ErrNotFound {
+				rollback()
+				return "", fmt.Errorf("delete previous refresh token: %w", err)
+			}
+		}
+		if err := rt.storage.UpdateOfflineSessions(ctx, session.UserID, session.ConnID, func(old storage.OfflineSessions) (storage.OfflineSessions, error) {
+			old.Refresh[tokenRef.ClientID] = &tokenRef
+			if len(auth.ConnectorData) > 0 {
+				old.ConnectorData = auth.ConnectorData
+			}
+			return old, nil
+		}); err != nil {
+			rollback()
+			return "", fmt.Errorf("update offline session: %w", err)
+		}
+	}
+
+	return rawToken, nil
+}
+
+// writeTokenResponse writes a TokenSet as an OAuth2 token response.
+func writeTokenResponse(w http.ResponseWriter, ts TokenSet, now time.Time) error {
+	resp := accessTokenResponse{
+		AccessToken:  ts.AccessToken,
+		TokenType:    "bearer",
+		ExpiresIn:    int(ts.Expiry.Sub(now).Seconds()),
+		RefreshToken: ts.RefreshToken,
+		IDToken:      ts.IDToken,
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return fmt.Errorf("marshal token response: %w", err)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	// Token response must include cache headers, https://tools.ietf.org/html/rfc6749#section-5.1
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	w.Write(data)
+	return nil
+}

--- a/server/token_issuer_test.go
+++ b/server/token_issuer_test.go
@@ -1,0 +1,107 @@
+package server
+
+import (
+	"log/slog"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dexidp/dex/server/internal"
+	"github.com/dexidp/dex/server/signer"
+	"github.com/dexidp/dex/storage"
+	"github.com/dexidp/dex/storage/memory"
+)
+
+func newTestIssuer(t *testing.T) (*tokenIssuer, storage.Storage) {
+	t.Helper()
+	logger := slog.New(slog.DiscardHandler)
+	store := memory.New(logger)
+	sig, err := signer.NewMockSigner(testKey)
+	require.NoError(t, err)
+	issuerURL, err := url.Parse("https://issuer.example.com")
+	require.NoError(t, err)
+
+	iss := &tokenIssuer{
+		signer: &tokenSigner{
+			storage: store, signer: sig, issuerURL: *issuerURL,
+			idTokensValidFor: time.Hour, now: time.Now, logger: logger,
+		},
+		refresh: &refreshTokens{storage: store, now: time.Now, logger: logger},
+	}
+	return iss, store
+}
+
+func testAuthorization() Authorization {
+	return Authorization{
+		Client:        storage.Client{ID: "client-1"},
+		Claims:        storage.Claims{UserID: "u1", Username: "alice", Email: "alice@example.com"},
+		Scopes:        []string{"openid", "email", "offline_access"},
+		ConnectorID:   "mock",
+		Nonce:         "n",
+		ConnectorData: []byte(`{"conn":"data"}`),
+	}
+}
+
+func TestTokenIssuerIssue(t *testing.T) {
+	ctx := t.Context()
+	iss, store := newTestIssuer(t)
+	auth := testAuthorization()
+
+	// With refresh requested: access + id + refresh, and the refresh token is persisted.
+	ts, err := iss.Issue(ctx, auth, true)
+	require.NoError(t, err)
+	require.NotEmpty(t, ts.AccessToken)
+	require.NotEmpty(t, ts.IDToken)
+	require.NotEmpty(t, ts.RefreshToken)
+
+	var rt internal.RefreshToken
+	require.NoError(t, internal.Unmarshal(ts.RefreshToken, &rt))
+	stored, err := store.GetRefresh(ctx, rt.RefreshId)
+	require.NoError(t, err)
+	require.Equal(t, "client-1", stored.ClientID)
+	require.Equal(t, "mock", stored.ConnectorID)
+	require.Equal(t, auth.ConnectorData, stored.ConnectorData)
+
+	sess, err := store.GetOfflineSessions(ctx, "u1", "mock")
+	require.NoError(t, err)
+	require.Contains(t, sess.Refresh, "client-1")
+
+	// Without refresh: access + id only.
+	ts2, err := iss.Issue(ctx, auth, false)
+	require.NoError(t, err)
+	require.NotEmpty(t, ts2.AccessToken)
+	require.NotEmpty(t, ts2.IDToken)
+	require.Empty(t, ts2.RefreshToken)
+}
+
+func TestRefreshTokensCreateReplacesExisting(t *testing.T) {
+	ctx := t.Context()
+	iss, store := newTestIssuer(t)
+	auth := testAuthorization()
+
+	first, err := iss.refresh.create(ctx, auth)
+	require.NoError(t, err)
+	var firstTok internal.RefreshToken
+	require.NoError(t, internal.Unmarshal(first, &firstTok))
+
+	// A second create for the same client replaces the old token: the old one is
+	// deleted and the offline session points at the new one.
+	second, err := iss.refresh.create(ctx, auth)
+	require.NoError(t, err)
+	var secondTok internal.RefreshToken
+	require.NoError(t, internal.Unmarshal(second, &secondTok))
+	require.NotEqual(t, firstTok.RefreshId, secondTok.RefreshId)
+
+	if _, err := store.GetRefresh(ctx, firstTok.RefreshId); err == nil {
+		t.Error("expected the previous refresh token to be deleted")
+	}
+	stored, err := store.GetRefresh(ctx, secondTok.RefreshId)
+	require.NoError(t, err)
+	require.Equal(t, "client-1", stored.ClientID)
+
+	sess, err := store.GetOfflineSessions(ctx, "u1", "mock")
+	require.NoError(t, err)
+	require.Equal(t, secondTok.RefreshId, sess.Refresh["client-1"].ID)
+}


### PR DESCRIPTION
#### Overview

A token-issuance core for the `server` package. Every grant reduces to producing an `Authorization`, and the issuer turns it into a `TokenSet`.

#### What this PR does / why we need it

Token issuance was spread across every grant as long positional calls to `Server.newIDToken`/`newAccessToken`, plus refresh-token creation that was copy-pasted between two grants. `token_issuer.go` gives it a small domain:

- `Authorization` (the authenticated subject and the client permission) and `TokenSet` (the tokens produced from it) value objects.
- `tokenSigner` for access and id JWT minting, owning cross-client audience resolution internally.
- `refreshTokens` for refresh-token persistence, unifying the create-and-record-offline-session logic that the authorization_code and password grants had copied. Rollback on a failed offline-session write is preserved.
- `tokenIssuer.Issue(auth, wantRefresh)` composing them, with `writeTokenResponse` as a separate transport helper.

Every grant is migrated: password, client_credentials, token_exchange, authorization_code, the approval implicit/hybrid path and the refresh grant. `Server.newIDToken`/`newAccessToken` are removed; callers and tests build an `Authorization` and go through the signer. Unit tests cover the issuer and the refresh store.

#### Special notes for your reviewer

One deliberate behaviour change. Unifying `refreshTokens.create` aligns the password grant with the authorization_code grant's connector-data handling:

- Password-issued refresh tokens now persist `ConnectorData` (previously left empty). In the common case this is a no-op: the refresh token and the offline session get the same `identity.ConnectorData`, and the refresh grant reads the same value from either.
- The offline-session update is now conditional (`if len(ConnectorData) > 0`) instead of unconditionally overwriting, so an empty re-auth no longer clobbers previously stored connector data. This matches both the authorization_code grant and the refresh grant's own read logic.

Refresh rotation (`updateRefreshToken`) and the `refreshContext` removal, which are entangled with introspection's shared token lookup, come in a follow-up.
