### PR TITLE
docs(server): give each subpackage a doc.go

### DIFF
--- a/server/connectors/connectors.go
+++ b/server/connectors/connectors.go
@@ -1,4 +1,3 @@
-// Package connectors holds the server's in-memory cache of opened connectors.
 package connectors
 
 import (

--- a/server/connectors/doc.go
+++ b/server/connectors/doc.go
@@ -1,0 +1,2 @@
+// Package connectors holds the server's in-memory cache of opened connectors.
+package connectors

--- a/server/device/device.go
+++ b/server/device/device.go
@@ -1,8 +1,3 @@
-// Package device implements the browser-facing side of the OAuth2 device
-// authorization grant (RFC 8628): the /device user-code entry page, the
-// /device/code authorization request, user-code verification, and the callback
-// that completes the flow. The device_code token grant that the device polls for
-// lives with the token endpoint.
 package device
 
 import (

--- a/server/device/doc.go
+++ b/server/device/doc.go
@@ -1,0 +1,6 @@
+// Package device implements the browser-facing side of the OAuth2 device
+// authorization grant (RFC 8628): the /device user-code entry page, the
+// /device/code authorization request, user-code verification, and the callback
+// that completes the flow. The device_code token grant that the device polls for
+// lives with the token endpoint.
+package device

--- a/server/discovery/discovery.go
+++ b/server/discovery/discovery.go
@@ -1,5 +1,3 @@
-// Package discovery serves the OIDC discovery document
-// (/.well-known/openid-configuration) and the JWKS endpoint (/keys).
 package discovery
 
 import (

--- a/server/discovery/doc.go
+++ b/server/discovery/doc.go
@@ -1,0 +1,3 @@
+// Package discovery serves the OIDC discovery document
+// (/.well-known/openid-configuration) and the JWKS endpoint (/keys).
+package discovery

--- a/server/home/doc.go
+++ b/server/home/doc.go
@@ -1,0 +1,2 @@
+// Package home serves the dex landing page at "/".
+package home

--- a/server/home/home.go
+++ b/server/home/home.go
@@ -1,4 +1,3 @@
-// Package home serves the dex landing page at "/".
 package home
 
 import (

--- a/server/internal/doc.go
+++ b/server/internal/doc.go
@@ -1,0 +1,4 @@
+// Package internal holds the server's wire formats: the protobuf value types and
+// the codecs that operate on them — base64 marshaling, the HMAC signer/verifier
+// used to protect redirect URLs, and the session-cookie encoder/decoder.
+package internal

--- a/server/internal/types.pb.go
+++ b/server/internal/types.pb.go
@@ -4,8 +4,6 @@
 // 	protoc        v5.29.3
 // source: server/internal/types.proto
 
-// Package internal holds protobuf types used by the server.
-
 package internal
 
 import (

--- a/server/internal/types.proto
+++ b/server/internal/types.proto
@@ -1,6 +1,5 @@
 syntax = "proto3";
 
-// Package internal holds protobuf types used by the server.
 package internal;
 
 option go_package = "github.com/dexidp/dex/server/internal";

--- a/server/introspection/doc.go
+++ b/server/introspection/doc.go
@@ -1,0 +1,3 @@
+// Package introspection serves the OAuth2 token introspection endpoint
+// (/token/introspect) as specified by RFC 7662.
+package introspection

--- a/server/introspection/introspection.go
+++ b/server/introspection/introspection.go
@@ -1,5 +1,3 @@
-// Package introspection serves the OAuth2 token introspection endpoint
-// (/token/introspect) as specified by [RFC 7662](https://tools.ietf.org/html/rfc7662).
 package introspection
 
 import (

--- a/server/oauth2/doc.go
+++ b/server/oauth2/doc.go
@@ -1,0 +1,7 @@
+// Package oauth2 holds the OAuth2/OIDC protocol vocabulary shared across the
+// server: the error codes returned in error responses, grant types, response
+// types, token-exchange token types, device-flow poll statuses, PKCE methods,
+// and the special redirect URIs, plus the OAuth2 error-response writer. Keeping
+// them in one place lets the per-domain handler packages reference the protocol
+// without depending on the server package.
+package oauth2

--- a/server/oauth2/oauth2.go
+++ b/server/oauth2/oauth2.go
@@ -1,8 +1,3 @@
-// Package oauth2 holds the OAuth2/OIDC protocol vocabulary shared across the
-// server: the error codes returned in error responses, grant types, response
-// types, token-exchange token types, device-flow poll statuses, and the special
-// redirect URIs. Keeping them in one place lets the per-domain handler packages
-// reference the protocol without depending on the server package.
 package oauth2
 
 // Error codes returned in OAuth2/OIDC error responses (RFC 6749 §5.2, the OIDC

--- a/server/router/doc.go
+++ b/server/router/doc.go
@@ -1,0 +1,3 @@
+// Package router defines the abstraction domain handlers use to mount their own
+// HTTP routes, so the top-level server does not hardcode each handler's paths.
+package router

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -1,5 +1,3 @@
-// Package router defines the abstraction domain handlers use to mount their own
-// HTTP routes, so the top-level server does not hardcode each handler's paths.
 package router
 
 import "net/http"

--- a/server/signer/doc.go
+++ b/server/signer/doc.go
@@ -1,0 +1,4 @@
+// Package signer signs tokens and exposes the corresponding validation keys.
+// It supports pluggable key backends (in-memory local rotation and Vault) and a
+// KeySet that verifies JWT signatures against the current validation keys.
+package signer

--- a/server/templates/doc.go
+++ b/server/templates/doc.go
@@ -1,0 +1,4 @@
+// Package templates renders dex's HTML pages — login, connector selection,
+// approval, out-of-band code, device flow, MFA (TOTP and WebAuthn), the landing
+// page, and error pages.
+package templates

--- a/server/tokens/doc.go
+++ b/server/tokens/doc.go
@@ -1,0 +1,3 @@
+// Package tokens owns the token value objects plus token issuance and
+// refresh-token rotation and persistence.
+package tokens

--- a/server/tokens/refresh_strategy.go
+++ b/server/tokens/refresh_strategy.go
@@ -1,5 +1,3 @@
-// Package tokens owns the token value objects plus refresh-token rotation and
-// persistence.
 package tokens
 
 import "time"

--- a/server/userinfo/doc.go
+++ b/server/userinfo/doc.go
@@ -1,0 +1,2 @@
+// Package userinfo serves the OIDC /userinfo endpoint.
+package userinfo

--- a/server/userinfo/userinfo.go
+++ b/server/userinfo/userinfo.go
@@ -1,4 +1,3 @@
-// Package userinfo serves the OIDC /userinfo endpoint.
 package userinfo
 
 import (


### PR DESCRIPTION
#### Overview

Give each `server` subpackage a dedicated `doc.go` holding its package comment.

#### What this PR does / why we need it

As the server is decomposed into subpackages, the package documentation lived in whatever file happened to be first (or, for `internal`, in the generated `types.pb.go`), and a couple of packages (`signer`, `templates`) had none.

- Move each package comment into a `doc.go` — the conventional home for a package-level comment.
- Add descriptions for `signer` and `templates`, which had none.
- Move the `internal` package comment out of the generated `types.pb.go` (and the `.proto`) into `doc.go`, and broaden it to cover the codecs the package gained (HMAC signer/verifier, session-cookie encoder) alongside the protobuf types.

No behaviour change; documentation only.
