### PR TITLE
fix(oidc): apply groupsFilter to single-string groups claim

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -676,9 +676,12 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
 			vs, found = claims[groupsKey].([]interface{})
 		}
 
-		// Fallback when claims[groupsKey] is a string instead of an array of strings.
+		// Fallback when claims[groupsKey] is a string instead of an array of
+		// strings. Fold it into the array path so groupsFilter (and the other
+		// per-group handling below) applies uniformly.
 		if g, b := claims[groupsKey].(string); b {
-			groups = []string{g}
+			vs = []interface{}{g}
+			found = true
 		}
 
 		if found {

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -470,6 +470,25 @@ func TestHandleCallback(t *testing.T) {
 			},
 		},
 		{
+			// A groups claim delivered as a single string must still be run
+			// through the configured groupsFilter, like the array form.
+			name:               "filterGroupClaimsString",
+			userIDKey:          "", // not configured
+			userNameKey:        "", // not configured
+			groupsRegex:        `^.*\d$`,
+			expectUserID:       "subvalue",
+			expectUserName:     "namevalue",
+			expectGroups:       nil,
+			expectedEmailField: "emailvalue",
+			token: map[string]interface{}{
+				"sub":            "subvalue",
+				"name":           "namevalue",
+				"groups":         "groupA",
+				"email":          "emailvalue",
+				"email_verified": true,
+			},
+		},
+		{
 			name:               "filterGroupClaimsMap",
 			userIDKey:          "", // not configured
 			userNameKey:        "", // not configured


### PR DESCRIPTION
#### Overview

Apply the configured `groupsFilter` to the groups claim even when the upstream IdP returns it as a single string instead of an array.

#### What this PR does / why we need it

`createIdentity` in the OIDC connector applies `groupsFilter` (from `claimMutations.filterGroupClaims.groupsFilter`) inside the loop that handles the **array** form of the groups claim. The **single-string fallback**, however, assigned the group directly:

```go
// Fallback when claims[groupsKey] is a string instead of an array of strings.
if g, b := claims[groupsKey].(string); b {
    groups = []string{g}   // groupsFilter never applied
}
```

Some IdPs deliver the groups claim as a single string (which is exactly why this fallback exists). For those providers `groupsFilter` was silently a no-op: a group the operator configured the filter to exclude still landed in `identity.Groups`, and therefore in the ID token and every downstream authorization decision — failing open, with no signal to the operator.

This folds the single-string case into the array path (`vs = []interface{}{g}; found = true`) so `groupsFilter` — and the existing per-group prefix/map handling below it — applies uniformly. Behaviour is unchanged when no filter is configured (the existing `singularGroupResponseAsString` test still yields `["group1"]`).

#### Special notes for your reviewer

Added a regression test (`filterGroupClaimsString`) to `TestHandleCallback`: a single-string groups claim of `"groupA"` with filter `^.*\d$` must be filtered out. It fails on `master` (leaks `["groupA"]`) and passes with this change. `go test ./connector/oidc/...`, `gofmt`, and `go vet` are clean.

*Disclosure: I used an LLM to help find and draft this fix; I reproduced the bug, wrote the test, and verified everything myself.*
