### PR TITLE
cmd/dex: make garbage collection frequency configurable

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -647,6 +647,10 @@ type Expiry struct {
 	// DeviceRequests defines the duration of time for which the DeviceRequests will be valid.
 	DeviceRequests string `json:"deviceRequests"`
 
+	// GarbageCollectionFrequency defines how often dex sweeps expired auth
+	// codes, device requests, and refresh tokens from storage. Defaults to 5m.
+	GarbageCollectionFrequency string `json:"garbageCollectionFrequency"`
+
 	// RefreshTokens defines refresh tokens expiry policy
 	RefreshTokens RefreshToken `json:"refreshTokens"`
 }

--- a/cmd/dex/config_test.go
+++ b/cmd/dex/config_test.go
@@ -145,6 +145,7 @@ expiry:
   idTokens: "25h"
   authRequests: "25h"
   deviceRequests: "10m"
+  garbageCollectionFrequency: "1h"
 
 logger:
   level: "debug"
@@ -247,10 +248,11 @@ additionalFeatures: [
 			},
 		},
 		Expiry: Expiry{
-			SigningKeys:    "7h",
-			IDTokens:       "25h",
-			AuthRequests:   "25h",
-			DeviceRequests: "10m",
+			SigningKeys:                "7h",
+			IDTokens:                   "25h",
+			AuthRequests:               "25h",
+			DeviceRequests:             "10m",
+			GarbageCollectionFrequency: "1h",
 		},
 		Logger: Logger{
 			Level:  slog.LevelDebug,

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -408,6 +408,14 @@ func runServe(options serveOptions) error {
 		logger.Info("config device requests", "valid_for", deviceRequests)
 		serverConfig.DeviceRequestsValidFor = deviceRequests
 	}
+	if c.Expiry.GarbageCollectionFrequency != "" {
+		gcFrequency, err := time.ParseDuration(c.Expiry.GarbageCollectionFrequency)
+		if err != nil {
+			return fmt.Errorf("invalid config value %q for garbage collection frequency: %v", c.Expiry.GarbageCollectionFrequency, err)
+		}
+		logger.Info("config garbage collection frequency", "frequency", gcFrequency)
+		serverConfig.GCFrequency = gcFrequency
+	}
 	refreshTokenPolicy, err := tokens.NewRefreshTokenPolicy(
 		logger,
 		c.Expiry.RefreshTokens.DisableRotation,

--- a/config.docker.yaml
+++ b/config.docker.yaml
@@ -24,6 +24,7 @@ expiry:
   deviceRequests: {{ getenv "DEX_EXPIRY_DEVICE_REQUESTS" "5m" }}
   idTokens: {{ getenv "DEX_EXPIRY_ID_TOKENS" "24h" }}
   authRequests: {{ getenv "DEX_EXPIRY_AUTH_REQUESTS" "24h" }}
+  garbageCollectionFrequency: {{ getenv "DEX_EXPIRY_GARBAGE_COLLECTION_FREQUENCY" "5m" }}
 
 signer:
   type: local

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -90,6 +90,7 @@ telemetry:
 #   deviceRequests: "5m"
 #   signingKeys: "6h" # deprecated, use signer.config.keysRotationPeriod
 #   idTokens: "24h"
+#   garbageCollectionFrequency: "5m" # how often expired records are swept from storage
 #   refreshTokens:
 #     reuseInterval: "3s"
 #     validIfNotUsedFor: "2160h" # 90 days


### PR DESCRIPTION
Closes #1384

`server.Config.GCFrequency` has always been documented as "Defaults to 5 minutes", but as noted in the issue it was never populated from user config — so there was no way to change how often dex sweeps expired auth codes, device requests, and refresh tokens from storage. @srenatus confirmed on the issue that making it configurable would be welcome.

This adds an `expiry.garbageCollectionFrequency` setting, parsed with `time.ParseDuration` exactly like the sibling `authRequests` / `deviceRequests` durations and wired into `serverConfig.GCFrequency`:

```yaml
expiry:
  garbageCollectionFrequency: "5m"
```

When the setting is omitted, `serverConfig.GCFrequency` stays zero and the existing `value(c.GCFrequency, 5*time.Minute)` fallback keeps the 5-minute default, so behavior is unchanged for existing deployments.

**Changes**
- `cmd/dex/config.go`: `GarbageCollectionFrequency` field on the `Expiry` struct.
- `cmd/dex/serve.go`: parse and set it (invalid durations return a clear config error).
- `cmd/dex/config_test.go`: extended `TestUnmarshalConfig` to cover the new field.
- `config.docker.yaml` (with a `DEX_EXPIRY_GARBAGE_COLLECTION_FREQUENCY` env knob) and `examples/config-dev.yaml`: documented the option.

`go build`, `go test ./cmd/dex/`, `go vet`, and `gofmt` are clean.
