### PR TITLE
fix(device): bind device-callback auth code to its request and stop leaking client_secret

### DIFF
--- a/server/device/device.go
+++ b/server/device/device.go
@@ -282,7 +282,11 @@ func (h *Handler) verifyUserCode(w http.ResponseWriter, r *http.Request) {
 	u.Path = path.Join(u.Path, "/auth")
 	q := u.Query()
 	q.Set("client_id", deviceRequest.ClientID)
-	q.Set("client_secret", deviceRequest.ClientSecret)
+	// Do not put client_secret in this browser redirect: /auth is the
+	// authorization endpoint and never consumes it, so it would only leak the
+	// confidential secret into browser history, Referer, and access logs. The
+	// client is authenticated later in completeDeviceAuthorization against the
+	// stored device request.
 	q.Set("state", deviceRequest.UserCode)
 	q.Set("response_type", "code")
 	q.Set("redirect_uri", path.Join(h.IssuerURL.Path, oauth2.DeviceCallbackURI))
@@ -351,6 +355,19 @@ func (h *Handler) completeDeviceAuthorization(w http.ResponseWriter, r *http.Req
 			status = http.StatusInternalServerError
 		}
 		return "", &deviceFlowError{status: status, message: "Invalid or expired user code."}
+	}
+
+	// Bind the auth code to this device request: it must have been minted for the
+	// same client and issued to the device callback redirect. The authorization_code
+	// grant enforces the same client/redirect binding (see grants/authcode.go); the
+	// device callback must not skip it, or a code minted for one client could be
+	// redeemed against another client's device request (cross-client token theft).
+	// The redirect is matched by suffix, mirroring how the auth flow recognizes the
+	// device callback, so an issuer path prefix does not matter.
+	if authCode.ClientID != deviceReq.ClientID || !strings.HasSuffix(authCode.RedirectURI, oauth2.DeviceCallbackURI) {
+		h.Logger.ErrorContext(ctx, "device callback: auth code does not match the device request",
+			"auth_code_client_id", authCode.ClientID, "device_client_id", deviceReq.ClientID)
+		return "", &deviceFlowError{status: http.StatusBadRequest, message: "Invalid or expired auth code."}
 	}
 
 	client, err := h.Storage.GetClient(ctx, deviceReq.ClientID)

--- a/server/device/device.go
+++ b/server/device/device.go
@@ -362,12 +362,13 @@ func (h *Handler) completeDeviceAuthorization(w http.ResponseWriter, r *http.Req
 	// grant enforces the same client/redirect binding (see grants/authcode.go); the
 	// device callback must not skip it, or a code minted for one client could be
 	// redeemed against another client's device request (cross-client token theft).
-	// The redirect is matched on its path suffix, mirroring how the auth flow
-	// recognizes the device callback, so an issuer path prefix does not matter; the
-	// path (not the raw string) is checked so a "/device/callback" in the query can
-	// not spoof it.
+	// The redirect is matched on its parsed path suffix, mirroring how the auth flow
+	// recognizes the device callback: the issuer path prefix does not matter, and a
+	// "/device/callback" in the query string can not spoof it. A value that fails to
+	// parse is not a valid device redirect.
 	redirectURL, err := url.Parse(authCode.RedirectURI)
-	if authCode.ClientID != deviceReq.ClientID || err != nil || !strings.HasSuffix(redirectURL.Path, oauth2.DeviceCallbackURI) {
+	validRedirect := err == nil && strings.HasSuffix(redirectURL.Path, oauth2.DeviceCallbackURI)
+	if authCode.ClientID != deviceReq.ClientID || !validRedirect {
 		h.Logger.ErrorContext(ctx, "device callback: auth code does not match the device request",
 			"auth_code_client_id", authCode.ClientID, "device_client_id", deviceReq.ClientID)
 		return "", &deviceFlowError{status: http.StatusBadRequest, message: "Invalid or expired auth code."}

--- a/server/device/device.go
+++ b/server/device/device.go
@@ -362,9 +362,12 @@ func (h *Handler) completeDeviceAuthorization(w http.ResponseWriter, r *http.Req
 	// grant enforces the same client/redirect binding (see grants/authcode.go); the
 	// device callback must not skip it, or a code minted for one client could be
 	// redeemed against another client's device request (cross-client token theft).
-	// The redirect is matched by suffix, mirroring how the auth flow recognizes the
-	// device callback, so an issuer path prefix does not matter.
-	if authCode.ClientID != deviceReq.ClientID || !strings.HasSuffix(authCode.RedirectURI, oauth2.DeviceCallbackURI) {
+	// The redirect is matched on its path suffix, mirroring how the auth flow
+	// recognizes the device callback, so an issuer path prefix does not matter; the
+	// path (not the raw string) is checked so a "/device/callback" in the query can
+	// not spoof it.
+	redirectURL, err := url.Parse(authCode.RedirectURI)
+	if authCode.ClientID != deviceReq.ClientID || err != nil || !strings.HasSuffix(redirectURL.Path, oauth2.DeviceCallbackURI) {
 		h.Logger.ErrorContext(ctx, "device callback: auth code does not match the device request",
 			"auth_code_client_id", authCode.ClientID, "device_client_id", deviceReq.ClientID)
 		return "", &deviceFlowError{status: http.StatusBadRequest, message: "Invalid or expired auth code."}

--- a/server/server_device_callback_test.go
+++ b/server/server_device_callback_test.go
@@ -170,6 +170,39 @@ func TestDeviceCallback(t *testing.T) {
 			expectedResponseCode: http.StatusBadRequest,
 		},
 		{
+			// Same client, but the code was minted for a non-device-callback
+			// redirect: the redirect binding must reject it.
+			testName: "Auth code from a different redirect",
+			values:   baseFormValues,
+			testAuthCode: storage.AuthCode{
+				ID:          "somecode",
+				ClientID:    "testclient",
+				RedirectURI: "https://example.com/callback",
+				Scopes:      []string{"openid", "profile", "email"},
+				ConnectorID: "mock",
+				Expiry:      now().Add(5 * time.Minute),
+			},
+			testDeviceRequest:    baseDeviceRequest,
+			expectedResponseCode: http.StatusBadRequest,
+		},
+		{
+			// The redirect path is not the device callback; only the query string
+			// ends with "/device/callback". Matching on the raw string would be
+			// spoofed here, so the path is what must be checked.
+			testName: "Auth code redirect spoofed via query string",
+			values:   baseFormValues,
+			testAuthCode: storage.AuthCode{
+				ID:          "somecode",
+				ClientID:    "testclient",
+				RedirectURI: "https://example.com/callback?next=/device/callback",
+				Scopes:      []string{"openid", "profile", "email"},
+				ConnectorID: "mock",
+				Expiry:      now().Add(5 * time.Minute),
+			},
+			testDeviceRequest:    baseDeviceRequest,
+			expectedResponseCode: http.StatusBadRequest,
+		},
+		{
 			testName:     "Bad Device Request Secret",
 			values:       baseFormValues,
 			testAuthCode: baseAuthCode,

--- a/server/server_device_callback_test.go
+++ b/server/server_device_callback_test.go
@@ -154,16 +154,20 @@ func TestDeviceCallback(t *testing.T) {
 			expectedResponseCode: http.StatusBadRequest,
 		},
 		{
-			testName:     "Bad Device Request Client",
+			// The device request names a different client than the auth code was
+			// minted for: the client/redirect binding must reject it (cross-client
+			// auth code injection guard) before any client lookup.
+			testName:     "Cross-client auth code injection",
 			values:       baseFormValues,
 			testAuthCode: baseAuthCode,
 			testDeviceRequest: storage.DeviceRequest{
 				UserCode:   "XXXX-XXXX",
 				DeviceCode: "devicecode",
+				ClientID:   "otherclient",
 				Scopes:     []string{"openid", "profile", "email"},
 				Expiry:     now().Add(5 * time.Minute),
 			},
-			expectedResponseCode: http.StatusUnauthorized,
+			expectedResponseCode: http.StatusBadRequest,
 		},
 		{
 			testName:     "Bad Device Request Secret",
@@ -172,6 +176,7 @@ func TestDeviceCallback(t *testing.T) {
 			testDeviceRequest: storage.DeviceRequest{
 				UserCode:     "XXXX-XXXX",
 				DeviceCode:   "devicecode",
+				ClientID:     "testclient",
 				ClientSecret: "foobar",
 				Scopes:       []string{"openid", "profile", "email"},
 				Expiry:       now().Add(5 * time.Minute),


### PR DESCRIPTION
#### Overview

Two security fixes in the device authorization callback (`server/device`). Separate from the other server hardening PR.

#### What this PR does / why we need it

- **Cross-client auth code injection:** the device callback exchanged the authorization code without verifying it was minted for the same client and issued to the device-callback redirect. A code obtained for one client could be redeemed against a different client's device request, and the attacker's polling device would then receive the victim's tokens. We now bind the code to the device request's `client_id` and redirect (suffix-matched, like the auth flow already recognizes the device callback) before exchanging — the same binding the `authorization_code` grant enforces.
- **client_secret leak in redirect:** `verifyUserCode` copied the confidential `client_secret` into the `/auth` redirect URL, exposing it in browser history, `Referer`, and access logs. The `/auth` authorization endpoint never consumes it — the client is authenticated later against the stored device request — so it is dropped from the redirect.

#### Special notes for your reviewer

The device-callback test gains a cross-client injection case; the former "bad client" case is sharpened to isolate the client-binding check, and the "bad secret" case now sets a matching `client_id` so it actually reaches the secret comparison.
