### PR TITLE
connector/oidc: allow overriding userinfo and device auth URLs

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -136,13 +136,19 @@ type ProviderDiscoveryOverrides struct {
 	// JWKSURL provides a way to user overwrite the JWKS URL
 	// from the .well-known/openid-configuration jwks_uri
 	JWKSURL string `json:"jwksURL"`
+	// UserInfoURL provides a way to override the UserInfo URL
+	// from the .well-known/openid-configuration userinfo_endpoint
+	UserInfoURL string `json:"userInfoURL"`
+	// DeviceAuthURL provides a way to override the Device Authorization URL
+	// from the .well-known/openid-configuration device_authorization_endpoint
+	DeviceAuthURL string `json:"deviceAuthURL"`
 	// EndSessionURL provides a way to override the end_session_endpoint
 	// from the .well-known/openid-configuration
 	EndSessionURL string `json:"endSessionURL"`
 }
 
 func (o *ProviderDiscoveryOverrides) Empty() bool {
-	return o.TokenURL == "" && o.AuthURL == "" && o.JWKSURL == "" && o.EndSessionURL == ""
+	return o.TokenURL == "" && o.AuthURL == "" && o.JWKSURL == "" && o.UserInfoURL == "" && o.DeviceAuthURL == "" && o.EndSessionURL == ""
 }
 
 func getProvider(ctx context.Context, issuer string, overrides ProviderDiscoveryOverrides) (*oidc.Provider, error) {
@@ -185,6 +191,12 @@ func getProvider(ctx context.Context, issuer string, overrides ProviderDiscovery
 	}
 	if overrides.JWKSURL != "" {
 		config.JWKSURL = overrides.JWKSURL
+	}
+	if overrides.UserInfoURL != "" {
+		config.UserInfoURL = overrides.UserInfoURL
+	}
+	if overrides.DeviceAuthURL != "" {
+		config.DeviceAuthURL = overrides.DeviceAuthURL
 	}
 	return config.NewProvider(context.Background()), nil
 }

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -833,6 +833,42 @@ func TestProviderOverride(t *testing.T) {
 			t.Fatalf("unexpected token URL: %s, expected: %s\n", conn.provider.Endpoint().TokenURL, expToken)
 		}
 	})
+
+	t.Run("Override userinfo and device auth URLs", func(t *testing.T) {
+		// A second server whose userinfo endpoint returns a distinct subject,
+		// so we can prove the overridden endpoint (not the discovery default)
+		// is the one actually used.
+		overrideServer, err := setupServer(map[string]any{"sub": "override-sub"}, true)
+		if err != nil {
+			t.Fatal("failed to setup override server", err)
+		}
+		defer overrideServer.Close()
+
+		conn, err := newConnector(Config{
+			Issuer: testServer.URL,
+			Scopes: []string{"openid", "groups"},
+			ProviderDiscoveryOverrides: ProviderDiscoveryOverrides{
+				DeviceAuthURL: "/test-device",
+				UserInfoURL:   fmt.Sprintf("%s/userinfo", overrideServer.URL),
+			},
+		})
+		if err != nil {
+			t.Fatal("failed to create new connector", err)
+		}
+
+		expDevice := "/test-device"
+		if conn.provider.Endpoint().DeviceAuthURL != expDevice {
+			t.Fatalf("unexpected device auth URL: %s, expected: %s\n", conn.provider.Endpoint().DeviceAuthURL, expDevice)
+		}
+
+		userInfo, err := conn.provider.UserInfo(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "sometoken"}))
+		if err != nil {
+			t.Fatal("failed to call UserInfo", err)
+		}
+		if userInfo.Subject != "override-sub" {
+			t.Fatalf("UserInfo did not use the overridden endpoint: got subject %q, expected %q", userInfo.Subject, "override-sub")
+		}
+	})
 }
 
 func setupServer(tok map[string]interface{}, idTokenDesired bool) (*httptest.Server, error) {


### PR DESCRIPTION
Closes #4110

The OIDC connector's `providerDiscoveryOverrides` can already override the token, auth and JWKS URLs discovered from `.well-known/openid-configuration`, but not the userinfo or device authorization endpoints.

As reported in #4110, this is a problem when a provider advertises those endpoints incorrectly in its discovery document (e.g. it declares `https` URLs when only `http` is reachable) and the provider's discovery configuration can't be changed.

This adds `userInfoURL` and `deviceAuthURL` to `ProviderDiscoveryOverrides` and applies them in `getProvider`, mirroring the existing `tokenURL` / `authURL` / `jwksURL` overrides. `oidc.ProviderConfig` already carries both fields, so this only wires the override branches.

Scope note: the issue text mentions "userinfo and device auth url", so this covers exactly the two discovery URLs that weren't yet overridable. The issuer URL is configured separately and isn't a discovery override.

### Testing

Extended `TestProviderOverride` with a case that overrides both new URLs: the device auth URL is asserted via `provider.Endpoint().DeviceAuthURL`, and the userinfo override is verified behaviourally — a second test server returns a distinct subject and the connector's `UserInfo` call is shown to hit the overridden endpoint. Runs offline (`httptest`), no infra.

```
go test ./connector/oidc/ -run TestProviderOverride
```
