### PR TITLE
fix(server): harden several auth-surface security findings

### DIFF
--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -591,6 +591,18 @@ func runServe(options serveOptions) error {
 	if c.GRPC.Addr != "" {
 		logger.Info("listening on", "server", "grpc", "address", c.GRPC.Addr)
 
+		if c.GRPC.TLSClientCA == "" {
+			// The gRPC API grants full administrative access (client secret reads,
+			// password/connector/identity CRUD). Its only built-in caller
+			// authentication is mutual TLS via grpc.tlsClientCA; without it, anyone
+			// who can reach the port controls the identity provider. This is a valid
+			// setup only when a trusted front-facing service authenticates callers.
+			logger.Warn("grpc: API server has no client certificate authentication (grpc.tlsClientCA is unset); "+
+				"it exposes full administrative access. Ensure the port is only reachable by an authenticated, trusted service, "+
+				"or set grpc.tlsClientCA to require mutual TLS.",
+				"tls", c.GRPC.TLSCert != "")
+		}
+
 		grpcListener, err := net.Listen("tcp", c.GRPC.Addr)
 		if err != nil {
 			return fmt.Errorf("listening (grpc) on %s: %w", c.GRPC.Addr, err)

--- a/server/apiserver/connectors.go
+++ b/server/apiserver/connectors.go
@@ -18,6 +18,10 @@ func (d dexAPI) CreateConnector(ctx context.Context, req *api.CreateConnectorReq
 		return nil, fmt.Errorf("%s feature flag is not enabled", featureflags.APIConnectorsCRUD.Name)
 	}
 
+	if req.Connector == nil {
+		return nil, errors.New("no connector supplied")
+	}
+
 	if req.Connector.Id == "" {
 		return nil, errors.New("no id supplied")
 	}

--- a/server/authflow/password.go
+++ b/server/authflow/password.go
@@ -22,7 +22,7 @@ func (h *Handler) handlePasswordLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	backLink := r.URL.Query().Get("back")
+	backLink := sanitizeBackLink(r.URL.Query().Get("back"))
 
 	authReq, err := h.Storage.GetAuthRequest(ctx, authID)
 	if err != nil {
@@ -129,6 +129,29 @@ func (h *Handler) handlePasswordLogin(w http.ResponseWriter, r *http.Request) {
 	default:
 		h.renderError(r, w, http.StatusBadRequest, "Unsupported request method.")
 	}
+}
+
+// sanitizeBackLink permits only a same-origin absolute path as the "Select
+// another login method" target. The legitimate value is always a rooted path
+// built from the issuer path (see login.go), so anything that could redirect
+// off-origin — an absolute URL, a scheme-relative "//host" or "/\host" that
+// browsers treat as protocol-relative, or a value that fails to parse — is
+// dropped rather than rendered as a link (open-redirect prevention).
+func sanitizeBackLink(back string) string {
+	if back == "" {
+		return ""
+	}
+	u, err := url.Parse(back)
+	if err != nil || u.IsAbs() || u.Host != "" {
+		return ""
+	}
+	if back[0] != '/' {
+		return ""
+	}
+	if len(back) >= 2 && (back[1] == '/' || back[1] == '\\') {
+		return ""
+	}
+	return back
 }
 
 // Check for username prompt override from connector. Defaults to "Username".

--- a/server/authflow/password_test.go
+++ b/server/authflow/password_test.go
@@ -1,0 +1,23 @@
+package authflow
+
+import "testing"
+
+func TestSanitizeBackLink(t *testing.T) {
+	tests := map[string]string{
+		"":                            "",
+		"/auth?prompt=select_account": "/auth?prompt=select_account",
+		"/dex/auth?client_id=x":       "/dex/auth?client_id=x",
+		"https://evil.example":        "",
+		"http://evil.example/auth":    "",
+		"//evil.example":              "",
+		"/\\evil.example":             "",
+		"javascript:alert(1)":         "",
+		"relative/path":               "", // not rooted
+		"/auth#frag":                  "/auth#frag",
+	}
+	for in, want := range tests {
+		if got := sanitizeBackLink(in); got != want {
+			t.Errorf("sanitizeBackLink(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/server/device/device.go
+++ b/server/device/device.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -361,7 +362,9 @@ func (h *Handler) completeDeviceAuthorization(w http.ResponseWriter, r *http.Req
 		}
 		return "", &deviceFlowError{status: http.StatusUnauthorized, code: oauth2.InvalidClient, message: "Invalid client credentials."}
 	}
-	if client.Secret != deviceReq.ClientSecret {
+	// Constant-time comparison of the client secret, matching grants.go's client
+	// authentication, so the compare does not leak the secret via timing.
+	if subtle.ConstantTimeCompare([]byte(client.Secret), []byte(deviceReq.ClientSecret)) != 1 {
 		return "", &deviceFlowError{status: http.StatusUnauthorized, code: oauth2.InvalidClient, message: "Invalid client credentials."}
 	}
 

--- a/server/home/home.go
+++ b/server/home/home.go
@@ -2,7 +2,6 @@ package home
 
 import (
 	"context"
-	"crypto/subtle"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -10,7 +9,6 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/dexidp/dex/server/internal"
 	"github.com/dexidp/dex/server/router"
 	"github.com/dexidp/dex/server/session"
 	"github.com/dexidp/dex/server/templates"
@@ -25,8 +23,9 @@ type Handler struct {
 	Storage   storage.Storage
 	Templates *templates.Templates
 	Logger    *slog.Logger
-	// SessionConfig holds cookie settings; nil when sessions are disabled.
-	SessionConfig *session.Config
+	// Sessions is the shared session manager; nil (or with a nil Config) when
+	// sessions are disabled.
+	Sessions *session.Manager
 }
 
 // Mount registers the landing-page route.
@@ -41,7 +40,7 @@ func (h *Handler) renderError(r *http.Request, w http.ResponseWriter, status int
 }
 
 func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
-	if h.SessionConfig == nil || !h.Templates.HasHome() {
+	if h.Sessions == nil || h.Sessions.Config == nil || !h.Templates.HasHome() {
 		h.handleInline(w, r)
 		return
 	}
@@ -56,18 +55,14 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 		LogoutURL:    logoutURL.String(),
 	}
 
-	if cookie, err := r.Cookie(h.SessionConfig.CookieName); err == nil && cookie.Value != "" {
-		if userID, connectorID, nonce, err := internal.ParseSessionCookie(cookie.Value, h.SessionConfig.CookieEncryptionKey); err == nil {
-			session, err := h.Storage.GetAuthSession(ctx, userID, connectorID)
-			if err == nil && subtle.ConstantTimeCompare([]byte(session.Nonce), []byte(nonce)) == 1 {
-				data.LoggedIn = true
-				data.IPAddress = session.IPAddress
-				data.UserAgent = session.UserAgent
-				h.populateData(ctx, &data, userID, connectorID)
-			} else if err != nil && !errors.Is(err, storage.ErrNotFound) {
-				h.Logger.ErrorContext(ctx, "home: failed to get auth session", "err", err)
-			}
-		}
+	// ValidSession enforces the nonce AND absolute/idle expiry (clearing an
+	// expired session), so an expired-but-not-yet-purged cookie no longer renders
+	// a logged-in page.
+	if session := h.Sessions.ValidSession(ctx, w, r); session != nil {
+		data.LoggedIn = true
+		data.IPAddress = session.IPAddress
+		data.UserAgent = session.UserAgent
+		h.populateData(ctx, &data, session.UserID, session.ConnectorID)
 	}
 
 	if err := h.Templates.Home(r, w, data); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -592,11 +592,11 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 			Connectors:       s.connectors,
 		},
 		&home.Handler{
-			IssuerURL:     s.issuerURL,
-			Storage:       s.storage,
-			Templates:     s.templates,
-			Logger:        s.logger,
-			SessionConfig: s.sessionConfig,
+			IssuerURL: s.issuerURL,
+			Storage:   s.storage,
+			Templates: s.templates,
+			Logger:    s.logger,
+			Sessions:  sessions,
 		},
 		&authflow.Handler{
 			IssuerURL:              s.issuerURL,

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -323,13 +323,20 @@ func (m *Manager) UpdateTokenIssuedAt(r *http.Request, clientID string) {
 		return
 	}
 
-	userID, connectorID, _, err := internal.ParseSessionCookie(cookie.Value, m.Config.CookieEncryptionKey)
+	userID, connectorID, nonce, err := internal.ParseSessionCookie(cookie.Value, m.Config.CookieEncryptionKey)
 	if err != nil {
 		return
 	}
 
 	now := m.Now()
 	_ = m.Storage.UpdateAuthSession(r.Context(), userID, connectorID, func(old storage.AuthSession) (storage.AuthSession, error) {
+		// Verify the cookie's nonce against the stored session, as every other
+		// session-trusting path does: a stale cookie for a superseded session
+		// must not refresh the current session's idle timeout. Abort the update
+		// (leaving the session untouched) on mismatch.
+		if subtle.ConstantTimeCompare([]byte(old.Nonce), []byte(nonce)) != 1 {
+			return old, errors.New("session nonce mismatch")
+		}
 		old.LastActivity = now
 		old.IdleExpiry = now.Add(m.Config.ValidIfNotUsedFor)
 		if cs, ok := old.ClientStates[clientID]; ok {

--- a/server/tokens/refresh_lookup.go
+++ b/server/tokens/refresh_lookup.go
@@ -2,6 +2,7 @@ package tokens
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -42,11 +43,14 @@ func LookupRefreshToken(ctx context.Context, s storage.Storage, strategy *Refres
 		return nil, ErrRefreshTokenClaimedByOtherClient
 	}
 
-	if refresh.Token != token.Token {
+	// Constant-time comparison of the token secret: introspection reaches this
+	// path unauthenticated, so a byte-by-byte '!=' would leak the secret via
+	// timing. Matches the client-secret/nonce comparisons elsewhere in the server.
+	if subtle.ConstantTimeCompare([]byte(refresh.Token), []byte(token.Token)) != 1 {
 		switch {
 		case !strategy.AllowedToReuse(refresh.LastUsed):
 			fallthrough
-		case refresh.ObsoleteToken != token.Token:
+		case subtle.ConstantTimeCompare([]byte(refresh.ObsoleteToken), []byte(token.Token)) != 1:
 			fallthrough
 		case refresh.ObsoleteToken == "":
 			logger.ErrorContext(ctx, "refresh token claimed twice", "token_id", refresh.ID)


### PR DESCRIPTION
#### Overview

Hardening fixes for a handful of security findings in the `server` package, surfaced during a review of the OAuth2/OIDC request-handling surface. No behavior change for well-formed requests; each fix closes a small misuse or timing/authorization gap.

#### What this PR does / why we need it

- **device callback:** compare the client secret with `crypto/subtle.ConstantTimeCompare`, matching the client auth in `grants`, instead of a byte-by-byte `!=`.
- **refresh lookup:** constant-time compare of the refresh-token secret. This path is reachable unauthenticated via `/token/introspect`, so a plain `!=` is a timing side channel on the token secret.
- **session:** verify the cookie nonce in `UpdateTokenIssuedAt` before bumping the idle timeout, so a stale cookie for a superseded session can no longer keep it alive (every other session-trusting path already checks the nonce).
- **home:** route the landing page through `session.Manager.ValidSession` so absolute/idle expiry is enforced (and expired sessions cleared), rather than trusting only the nonce — an expired-but-not-purged cookie no longer renders a logged-in page.
- **authflow:** validate the password page `back` query parameter to a same-origin rooted path, dropping absolute URLs and protocol-relative `//host` / `/\host` forms, to prevent an open redirect on the "Select another login method" link.
- **apiserver:** nil-guard `CreateConnector` on an omitted connector field, mirroring the existing `CreateClient` check, instead of panicking.
- **serve:** log a warning when the gRPC API listens without `grpc.tlsClientCA`. The config is valid (auth may be terminated by a trusted front-facing service), but the privileged API otherwise has no built-in caller authentication, so the risk is now surfaced to operators.

#### Special notes for your reviewer

A unit test covers the `back`-parameter sanitizer; the other fixes are exercised by the existing package tests. No new dependencies.
