### PR TITLE
Configure TLS CipherSuites and CurvePreferences

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -257,16 +258,18 @@ type PKCE struct {
 
 // Web is the config format for the HTTP server.
 type Web struct {
-	HTTP           string         `json:"http"`
-	HTTPS          string         `json:"https"`
-	Headers        Headers        `json:"headers"`
-	TLSCert        string         `json:"tlsCert"`
-	TLSKey         string         `json:"tlsKey"`
-	TLSMinVersion  string         `json:"tlsMinVersion"`
-	TLSMaxVersion  string         `json:"tlsMaxVersion"`
-	AllowedOrigins []string       `json:"allowedOrigins"`
-	AllowedHeaders []string       `json:"allowedHeaders"`
-	ClientRemoteIP ClientRemoteIP `json:"clientRemoteIP"`
+	HTTP                    string         `json:"http"`
+	HTTPS                   string         `json:"https"`
+	Headers                 Headers        `json:"headers"`
+	TLSCert                 string         `json:"tlsCert"`
+	TLSKey                  string         `json:"tlsKey"`
+	TLSMinVersion           string         `json:"tlsMinVersion"`
+	TLSMaxVersion           string         `json:"tlsMaxVersion"`
+	AllowedTLSCiphers       []string       `json:"allowedTLSCiphers"`
+	AllowedOrigins          []string       `json:"allowedOrigins"`
+	AllowedHeaders          []string       `json:"allowedHeaders"`
+	ClientRemoteIP          ClientRemoteIP `json:"clientRemoteIP"`
+	AllowedCurvePreferences []tls.CurveID  `json:"allowedCurvePreferences"`
 }
 
 type ClientRemoteIP struct {

--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -269,12 +269,43 @@ type Web struct {
 	AllowedOrigins          []string       `json:"allowedOrigins"`
 	AllowedHeaders          []string       `json:"allowedHeaders"`
 	ClientRemoteIP          ClientRemoteIP `json:"clientRemoteIP"`
-	AllowedCurvePreferences []tls.CurveID  `json:"allowedCurvePreferences"`
+	AllowedCurvePreferences []string       `json:"allowedCurvePreferences"`
+}
+
+var allowedCurveNames = map[string]tls.CurveID{
+	"SecP256r1MLKEM768":  tls.SecP256r1MLKEM768,
+	"SecP384r1MLKEM1024": tls.SecP384r1MLKEM1024,
+	"P256":               tls.CurveP256,
+	"P384":               tls.CurveP384,
+	"P521":               tls.CurveP521,
+	"CurveP256":          tls.CurveP256,
+	"CurveP384":          tls.CurveP384,
+	"CurveP521":          tls.CurveP521,
+	"X25519":             tls.X25519,
+	"P-256":              tls.CurveP256,
+	"P-384":              tls.CurveP384,
+	"P-521":              tls.CurveP521,
 }
 
 type ClientRemoteIP struct {
 	Header         string   `json:"header"`
 	TrustedProxies []string `json:"trustedProxies"`
+}
+
+func parseCurvePreferences(names []string) ([]tls.CurveID, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+	curves := make([]tls.CurveID, 0, len(names))
+	for _, name := range names {
+		if id, ok := allowedCurveNames[name]; ok {
+			curves = append(curves, id)
+		} else {
+			return nil, fmt.Errorf("unknown curve: %q (supported: %v)",
+				name, mapKeys(allowedCurveNames))
+		}
+	}
+	return curves, nil
 }
 
 func (cr *ClientRemoteIP) ParseTrustedProxies() ([]netip.Prefix, error) {

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -552,12 +552,25 @@ func runServe(options serveOptions) error {
 		if c.Web.TLSMaxVersion != "" {
 			tlsMaxVersion = allowedTLSVersions[c.Web.TLSMaxVersion]
 		}
+		allowedTLSCiphers := allowedTLSCiphers
+		if len(c.Web.AllowedTLSCiphers) > 0 {
+			ciphers, err := parseCipherSuites(c.Web.AllowedTLSCiphers)
+			if err != nil {
+				return fmt.Errorf("invalid TLS cipher suites: %w", err)
+			}
+			allowedTLSCiphers = ciphers
+		}
+		var CurvePreferences []tls.CurveID
+		if len(c.Web.AllowedCurvePreferences) > 0 {
+			CurvePreferences = c.Web.AllowedCurvePreferences
+		}
 
 		baseTLSConfig := &tls.Config{
 			MinVersion:               uint16(tlsMinVersion),
 			MaxVersion:               uint16(tlsMaxVersion),
 			CipherSuites:             allowedTLSCiphers,
 			PreferServerCipherSuites: true,
+			CurvePreferences:         CurvePreferences,
 		}
 
 		tlsConfig, err := newTLSReloader(logger, c.Web.TLSCert, c.Web.TLSKey, "", baseTLSConfig)
@@ -618,6 +631,26 @@ func runServe(options serveOptions) error {
 		logger.Info("shutdown now", "err", err)
 	}
 	return nil
+}
+
+// parseCipherSuites parses a list of cipher suite names and returns their corresponding IDs.
+func parseCipherSuites(names []string) ([]uint16, error) {
+	cipherMap := make(map[string]uint16)
+	for _, cs := range tls.CipherSuites() {
+		cipherMap[cs.Name] = cs.ID
+	}
+	for _, cs := range tls.InsecureCipherSuites() {
+		cipherMap[cs.Name] = cs.ID
+	}
+	ids := make([]uint16, 0, len(names))
+	for _, name := range names {
+		id, ok := cipherMap[name]
+		if !ok {
+			return nil, fmt.Errorf("unsupported cipher suite %q", name)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
 }
 
 func applyConfigOverrides(options serveOptions, config *Config) {

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -552,25 +552,29 @@ func runServe(options serveOptions) error {
 		if c.Web.TLSMaxVersion != "" {
 			tlsMaxVersion = allowedTLSVersions[c.Web.TLSMaxVersion]
 		}
-		allowedTLSCiphers := allowedTLSCiphers
+		cipherSuites := allowedTLSCiphers
 		if len(c.Web.AllowedTLSCiphers) > 0 {
 			ciphers, err := parseCipherSuites(c.Web.AllowedTLSCiphers)
 			if err != nil {
 				return fmt.Errorf("invalid TLS cipher suites: %w", err)
 			}
-			allowedTLSCiphers = ciphers
+			cipherSuites = ciphers
 		}
-		var CurvePreferences []tls.CurveID
+		curvePreferences := []tls.CurveID(nil)
 		if len(c.Web.AllowedCurvePreferences) > 0 {
-			CurvePreferences = c.Web.AllowedCurvePreferences
+			curves, err := parseCurvePreferences(c.Web.AllowedCurvePreferences)
+			if err != nil {
+				return fmt.Errorf("invalid TLS curve preferences: %w", err)
+			}
+			curvePreferences = curves
 		}
 
 		baseTLSConfig := &tls.Config{
 			MinVersion:               uint16(tlsMinVersion),
 			MaxVersion:               uint16(tlsMaxVersion),
-			CipherSuites:             allowedTLSCiphers,
+			CipherSuites:             cipherSuites,
 			PreferServerCipherSuites: true,
-			CurvePreferences:         CurvePreferences,
+			CurvePreferences:         curvePreferences,
 		}
 
 		tlsConfig, err := newTLSReloader(logger, c.Web.TLSCert, c.Web.TLSKey, "", baseTLSConfig)

--- a/cmd/dex/serve_test.go
+++ b/cmd/dex/serve_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"crypto/tls"
 	"log/slog"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,4 +29,76 @@ func TestNewLogger(t *testing.T) {
 		require.Equal(t, "log format is not one of the supported values (json, text): gofmt", err.Error())
 		require.Equal(t, (*slog.Logger)(nil), logger)
 	})
+}
+
+func TestParseCipherSuites(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []string
+		wantErr     bool
+		errContains string
+		validate    func(t *testing.T, got []uint16)
+	}{
+		{
+			name:    "empty input",
+			input:   []string{},
+			wantErr: false,
+			validate: func(t *testing.T, got []uint16) {
+				assert.Empty(t, got)
+			},
+		},
+		{
+			name:    "single valid cipher",
+			input:   []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+			wantErr: false,
+			validate: func(t *testing.T, got []uint16) {
+				require.Len(t, got, 1)
+				assert.Equal(t, tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, got[0])
+			},
+		},
+		{
+			name: "multiple valid ciphers",
+			input: []string{
+				"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+			},
+			wantErr: false,
+			validate: func(t *testing.T, got []uint16) {
+				require.Len(t, got, 2)
+				assert.Equal(t, tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, got[0])
+				assert.Equal(t, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, got[1])
+			},
+		},
+		{
+			name:    "insecure cipher",
+			input:   []string{"TLS_RSA_WITH_3DES_EDE_CBC_SHA"},
+			wantErr: false,
+			validate: func(t *testing.T, got []uint16) {
+				require.Len(t, got, 1)
+				assert.Equal(t, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA, got[0])
+			},
+		},
+		{
+			name:        "unsupported cipher",
+			input:       []string{"TLS_FAKE_CIPHER"},
+			wantErr:     true,
+			errContains: `unsupported cipher suite "TLS_FAKE_CIPHER"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCipherSuites(tt.input)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.True(t, strings.Contains(err.Error(), tt.errContains))
+				assert.Nil(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			tt.validate(t, got)
+		})
+	}
 }


### PR DESCRIPTION
#### Overview

TLS Ciphersuites are hardcoded currently, to meet the platform side compliance ciphersuites needs to be configureable, so made changes for tls ciphersuites and curve preferences to be configurable for web.

#### What this PR does / why we need it
Configures the tls ciphersuites and curvepreferences based on the parameters in config.yaml

Fixes: https://github.com/dexidp/dex/issues/4913