### PR TITLE
refactor(server): slim the Server and dedupe issuer-URL helpers

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/dexidp/dex/pkg/featureflags"
 	"github.com/dexidp/dex/server"
+	"github.com/dexidp/dex/server/connectors"
 	"github.com/dexidp/dex/server/signer"
 	"github.com/dexidp/dex/storage"
 	"github.com/dexidp/dex/storage/ent"
@@ -557,8 +558,8 @@ type Connector struct {
 	Name string `json:"name"`
 	ID   string `json:"id"`
 
-	Config     server.ConnectorConfig `json:"config"`
-	GrantTypes []string               `json:"grantTypes"`
+	Config     connectors.ConnectorConfig `json:"config"`
+	GrantTypes []string                   `json:"grantTypes"`
 }
 
 // UnmarshalJSON allows Connector to implement the unmarshaler interface to

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -609,7 +609,7 @@ func runServe(options serveOptions) error {
 		}
 
 		grpcSrv := grpc.NewServer(grpcOptions...)
-		api.RegisterDexServer(grpcSrv, apiserver.NewAPI(serverConfig.Storage, logger, version, serv.Connectors(), serv.ConstructDiscovery))
+		api.RegisterDexServer(grpcSrv, apiserver.NewAPI(serverConfig.Storage, logger, version, serv.Connectors(), serv.Discovery()))
 
 		grpcMetrics.InitializeMetrics(grpcSrv)
 		if c.GRPC.Reflection {

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -279,9 +279,9 @@ func runServe(options serveOptions) error {
 
 	if c.EnablePasswordDB {
 		storageConnectors = append(storageConnectors, storage.Connector{
-			ID:   server.LocalConnector,
+			ID:   connectors.LocalConnector,
 			Name: "Email",
-			Type: server.LocalConnector,
+			Type: connectors.LocalConnector,
 		})
 		logger.Info("config connector: local passwords enabled")
 	}

--- a/server/apiserver/api.go
+++ b/server/apiserver/api.go
@@ -20,15 +20,16 @@ const apiVersion = 4
 
 // NewAPI returns a server which implements the gRPC API interface. It takes only
 // the narrow dependencies it needs — the connector cache to invalidate on
-// connector CRUD, and a discovery-document builder — rather than the whole Server.
-func NewAPI(s storage.Storage, logger *slog.Logger, version string, conns *connectors.Cache, discovery func(context.Context) discovery.Document) api.DexServer {
+// connector CRUD, and the discovery handler to serve the same document as HTTP —
+// rather than the whole Server.
+func NewAPI(s storage.Storage, logger *slog.Logger, version string, conns *connectors.Cache, disc *discovery.Handler) api.DexServer {
 	apiLogger := logger.With("component", "api")
 	return dexAPI{
 		s:          s,
 		logger:     apiLogger,
 		version:    version,
 		connectors: conns,
-		discovery:  discovery,
+		discovery:  disc,
 		refresh:    tokens.NewRefreshStore(s, time.Now, apiLogger),
 	}
 }
@@ -40,7 +41,7 @@ type dexAPI struct {
 	logger     *slog.Logger
 	version    string
 	connectors *connectors.Cache
-	discovery  func(context.Context) discovery.Document
+	discovery  *discovery.Handler
 	refresh    *tokens.RefreshStore
 }
 
@@ -52,7 +53,7 @@ func (d dexAPI) GetVersion(ctx context.Context, req *api.VersionReq) (*api.Versi
 }
 
 func (d dexAPI) GetDiscovery(ctx context.Context, req *api.DiscoveryReq) (*api.DiscoveryResp, error) {
-	discoveryDoc := d.discovery(ctx)
+	discoveryDoc := d.discovery.Construct(ctx)
 	data, err := json.Marshal(discoveryDoc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal discovery data: %v", err)

--- a/server/apiserver/api.go
+++ b/server/apiserver/api.go
@@ -53,6 +53,9 @@ func (d dexAPI) GetVersion(ctx context.Context, req *api.VersionReq) (*api.Versi
 }
 
 func (d dexAPI) GetDiscovery(ctx context.Context, req *api.DiscoveryReq) (*api.DiscoveryResp, error) {
+	if d.discovery == nil {
+		return nil, fmt.Errorf("discovery is not configured")
+	}
 	discoveryDoc := d.discovery.Construct(ctx)
 	data, err := json.Marshal(discoveryDoc)
 	if err != nil {

--- a/server/authflow/authorize.go
+++ b/server/authflow/authorize.go
@@ -94,7 +94,7 @@ func (h *Handler) handleAuthorization(w http.ResponseWriter, r *http.Request) {
 	if connectorID != "" {
 		for _, c := range connectors {
 			if c.ID == connectorID {
-				connURL.Path = h.absPath("/auth", url.PathEscape(c.ID))
+				connURL.Path = h.IssuerURL.AbsPath("/auth", url.PathEscape(c.ID))
 				http.Redirect(w, r, connURL.String(), http.StatusFound)
 				return
 			}
@@ -104,7 +104,7 @@ func (h *Handler) handleAuthorization(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(connectors) == 1 && !h.AlwaysShowLogin {
-		connURL.Path = h.absPath("/auth", url.PathEscape(connectors[0].ID))
+		connURL.Path = h.IssuerURL.AbsPath("/auth", url.PathEscape(connectors[0].ID))
 		http.Redirect(w, r, connURL.String(), http.StatusFound)
 		return
 	}
@@ -140,7 +140,7 @@ func (h *Handler) handleAuthorization(w http.ResponseWriter, r *http.Request) {
 					if c.ID != session.ConnectorID {
 						continue
 					}
-					connURL.Path = h.absPath("/auth", url.PathEscape(session.ConnectorID))
+					connURL.Path = h.IssuerURL.AbsPath("/auth", url.PathEscape(session.ConnectorID))
 					http.Redirect(w, r, connURL.String(), http.StatusFound)
 					return
 				}
@@ -155,7 +155,7 @@ func (h *Handler) handleAuthorization(w http.ResponseWriter, r *http.Request) {
 
 	connectorInfos := make([]templates.ConnectorInfo, 0, len(connectors))
 	for _, conn := range connectors {
-		connURL.Path = h.absPath("/auth", url.PathEscape(conn.ID))
+		connURL.Path = h.IssuerURL.AbsPath("/auth", url.PathEscape(conn.ID))
 		connectorInfos = append(connectorInfos, templates.ConnectorInfo{
 			ID:   conn.ID,
 			Name: conn.Name,

--- a/server/authflow/handler.go
+++ b/server/authflow/handler.go
@@ -3,11 +3,11 @@ package authflow
 import (
 	"log/slog"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
 	"github.com/dexidp/dex/server/connectors"
+	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/router"
 	"github.com/dexidp/dex/server/session"
 	"github.com/dexidp/dex/server/signer"
@@ -24,7 +24,7 @@ import (
 // reference to the MFA or consent handlers; each step only redirects back to
 // /auth, never to another step.
 type Handler struct {
-	IssuerURL              url.URL
+	IssuerURL              oauth2.IssuerURL
 	Connectors             *connectors.Cache
 	Storage                storage.Storage
 	Templates              *templates.Templates

--- a/server/authflow/handler_test.go
+++ b/server/authflow/handler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dexidp/dex/server/consent"
 	"github.com/dexidp/dex/server/logout"
 	"github.com/dexidp/dex/server/mfa"
+	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/session"
 	"github.com/dexidp/dex/server/signer"
 	"github.com/dexidp/dex/server/templates"
@@ -107,7 +108,7 @@ func newTestHandler(t *testing.T, updateConfig func(c *testFlowConfig)) (*httpte
 
 	tc := testFlowConfig{
 		Handler: Handler{
-			IssuerURL:              *issuerURL,
+			IssuerURL:              oauth2.IssuerURL{URL: *issuerURL},
 			Connectors:             conns,
 			Storage:                store,
 			Templates:              tmpls,
@@ -126,10 +127,10 @@ func newTestHandler(t *testing.T, updateConfig func(c *testFlowConfig)) (*httpte
 
 	// Assemble the flow the same way the server does: shared infrastructure plus
 	// independent step handlers that hand off by redirect.
-	sessions := &session.Manager{Storage: store, Config: tc.SessionConfig, Now: now, Logger: logger, IssuerURL: *issuerURL}
-	mfaManager := &mfa.Handler{IssuerURL: *issuerURL, Storage: store, Templates: tmpls, Logger: logger, MFAProviders: tc.MFAProviders, DefaultMFAChain: tc.DefaultMFAChain, Now: now, Connectors: conns}
-	consentManager := &consent.Handler{IssuerURL: *issuerURL, Storage: store, Templates: tmpls, Logger: logger, Sessions: sessions, SkipApproval: tc.SkipApproval}
-	logoutManager := &logout.Handler{Storage: store, Templates: tmpls, Logger: logger, Sessions: sessions, Connectors: conns, Issuer: issuer, Signer: sig, IssuerURL: *issuerURL}
+	sessions := &session.Manager{Storage: store, Config: tc.SessionConfig, Now: now, Logger: logger, IssuerURL: oauth2.IssuerURL{URL: *issuerURL}}
+	mfaManager := &mfa.Handler{IssuerURL: oauth2.IssuerURL{URL: *issuerURL}, Storage: store, Templates: tmpls, Logger: logger, MFAProviders: tc.MFAProviders, DefaultMFAChain: tc.DefaultMFAChain, Now: now, Connectors: conns}
+	consentManager := &consent.Handler{IssuerURL: oauth2.IssuerURL{URL: *issuerURL}, Storage: store, Templates: tmpls, Logger: logger, Sessions: sessions, SkipApproval: tc.SkipApproval}
+	logoutManager := &logout.Handler{Storage: store, Templates: tmpls, Logger: logger, Sessions: sessions, Connectors: conns, Issuer: issuer, Signer: sig, IssuerURL: oauth2.IssuerURL{URL: *issuerURL}}
 
 	tc.Sessions = sessions
 	tc.Issuer = issuer

--- a/server/authflow/login.go
+++ b/server/authflow/login.go
@@ -149,7 +149,7 @@ func (h *Handler) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 			backLinkParams.Set("prompt", "select_account")
 		}
 		backLinkURL := url.URL{
-			Path:     h.absPath("/auth"),
+			Path:     h.IssuerURL.AbsPath("/auth"),
 			RawQuery: backLinkParams.Encode(),
 		}
 		backLink = backLinkURL.String()
@@ -162,7 +162,7 @@ func (h *Handler) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 			// Use the auth request ID as the "state" token.
 			//
 			// TODO(ericchiang): Is this appropriate or should we also be using a nonce?
-			callbackURL, connData, err := conn.LoginURL(scopes, h.absURL("/callback"), authReq.ID)
+			callbackURL, connData, err := conn.LoginURL(scopes, h.IssuerURL.AbsURL("/callback"), authReq.ID)
 			if err != nil {
 				h.Logger.ErrorContext(r.Context(), "connector returned error when creating callback", "connector_id", connID, "err", err)
 				h.renderError(r, w, http.StatusInternalServerError, "Login error.")
@@ -183,7 +183,7 @@ func (h *Handler) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, callbackURL, http.StatusFound)
 		case connector.PasswordConnector:
 			loginURL := url.URL{
-				Path: h.absPath("/auth", connID, "login"),
+				Path: h.IssuerURL.AbsPath("/auth", connID, "login"),
 			}
 			q := loginURL.Query()
 			q.Set("state", authReq.ID)

--- a/server/authflow/render.go
+++ b/server/authflow/render.go
@@ -2,7 +2,6 @@ package authflow
 
 import (
 	"net/http"
-	"path"
 )
 
 // renderError renders a user-facing HTML error page.
@@ -10,16 +9,4 @@ func (h *Handler) renderError(r *http.Request, w http.ResponseWriter, status int
 	if err := h.Templates.Err(r, w, status, description); err != nil {
 		h.Logger.ErrorContext(r.Context(), "server template error", "err", err)
 	}
-}
-
-// absPath returns the issuer path joined with the given path items.
-func (h *Handler) absPath(pathItems ...string) string {
-	return path.Join(append([]string{h.IssuerURL.Path}, pathItems...)...)
-}
-
-// absURL returns the absolute issuer URL for the given path items.
-func (h *Handler) absURL(pathItems ...string) string {
-	u := h.IssuerURL
-	u.Path = h.absPath(pathItems...)
-	return u.String()
 }

--- a/server/authflow/request.go
+++ b/server/authflow/request.go
@@ -215,7 +215,7 @@ func (h *Handler) parseAuthorizationRequest(r *http.Request) (*storage.AuthReque
 		return nil, "", newDisplayedErr(http.StatusBadRequest, "Unregistered redirect_uri.")
 	}
 	if redirectURI == oauth2.DeviceCallbackURI && client.Public {
-		redirectURI = h.absPath(oauth2.DeviceCallbackURI)
+		redirectURI = h.IssuerURL.AbsPath(oauth2.DeviceCallbackURI)
 	}
 
 	// From here on out, we want to redirect back to the client with an error.

--- a/server/authflow/request_test.go
+++ b/server/authflow/request_test.go
@@ -774,7 +774,7 @@ func TestValidateIDTokenHint(t *testing.T) {
 
 	s := &Handler{
 		Signer:    sig,
-		IssuerURL: *issuerURL,
+		IssuerURL: oauth2.IssuerURL{URL: *issuerURL},
 		Logger:    slog.Default(),
 	}
 

--- a/server/authflow/sessionlogin_test.go
+++ b/server/authflow/sessionlogin_test.go
@@ -46,10 +46,10 @@ func newTestSessionServer(t *testing.T) *sessionTestServer {
 		Storage:   memory.New(nil),
 		Now:       func() time.Time { return now },
 		Logger:    slog.Default(),
-		IssuerURL: *issuerURL,
+		IssuerURL: oauth2.IssuerURL{URL: *issuerURL},
 	}
 	h.Connectors = connectors.NewCache(h.Storage, testResolveConnector)
-	h.Sessions = &session.Manager{Storage: h.Storage, Config: sessionCfg, Now: h.Now, Logger: slog.Default(), IssuerURL: *issuerURL}
+	h.Sessions = &session.Manager{Storage: h.Storage, Config: sessionCfg, Now: h.Now, Logger: slog.Default(), IssuerURL: oauth2.IssuerURL{URL: *issuerURL}}
 	return &sessionTestServer{Handler: h}
 }
 
@@ -2151,5 +2151,5 @@ func TestRememberMeDefault(t *testing.T) {
 // resetSessions rebuilds the Handler's session manager with the given config and
 // issuer, for tests that exercise Manager behavior under a different config.
 func resetSessions(s *sessionTestServer, cfg *session.Config, issuer url.URL) {
-	s.Sessions = &session.Manager{Storage: s.Storage, Config: cfg, Now: s.Now, Logger: slog.Default(), IssuerURL: issuer}
+	s.Sessions = &session.Manager{Storage: s.Storage, Config: cfg, Now: s.Now, Logger: slog.Default(), IssuerURL: oauth2.IssuerURL{URL: issuer}}
 }

--- a/server/authflow/urls.go
+++ b/server/authflow/urls.go
@@ -13,7 +13,7 @@ func (h *Handler) buildContinueURL(authReq storage.AuthRequest) string {
 	v := url.Values{}
 	v.Set("req", authReq.ID)
 	v.Set("hmac", internal.ComputeHMAC(authReq.HMACKey, authReq.ID, "continue"))
-	return h.absPath("/auth") + "?" + v.Encode()
+	return h.IssuerURL.AbsPath("/auth") + "?" + v.Encode()
 }
 
 // buildMFAURL builds the HMAC-protected URL of the MFA entry, where the
@@ -24,7 +24,7 @@ func (h *Handler) buildMFAURL(authReq storage.AuthRequest) string {
 	v := url.Values{}
 	v.Set("req", authReq.ID)
 	v.Set("hmac", internal.ComputeHMAC(authReq.HMACKey, authReq.ID, "mfa"))
-	return h.absPath("/mfa") + "?" + v.Encode()
+	return h.IssuerURL.AbsPath("/mfa") + "?" + v.Encode()
 }
 
 // buildApprovalURL builds the HMAC-protected URL of the consent screen, where the
@@ -33,5 +33,5 @@ func (h *Handler) buildApprovalURL(authReq storage.AuthRequest) string {
 	v := url.Values{}
 	v.Set("req", authReq.ID)
 	v.Set("hmac", internal.ComputeHMAC(authReq.HMACKey, authReq.ID, "approval"))
-	return h.absPath("/approval") + "?" + v.Encode()
+	return h.IssuerURL.AbsPath("/approval") + "?" + v.Encode()
 }

--- a/server/connector.go
+++ b/server/connector.go
@@ -1,15 +1,6 @@
 package server
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"log/slog"
-
-	"golang.org/x/crypto/bcrypt"
-
-	"github.com/dexidp/dex/connector"
 	"github.com/dexidp/dex/connector/atlassiancrowd"
 	"github.com/dexidp/dex/connector/authproxy"
 	"github.com/dexidp/dex/connector/bitbucketcloud"
@@ -27,21 +18,20 @@ import (
 	"github.com/dexidp/dex/connector/openshift"
 	"github.com/dexidp/dex/connector/saml"
 	"github.com/dexidp/dex/server/connectors"
-	"github.com/dexidp/dex/server/passwords"
-	"github.com/dexidp/dex/storage"
 )
 
-// LocalConnector is the local passwordDB connector which is an internal
-// connector maintained by the server.
-const LocalConnector = "local"
+// ConnectorConfig is a configuration that can open a connector. The resolution
+// machinery lives in the connectors package; this alias is kept for callers of
+// the server package.
+type ConnectorConfig = connectors.ConnectorConfig
 
-// ConnectorConfig is a configuration that can open a connector.
-type ConnectorConfig interface {
-	Open(id string, logger *slog.Logger) (connector.Connector, error)
-}
+// LocalConnector is the built-in local password-DB connector type, re-exported
+// from the connectors package.
+const LocalConnector = connectors.LocalConnector
 
-// ConnectorsConfig variable provides an easy way to return a config struct
-// depending on the connector type.
+// ConnectorsConfig maps each built-in connector type to its config factory. It
+// is handed to connectors.Resolver so the connectors package itself imports no
+// connector implementation; a library consumer can pass a different map.
 var ConnectorsConfig = map[string]func() ConnectorConfig{
 	"keystone":        func() ConnectorConfig { return new(keystone.Config) },
 	"mockCallback":    func() ConnectorConfig { return new(mock.CallbackConfig) },
@@ -62,126 +52,4 @@ var ConnectorsConfig = map[string]func() ConnectorConfig{
 	"atlassian-crowd": func() ConnectorConfig { return new(atlassiancrowd.Config) },
 	// Keep around for backwards compatibility.
 	"samlExperimental": func() ConnectorConfig { return new(saml.Config) },
-}
-
-// connectorResolver returns the resolver the connector cache uses to build the
-// underlying implementation for a stored connector: the built-in local password
-// DB (backed by storage), or a configured connector from ConnectorsConfig. It
-// captures only storage and a logger, so connector construction does not depend
-// on the Server.
-func connectorResolver(store storage.Storage, logger *slog.Logger) connectors.ResolveFunc {
-	return func(conn storage.Connector) (connector.Connector, error) {
-		if conn.Type == LocalConnector {
-			return newPasswordDB(store), nil
-		}
-		return openConnector(logger, conn)
-	}
-}
-
-// openConnector will parse the connector config and open the connector.
-func openConnector(logger *slog.Logger, conn storage.Connector) (connector.Connector, error) {
-	var c connector.Connector
-
-	f, ok := ConnectorsConfig[conn.Type]
-	if !ok {
-		return c, fmt.Errorf("unknown connector type %q", conn.Type)
-	}
-
-	connConfig := f()
-	if len(conn.Config) != 0 {
-		data := []byte(string(conn.Config))
-		if err := json.Unmarshal(data, connConfig); err != nil {
-			return c, fmt.Errorf("parse connector config: %v", err)
-		}
-	}
-
-	c, err := connConfig.Open(conn.ID, logger)
-	if err != nil {
-		return c, fmt.Errorf("failed to create connector %s: %v", conn.ID, err)
-	}
-
-	return c, nil
-}
-
-func newPasswordDB(s storage.Storage) interface {
-	connector.Connector
-	connector.PasswordConnector
-} {
-	return passwordDB{s}
-}
-
-type passwordDB struct {
-	s storage.Storage
-}
-
-func resolvePasswordName(p storage.Password) string {
-	if p.Name != "" {
-		return p.Name
-	}
-	return p.Username
-}
-
-func resolvePasswordEmailVerified(p storage.Password) bool {
-	if p.EmailVerified != nil {
-		return *p.EmailVerified
-	}
-	return true
-}
-
-func (db passwordDB) Login(ctx context.Context, s connector.Scopes, email, password string) (connector.Identity, bool, error) {
-	p, err := db.s.GetPassword(ctx, email)
-	if err != nil {
-		if err != storage.ErrNotFound {
-			return connector.Identity{}, false, fmt.Errorf("get password: %v", err)
-		}
-		return connector.Identity{}, false, nil
-	}
-	// This check prevents dex users from logging in using static passwords
-	// configured with hash costs that are too high or low.
-	if err := passwords.CheckCost(p.Hash); err != nil {
-		return connector.Identity{}, false, err
-	}
-	if err := bcrypt.CompareHashAndPassword(p.Hash, []byte(password)); err != nil {
-		return connector.Identity{}, false, nil
-	}
-	return connector.Identity{
-		UserID:            p.UserID,
-		Username:          resolvePasswordName(p),
-		PreferredUsername: p.PreferredUsername,
-		Email:             p.Email,
-		EmailVerified:     resolvePasswordEmailVerified(p),
-		Groups:            p.Groups,
-	}, true, nil
-}
-
-func (db passwordDB) Refresh(ctx context.Context, s connector.Scopes, identity connector.Identity) (connector.Identity, error) {
-	// If the user has been deleted, the refresh token will be rejected.
-	p, err := db.s.GetPassword(ctx, identity.Email)
-	if err != nil {
-		if err == storage.ErrNotFound {
-			return connector.Identity{}, errors.New("user not found")
-		}
-		return connector.Identity{}, fmt.Errorf("get password: %v", err)
-	}
-
-	// User removed but a new user with the same email exists.
-	if p.UserID != identity.UserID {
-		return connector.Identity{}, errors.New("user not found")
-	}
-
-	// If a user has updated their username, that will be reflected in the
-	// refreshed token.
-	//
-	// No other fields are expected to be refreshable as email is effectively used
-	// as an ID.
-	identity.Username = resolvePasswordName(p)
-	identity.PreferredUsername = p.PreferredUsername
-	identity.EmailVerified = resolvePasswordEmailVerified(p)
-	identity.Groups = p.Groups
-
-	return identity, nil
-}
-
-func (db passwordDB) Prompt() string {
-	return "Email Address"
 }

--- a/server/connector.go
+++ b/server/connector.go
@@ -1,0 +1,187 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/dexidp/dex/connector"
+	"github.com/dexidp/dex/connector/atlassiancrowd"
+	"github.com/dexidp/dex/connector/authproxy"
+	"github.com/dexidp/dex/connector/bitbucketcloud"
+	"github.com/dexidp/dex/connector/gitea"
+	"github.com/dexidp/dex/connector/github"
+	"github.com/dexidp/dex/connector/gitlab"
+	"github.com/dexidp/dex/connector/google"
+	"github.com/dexidp/dex/connector/keystone"
+	"github.com/dexidp/dex/connector/ldap"
+	"github.com/dexidp/dex/connector/linkedin"
+	"github.com/dexidp/dex/connector/microsoft"
+	"github.com/dexidp/dex/connector/mock"
+	"github.com/dexidp/dex/connector/oauth"
+	"github.com/dexidp/dex/connector/oidc"
+	"github.com/dexidp/dex/connector/openshift"
+	"github.com/dexidp/dex/connector/saml"
+	"github.com/dexidp/dex/server/connectors"
+	"github.com/dexidp/dex/server/passwords"
+	"github.com/dexidp/dex/storage"
+)
+
+// LocalConnector is the local passwordDB connector which is an internal
+// connector maintained by the server.
+const LocalConnector = "local"
+
+// ConnectorConfig is a configuration that can open a connector.
+type ConnectorConfig interface {
+	Open(id string, logger *slog.Logger) (connector.Connector, error)
+}
+
+// ConnectorsConfig variable provides an easy way to return a config struct
+// depending on the connector type.
+var ConnectorsConfig = map[string]func() ConnectorConfig{
+	"keystone":        func() ConnectorConfig { return new(keystone.Config) },
+	"mockCallback":    func() ConnectorConfig { return new(mock.CallbackConfig) },
+	"mockPassword":    func() ConnectorConfig { return new(mock.PasswordConfig) },
+	"ldap":            func() ConnectorConfig { return new(ldap.Config) },
+	"gitea":           func() ConnectorConfig { return new(gitea.Config) },
+	"github":          func() ConnectorConfig { return new(github.Config) },
+	"gitlab":          func() ConnectorConfig { return new(gitlab.Config) },
+	"google":          func() ConnectorConfig { return new(google.Config) },
+	"oidc":            func() ConnectorConfig { return new(oidc.Config) },
+	"oauth":           func() ConnectorConfig { return new(oauth.Config) },
+	"saml":            func() ConnectorConfig { return new(saml.Config) },
+	"authproxy":       func() ConnectorConfig { return new(authproxy.Config) },
+	"linkedin":        func() ConnectorConfig { return new(linkedin.Config) },
+	"microsoft":       func() ConnectorConfig { return new(microsoft.Config) },
+	"bitbucket-cloud": func() ConnectorConfig { return new(bitbucketcloud.Config) },
+	"openshift":       func() ConnectorConfig { return new(openshift.Config) },
+	"atlassian-crowd": func() ConnectorConfig { return new(atlassiancrowd.Config) },
+	// Keep around for backwards compatibility.
+	"samlExperimental": func() ConnectorConfig { return new(saml.Config) },
+}
+
+// connectorResolver returns the resolver the connector cache uses to build the
+// underlying implementation for a stored connector: the built-in local password
+// DB (backed by storage), or a configured connector from ConnectorsConfig. It
+// captures only storage and a logger, so connector construction does not depend
+// on the Server.
+func connectorResolver(store storage.Storage, logger *slog.Logger) connectors.ResolveFunc {
+	return func(conn storage.Connector) (connector.Connector, error) {
+		if conn.Type == LocalConnector {
+			return newPasswordDB(store), nil
+		}
+		return openConnector(logger, conn)
+	}
+}
+
+// openConnector will parse the connector config and open the connector.
+func openConnector(logger *slog.Logger, conn storage.Connector) (connector.Connector, error) {
+	var c connector.Connector
+
+	f, ok := ConnectorsConfig[conn.Type]
+	if !ok {
+		return c, fmt.Errorf("unknown connector type %q", conn.Type)
+	}
+
+	connConfig := f()
+	if len(conn.Config) != 0 {
+		data := []byte(string(conn.Config))
+		if err := json.Unmarshal(data, connConfig); err != nil {
+			return c, fmt.Errorf("parse connector config: %v", err)
+		}
+	}
+
+	c, err := connConfig.Open(conn.ID, logger)
+	if err != nil {
+		return c, fmt.Errorf("failed to create connector %s: %v", conn.ID, err)
+	}
+
+	return c, nil
+}
+
+func newPasswordDB(s storage.Storage) interface {
+	connector.Connector
+	connector.PasswordConnector
+} {
+	return passwordDB{s}
+}
+
+type passwordDB struct {
+	s storage.Storage
+}
+
+func resolvePasswordName(p storage.Password) string {
+	if p.Name != "" {
+		return p.Name
+	}
+	return p.Username
+}
+
+func resolvePasswordEmailVerified(p storage.Password) bool {
+	if p.EmailVerified != nil {
+		return *p.EmailVerified
+	}
+	return true
+}
+
+func (db passwordDB) Login(ctx context.Context, s connector.Scopes, email, password string) (connector.Identity, bool, error) {
+	p, err := db.s.GetPassword(ctx, email)
+	if err != nil {
+		if err != storage.ErrNotFound {
+			return connector.Identity{}, false, fmt.Errorf("get password: %v", err)
+		}
+		return connector.Identity{}, false, nil
+	}
+	// This check prevents dex users from logging in using static passwords
+	// configured with hash costs that are too high or low.
+	if err := passwords.CheckCost(p.Hash); err != nil {
+		return connector.Identity{}, false, err
+	}
+	if err := bcrypt.CompareHashAndPassword(p.Hash, []byte(password)); err != nil {
+		return connector.Identity{}, false, nil
+	}
+	return connector.Identity{
+		UserID:            p.UserID,
+		Username:          resolvePasswordName(p),
+		PreferredUsername: p.PreferredUsername,
+		Email:             p.Email,
+		EmailVerified:     resolvePasswordEmailVerified(p),
+		Groups:            p.Groups,
+	}, true, nil
+}
+
+func (db passwordDB) Refresh(ctx context.Context, s connector.Scopes, identity connector.Identity) (connector.Identity, error) {
+	// If the user has been deleted, the refresh token will be rejected.
+	p, err := db.s.GetPassword(ctx, identity.Email)
+	if err != nil {
+		if err == storage.ErrNotFound {
+			return connector.Identity{}, errors.New("user not found")
+		}
+		return connector.Identity{}, fmt.Errorf("get password: %v", err)
+	}
+
+	// User removed but a new user with the same email exists.
+	if p.UserID != identity.UserID {
+		return connector.Identity{}, errors.New("user not found")
+	}
+
+	// If a user has updated their username, that will be reflected in the
+	// refreshed token.
+	//
+	// No other fields are expected to be refreshable as email is effectively used
+	// as an ID.
+	identity.Username = resolvePasswordName(p)
+	identity.PreferredUsername = p.PreferredUsername
+	identity.EmailVerified = resolvePasswordEmailVerified(p)
+	identity.Groups = p.Groups
+
+	return identity, nil
+}
+
+func (db passwordDB) Prompt() string {
+	return "Email Address"
+}

--- a/server/connector.go
+++ b/server/connector.go
@@ -20,36 +20,27 @@ import (
 	"github.com/dexidp/dex/server/connectors"
 )
 
-// ConnectorConfig is a configuration that can open a connector. The resolution
-// machinery lives in the connectors package; this alias is kept for callers of
-// the server package.
-type ConnectorConfig = connectors.ConnectorConfig
-
-// LocalConnector is the built-in local password-DB connector type, re-exported
-// from the connectors package.
-const LocalConnector = connectors.LocalConnector
-
 // ConnectorsConfig maps each built-in connector type to its config factory. It
 // is handed to connectors.Resolver so the connectors package itself imports no
 // connector implementation; a library consumer can pass a different map.
-var ConnectorsConfig = map[string]func() ConnectorConfig{
-	"keystone":        func() ConnectorConfig { return new(keystone.Config) },
-	"mockCallback":    func() ConnectorConfig { return new(mock.CallbackConfig) },
-	"mockPassword":    func() ConnectorConfig { return new(mock.PasswordConfig) },
-	"ldap":            func() ConnectorConfig { return new(ldap.Config) },
-	"gitea":           func() ConnectorConfig { return new(gitea.Config) },
-	"github":          func() ConnectorConfig { return new(github.Config) },
-	"gitlab":          func() ConnectorConfig { return new(gitlab.Config) },
-	"google":          func() ConnectorConfig { return new(google.Config) },
-	"oidc":            func() ConnectorConfig { return new(oidc.Config) },
-	"oauth":           func() ConnectorConfig { return new(oauth.Config) },
-	"saml":            func() ConnectorConfig { return new(saml.Config) },
-	"authproxy":       func() ConnectorConfig { return new(authproxy.Config) },
-	"linkedin":        func() ConnectorConfig { return new(linkedin.Config) },
-	"microsoft":       func() ConnectorConfig { return new(microsoft.Config) },
-	"bitbucket-cloud": func() ConnectorConfig { return new(bitbucketcloud.Config) },
-	"openshift":       func() ConnectorConfig { return new(openshift.Config) },
-	"atlassian-crowd": func() ConnectorConfig { return new(atlassiancrowd.Config) },
+var ConnectorsConfig = map[string]func() connectors.ConnectorConfig{
+	"keystone":        func() connectors.ConnectorConfig { return new(keystone.Config) },
+	"mockCallback":    func() connectors.ConnectorConfig { return new(mock.CallbackConfig) },
+	"mockPassword":    func() connectors.ConnectorConfig { return new(mock.PasswordConfig) },
+	"ldap":            func() connectors.ConnectorConfig { return new(ldap.Config) },
+	"gitea":           func() connectors.ConnectorConfig { return new(gitea.Config) },
+	"github":          func() connectors.ConnectorConfig { return new(github.Config) },
+	"gitlab":          func() connectors.ConnectorConfig { return new(gitlab.Config) },
+	"google":          func() connectors.ConnectorConfig { return new(google.Config) },
+	"oidc":            func() connectors.ConnectorConfig { return new(oidc.Config) },
+	"oauth":           func() connectors.ConnectorConfig { return new(oauth.Config) },
+	"saml":            func() connectors.ConnectorConfig { return new(saml.Config) },
+	"authproxy":       func() connectors.ConnectorConfig { return new(authproxy.Config) },
+	"linkedin":        func() connectors.ConnectorConfig { return new(linkedin.Config) },
+	"microsoft":       func() connectors.ConnectorConfig { return new(microsoft.Config) },
+	"bitbucket-cloud": func() connectors.ConnectorConfig { return new(bitbucketcloud.Config) },
+	"openshift":       func() connectors.ConnectorConfig { return new(openshift.Config) },
+	"atlassian-crowd": func() connectors.ConnectorConfig { return new(atlassiancrowd.Config) },
 	// Keep around for backwards compatibility.
-	"samlExperimental": func() ConnectorConfig { return new(saml.Config) },
+	"samlExperimental": func() connectors.ConnectorConfig { return new(saml.Config) },
 }

--- a/server/connectors/password.go
+++ b/server/connectors/password.go
@@ -1,0 +1,99 @@
+package connectors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/dexidp/dex/connector"
+	"github.com/dexidp/dex/server/passwords"
+	"github.com/dexidp/dex/storage"
+)
+
+// NewPasswordDB returns the built-in local password connector backed by the
+// password store. Resolver uses it for LocalConnector; it is exported so a
+// custom ResolveFunc can reuse it.
+func NewPasswordDB(s storage.Storage) interface {
+	connector.Connector
+	connector.PasswordConnector
+} {
+	return passwordDB{s}
+}
+
+type passwordDB struct {
+	s storage.Storage
+}
+
+func resolvePasswordName(p storage.Password) string {
+	if p.Name != "" {
+		return p.Name
+	}
+	return p.Username
+}
+
+func resolvePasswordEmailVerified(p storage.Password) bool {
+	if p.EmailVerified != nil {
+		return *p.EmailVerified
+	}
+	return true
+}
+
+func (db passwordDB) Login(ctx context.Context, s connector.Scopes, email, password string) (connector.Identity, bool, error) {
+	p, err := db.s.GetPassword(ctx, email)
+	if err != nil {
+		if err != storage.ErrNotFound {
+			return connector.Identity{}, false, fmt.Errorf("get password: %v", err)
+		}
+		return connector.Identity{}, false, nil
+	}
+	// This check prevents dex users from logging in using static passwords
+	// configured with hash costs that are too high or low.
+	if err := passwords.CheckCost(p.Hash); err != nil {
+		return connector.Identity{}, false, err
+	}
+	if err := bcrypt.CompareHashAndPassword(p.Hash, []byte(password)); err != nil {
+		return connector.Identity{}, false, nil
+	}
+	return connector.Identity{
+		UserID:            p.UserID,
+		Username:          resolvePasswordName(p),
+		PreferredUsername: p.PreferredUsername,
+		Email:             p.Email,
+		EmailVerified:     resolvePasswordEmailVerified(p),
+		Groups:            p.Groups,
+	}, true, nil
+}
+
+func (db passwordDB) Refresh(ctx context.Context, s connector.Scopes, identity connector.Identity) (connector.Identity, error) {
+	// If the user has been deleted, the refresh token will be rejected.
+	p, err := db.s.GetPassword(ctx, identity.Email)
+	if err != nil {
+		if err == storage.ErrNotFound {
+			return connector.Identity{}, errors.New("user not found")
+		}
+		return connector.Identity{}, fmt.Errorf("get password: %v", err)
+	}
+
+	// User removed but a new user with the same email exists.
+	if p.UserID != identity.UserID {
+		return connector.Identity{}, errors.New("user not found")
+	}
+
+	// If a user has updated their username, that will be reflected in the
+	// refreshed token.
+	//
+	// No other fields are expected to be refreshable as email is effectively used
+	// as an ID.
+	identity.Username = resolvePasswordName(p)
+	identity.PreferredUsername = p.PreferredUsername
+	identity.EmailVerified = resolvePasswordEmailVerified(p)
+	identity.Groups = p.Groups
+
+	return identity, nil
+}
+
+func (db passwordDB) Prompt() string {
+	return "Email Address"
+}

--- a/server/connectors/resolve.go
+++ b/server/connectors/resolve.go
@@ -1,0 +1,149 @@
+package connectors
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/dexidp/dex/connector"
+	"github.com/dexidp/dex/server/passwords"
+	"github.com/dexidp/dex/storage"
+)
+
+// LocalConnector is the local passwordDB connector: an internal connector,
+// backed by the password store, that is not part of the injected config map.
+const LocalConnector = "local"
+
+// ConnectorConfig is a configuration that can open a connector.
+type ConnectorConfig interface {
+	Open(id string, logger *slog.Logger) (connector.Connector, error)
+}
+
+// Resolver returns a ResolveFunc that builds the underlying implementation for a
+// stored connector: the built-in local password DB (backed by storage), or a
+// connector from the given config map. The map is injected by the caller so this
+// package need not import any connector implementation — a library consumer can
+// pass its own set of connectors.
+func Resolver(store storage.Storage, logger *slog.Logger, configs map[string]func() ConnectorConfig) ResolveFunc {
+	return func(conn storage.Connector) (connector.Connector, error) {
+		if conn.Type == LocalConnector {
+			return NewPasswordDB(store), nil
+		}
+		return openConnector(logger, configs, conn)
+	}
+}
+
+// openConnector parses the stored config and opens the connector named by its type.
+func openConnector(logger *slog.Logger, configs map[string]func() ConnectorConfig, conn storage.Connector) (connector.Connector, error) {
+	var c connector.Connector
+
+	f, ok := configs[conn.Type]
+	if !ok {
+		return c, fmt.Errorf("unknown connector type %q", conn.Type)
+	}
+
+	connConfig := f()
+	if len(conn.Config) != 0 {
+		data := []byte(string(conn.Config))
+		if err := json.Unmarshal(data, connConfig); err != nil {
+			return c, fmt.Errorf("parse connector config: %v", err)
+		}
+	}
+
+	c, err := connConfig.Open(conn.ID, logger)
+	if err != nil {
+		return c, fmt.Errorf("failed to create connector %s: %v", conn.ID, err)
+	}
+
+	return c, nil
+}
+
+// NewPasswordDB returns the built-in local password connector backed by the
+// password store. Resolver uses it for LocalConnector; it is exported so a
+// custom ResolveFunc can reuse it.
+func NewPasswordDB(s storage.Storage) interface {
+	connector.Connector
+	connector.PasswordConnector
+} {
+	return passwordDB{s}
+}
+
+type passwordDB struct {
+	s storage.Storage
+}
+
+func resolvePasswordName(p storage.Password) string {
+	if p.Name != "" {
+		return p.Name
+	}
+	return p.Username
+}
+
+func resolvePasswordEmailVerified(p storage.Password) bool {
+	if p.EmailVerified != nil {
+		return *p.EmailVerified
+	}
+	return true
+}
+
+func (db passwordDB) Login(ctx context.Context, s connector.Scopes, email, password string) (connector.Identity, bool, error) {
+	p, err := db.s.GetPassword(ctx, email)
+	if err != nil {
+		if err != storage.ErrNotFound {
+			return connector.Identity{}, false, fmt.Errorf("get password: %v", err)
+		}
+		return connector.Identity{}, false, nil
+	}
+	// This check prevents dex users from logging in using static passwords
+	// configured with hash costs that are too high or low.
+	if err := passwords.CheckCost(p.Hash); err != nil {
+		return connector.Identity{}, false, err
+	}
+	if err := bcrypt.CompareHashAndPassword(p.Hash, []byte(password)); err != nil {
+		return connector.Identity{}, false, nil
+	}
+	return connector.Identity{
+		UserID:            p.UserID,
+		Username:          resolvePasswordName(p),
+		PreferredUsername: p.PreferredUsername,
+		Email:             p.Email,
+		EmailVerified:     resolvePasswordEmailVerified(p),
+		Groups:            p.Groups,
+	}, true, nil
+}
+
+func (db passwordDB) Refresh(ctx context.Context, s connector.Scopes, identity connector.Identity) (connector.Identity, error) {
+	// If the user has been deleted, the refresh token will be rejected.
+	p, err := db.s.GetPassword(ctx, identity.Email)
+	if err != nil {
+		if err == storage.ErrNotFound {
+			return connector.Identity{}, errors.New("user not found")
+		}
+		return connector.Identity{}, fmt.Errorf("get password: %v", err)
+	}
+
+	// User removed but a new user with the same email exists.
+	if p.UserID != identity.UserID {
+		return connector.Identity{}, errors.New("user not found")
+	}
+
+	// If a user has updated their username, that will be reflected in the
+	// refreshed token.
+	//
+	// No other fields are expected to be refreshable as email is effectively used
+	// as an ID.
+	identity.Username = resolvePasswordName(p)
+	identity.PreferredUsername = p.PreferredUsername
+	identity.EmailVerified = resolvePasswordEmailVerified(p)
+	identity.Groups = p.Groups
+
+	return identity, nil
+}
+
+func (db passwordDB) Prompt() string {
+	return "Email Address"
+}

--- a/server/connectors/resolve.go
+++ b/server/connectors/resolve.go
@@ -43,8 +43,7 @@ func openConnector(logger *slog.Logger, configs map[string]func() ConnectorConfi
 
 	connConfig := f()
 	if len(conn.Config) != 0 {
-		data := []byte(string(conn.Config))
-		if err := json.Unmarshal(data, connConfig); err != nil {
+		if err := json.Unmarshal(conn.Config, connConfig); err != nil {
 			return c, fmt.Errorf("parse connector config: %v", err)
 		}
 	}

--- a/server/connectors/resolve.go
+++ b/server/connectors/resolve.go
@@ -1,16 +1,11 @@
 package connectors
 
 import (
-	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 
-	"golang.org/x/crypto/bcrypt"
-
 	"github.com/dexidp/dex/connector"
-	"github.com/dexidp/dex/server/passwords"
 	"github.com/dexidp/dex/storage"
 )
 
@@ -60,90 +55,4 @@ func openConnector(logger *slog.Logger, configs map[string]func() ConnectorConfi
 	}
 
 	return c, nil
-}
-
-// NewPasswordDB returns the built-in local password connector backed by the
-// password store. Resolver uses it for LocalConnector; it is exported so a
-// custom ResolveFunc can reuse it.
-func NewPasswordDB(s storage.Storage) interface {
-	connector.Connector
-	connector.PasswordConnector
-} {
-	return passwordDB{s}
-}
-
-type passwordDB struct {
-	s storage.Storage
-}
-
-func resolvePasswordName(p storage.Password) string {
-	if p.Name != "" {
-		return p.Name
-	}
-	return p.Username
-}
-
-func resolvePasswordEmailVerified(p storage.Password) bool {
-	if p.EmailVerified != nil {
-		return *p.EmailVerified
-	}
-	return true
-}
-
-func (db passwordDB) Login(ctx context.Context, s connector.Scopes, email, password string) (connector.Identity, bool, error) {
-	p, err := db.s.GetPassword(ctx, email)
-	if err != nil {
-		if err != storage.ErrNotFound {
-			return connector.Identity{}, false, fmt.Errorf("get password: %v", err)
-		}
-		return connector.Identity{}, false, nil
-	}
-	// This check prevents dex users from logging in using static passwords
-	// configured with hash costs that are too high or low.
-	if err := passwords.CheckCost(p.Hash); err != nil {
-		return connector.Identity{}, false, err
-	}
-	if err := bcrypt.CompareHashAndPassword(p.Hash, []byte(password)); err != nil {
-		return connector.Identity{}, false, nil
-	}
-	return connector.Identity{
-		UserID:            p.UserID,
-		Username:          resolvePasswordName(p),
-		PreferredUsername: p.PreferredUsername,
-		Email:             p.Email,
-		EmailVerified:     resolvePasswordEmailVerified(p),
-		Groups:            p.Groups,
-	}, true, nil
-}
-
-func (db passwordDB) Refresh(ctx context.Context, s connector.Scopes, identity connector.Identity) (connector.Identity, error) {
-	// If the user has been deleted, the refresh token will be rejected.
-	p, err := db.s.GetPassword(ctx, identity.Email)
-	if err != nil {
-		if err == storage.ErrNotFound {
-			return connector.Identity{}, errors.New("user not found")
-		}
-		return connector.Identity{}, fmt.Errorf("get password: %v", err)
-	}
-
-	// User removed but a new user with the same email exists.
-	if p.UserID != identity.UserID {
-		return connector.Identity{}, errors.New("user not found")
-	}
-
-	// If a user has updated their username, that will be reflected in the
-	// refreshed token.
-	//
-	// No other fields are expected to be refreshable as email is effectively used
-	// as an ID.
-	identity.Username = resolvePasswordName(p)
-	identity.PreferredUsername = p.PreferredUsername
-	identity.EmailVerified = resolvePasswordEmailVerified(p)
-	identity.Groups = p.Groups
-
-	return identity, nil
-}
-
-func (db passwordDB) Prompt() string {
-	return "Email Address"
 }

--- a/server/consent/consent.go
+++ b/server/consent/consent.go
@@ -5,9 +5,9 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"path"
 
 	"github.com/dexidp/dex/server/internal"
+	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/router"
 	"github.com/dexidp/dex/server/session"
 	"github.com/dexidp/dex/server/templates"
@@ -23,7 +23,7 @@ type Handler struct {
 	Storage      storage.Storage
 	Templates    *templates.Templates
 	Logger       *slog.Logger
-	IssuerURL    url.URL
+	IssuerURL    oauth2.IssuerURL
 	Sessions     *session.Manager
 	SkipApproval bool
 }
@@ -33,11 +33,6 @@ func (h *Handler) renderError(r *http.Request, w http.ResponseWriter, status int
 	if err := h.Templates.Err(r, w, status, description); err != nil {
 		h.Logger.ErrorContext(r.Context(), "server template error", "err", err)
 	}
-}
-
-// absPath returns the issuer path joined with the given path items.
-func (h *Handler) absPath(pathItems ...string) string {
-	return path.Join(append([]string{h.IssuerURL.Path}, pathItems...)...)
 }
 
 // Mount registers the consent endpoint.
@@ -52,7 +47,7 @@ func (h *Handler) buildApprovedURL(authReq storage.AuthRequest) string {
 	v := url.Values{}
 	v.Set("req", authReq.ID)
 	v.Set("hmac", internal.ComputeHMAC(authReq.HMACKey, authReq.ID, "approved"))
-	return h.absPath("/auth") + "?" + v.Encode()
+	return h.IssuerURL.AbsPath("/auth") + "?" + v.Encode()
 }
 
 // Satisfied reports whether the approval screen can be skipped: the client did

--- a/server/device/device.go
+++ b/server/device/device.go
@@ -41,7 +41,7 @@ type DeviceCodeResponse struct {
 
 // Handler serves the browser side of the device authorization grant.
 type Handler struct {
-	IssuerURL        url.URL
+	IssuerURL        oauth2.IssuerURL
 	Storage          storage.Storage
 	Templates        *templates.Templates
 	Now              func() time.Time
@@ -95,7 +95,7 @@ func (h *Handler) renderError(r *http.Request, w http.ResponseWriter, status int
 }
 
 func (h *Handler) getDeviceVerificationURI() string {
-	return path.Join(h.IssuerURL.Path, "/device/auth/verify_code")
+	return h.IssuerURL.AbsPath("/device/auth/verify_code")
 }
 
 // handleDeviceExchange serves the /device user-code entry page.
@@ -290,7 +290,7 @@ func (h *Handler) verifyUserCode(w http.ResponseWriter, r *http.Request) {
 	// stored device request.
 	q.Set("state", deviceRequest.UserCode)
 	q.Set("response_type", "code")
-	q.Set("redirect_uri", path.Join(h.IssuerURL.Path, oauth2.DeviceCallbackURI))
+	q.Set("redirect_uri", h.IssuerURL.AbsPath(oauth2.DeviceCallbackURI))
 	q.Set("scope", strings.Join(deviceRequest.Scopes, " "))
 	u.RawQuery = q.Encode()
 

--- a/server/device/device_test.go
+++ b/server/device/device_test.go
@@ -4,8 +4,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/dexidp/dex/server/oauth2"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dexidp/dex/server/oauth2"
 )
 
 func TestGetDeviceVerificationURI(t *testing.T) {

--- a/server/device/device_test.go
+++ b/server/device/device_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/dexidp/dex/server/oauth2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -11,6 +12,6 @@ func TestGetDeviceVerificationURI(t *testing.T) {
 	u, err := url.Parse("https://dex.example.com/non-root-path")
 	require.NoError(t, err)
 
-	h := &Handler{IssuerURL: *u}
+	h := &Handler{IssuerURL: oauth2.IssuerURL{URL: *u}}
 	require.Equal(t, "/non-root-path/device/auth/verify_code", h.getDeviceVerificationURI())
 }

--- a/server/home/home.go
+++ b/server/home/home.go
@@ -6,9 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"net/url"
-	"path"
 
+	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/router"
 	"github.com/dexidp/dex/server/session"
 	"github.com/dexidp/dex/server/templates"
@@ -19,7 +18,7 @@ import (
 // is available it renders the rich page (with logged-in details); otherwise it
 // falls back to a minimal inline page.
 type Handler struct {
-	IssuerURL url.URL
+	IssuerURL oauth2.IssuerURL
 	Storage   storage.Storage
 	Templates *templates.Templates
 	Logger    *slog.Logger
@@ -47,12 +46,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
-	logoutURL := h.IssuerURL
-	logoutURL.Path = path.Join(logoutURL.Path, "/logout")
-
 	data := templates.HomeData{
 		DiscoveryURL: h.IssuerURL.JoinPath(".well-known", "openid-configuration").String(),
-		LogoutURL:    logoutURL.String(),
+		LogoutURL:    h.IssuerURL.AbsURL("/logout"),
 	}
 
 	// ValidSession enforces the nonce AND absolute/idle expiry (clearing an

--- a/server/logout/logout.go
+++ b/server/logout/logout.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"path"
 	"slices"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -15,6 +14,7 @@ import (
 	"github.com/dexidp/dex/connector"
 	"github.com/dexidp/dex/server/connectors"
 	"github.com/dexidp/dex/server/internal"
+	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/router"
 	"github.com/dexidp/dex/server/session"
 	"github.com/dexidp/dex/server/signer"
@@ -34,7 +34,7 @@ type Handler struct {
 	Connectors *connectors.Cache
 	Issuer     *tokens.Issuer
 	Signer     signer.Signer
-	IssuerURL  url.URL
+	IssuerURL  oauth2.IssuerURL
 }
 
 // renderError renders a user-facing HTML error page.
@@ -42,13 +42,6 @@ func (h *Handler) renderError(r *http.Request, w http.ResponseWriter, status int
 	if err := h.Templates.Err(r, w, status, description); err != nil {
 		h.Logger.ErrorContext(r.Context(), "server template error", "err", err)
 	}
-}
-
-// absURL returns the absolute issuer URL for the given path items.
-func (h *Handler) absURL(pathItems ...string) string {
-	u := h.IssuerURL
-	u.Path = path.Join(append([]string{h.IssuerURL.Path}, pathItems...)...)
-	return u.String()
 }
 
 // Mount registers the logout endpoints. Logout requires an active session, so it
@@ -322,7 +315,7 @@ func (h *Handler) tryUpstreamLogout(ctx context.Context, userID, connectorID, po
 		return "", false
 	}
 
-	callbackURI := h.absURL("/logout/callback")
+	callbackURI := h.IssuerURL.AbsURL("/logout/callback")
 	upstreamURL, err := logoutConn.LogoutURL(ctx, callbackURI)
 	if err != nil {
 		h.Logger.ErrorContext(ctx, "logout: upstream connector error", "err", err)

--- a/server/mfa/handler.go
+++ b/server/mfa/handler.go
@@ -6,11 +6,11 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"path"
 	"time"
 
 	"github.com/dexidp/dex/server/connectors"
 	"github.com/dexidp/dex/server/internal"
+	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/router"
 	"github.com/dexidp/dex/server/templates"
 	"github.com/dexidp/dex/storage"
@@ -39,7 +39,7 @@ type Handler struct {
 	Storage         storage.Storage
 	Templates       *templates.Templates
 	Logger          *slog.Logger
-	IssuerURL       url.URL
+	IssuerURL       oauth2.IssuerURL
 	MFAProviders    map[string]Provider
 	DefaultMFAChain []string
 	Now             func() time.Time
@@ -51,11 +51,6 @@ func (h *Handler) renderError(r *http.Request, w http.ResponseWriter, status int
 	if err := h.Templates.Err(r, w, status, description); err != nil {
 		h.Logger.ErrorContext(r.Context(), "server template error", "err", err)
 	}
-}
-
-// absPath returns the issuer path joined with the given path items.
-func (h *Handler) absPath(pathItems ...string) string {
-	return path.Join(append([]string{h.IssuerURL.Path}, pathItems...)...)
 }
 
 func (h *Handler) validateMFARequest(w http.ResponseWriter, r *http.Request) (*mfaRequestContext, bool) {
@@ -251,7 +246,7 @@ func (h *Handler) buildRedirectURL(authReq storage.AuthRequest, authenticatorID 
 	v.Set("req", authReq.ID)
 	v.Set("hmac", internal.ComputeHMAC(authReq.HMACKey, authReq.ID, authenticatorID))
 	v.Set("authenticator", authenticatorID)
-	return h.absPath(h.mfaPagePath(authenticatorID)) + "?" + v.Encode()
+	return h.IssuerURL.AbsPath(h.mfaPagePath(authenticatorID)) + "?" + v.Encode()
 }
 
 // buildContinueURL builds the HMAC-protected URL that returns to the authorize
@@ -260,7 +255,7 @@ func (h *Handler) buildContinueURL(authReq storage.AuthRequest) string {
 	v := url.Values{}
 	v.Set("req", authReq.ID)
 	v.Set("hmac", internal.ComputeHMAC(authReq.HMACKey, authReq.ID, "continue"))
-	return h.absPath("/auth") + "?" + v.Encode()
+	return h.IssuerURL.AbsPath("/auth") + "?" + v.Encode()
 }
 
 // Mount registers the MFA factor endpoints, only when at least one authenticator

--- a/server/mfa/handler_test.go
+++ b/server/mfa/handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dexidp/dex/connector/mock"
 	"github.com/dexidp/dex/server/connectors"
 	"github.com/dexidp/dex/server/internal"
+	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/templates"
 	"github.com/dexidp/dex/storage"
 	"github.com/dexidp/dex/storage/memory"
@@ -67,7 +68,7 @@ func newTestHandler(t *testing.T, providers map[string]Provider, defaultChain []
 		Storage:         store,
 		Templates:       tmpls,
 		Logger:          logger,
-		IssuerURL:       *issuerURL,
+		IssuerURL:       oauth2.IssuerURL{URL: *issuerURL},
 		MFAProviders:    providers,
 		DefaultMFAChain: defaultChain,
 		Now:             time.Now,

--- a/server/oauth2/issuer.go
+++ b/server/oauth2/issuer.go
@@ -1,0 +1,29 @@
+package oauth2
+
+import (
+	"net/url"
+	"path"
+)
+
+// IssuerURL is the dex issuer URL together with the helpers for building paths
+// and absolute URLs under its path. Handlers hold this instead of a bare
+// url.URL so the "join onto the issuer path" logic lives in one place rather
+// than being reimplemented per handler. The embedded url.URL keeps String,
+// JoinPath, Query, and the fields available directly.
+type IssuerURL struct {
+	url.URL
+}
+
+// AbsPath joins the given items onto the issuer path, e.g. issuer path "/dex"
+// plus "auth" gives "/dex/auth".
+func (i IssuerURL) AbsPath(items ...string) string {
+	return path.Join(append([]string{i.Path}, items...)...)
+}
+
+// AbsURL returns the absolute issuer URL with the given items joined onto its
+// path.
+func (i IssuerURL) AbsURL(items ...string) string {
+	u := i.URL
+	u.Path = i.AbsPath(items...)
+	return u.String()
+}

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -1,9 +1,17 @@
 package router
 
-import "net/http"
+import (
+	"net/http"
+	"path"
 
-// Mux registers HTTP routes. The server provides the implementation (path
-// prefixing, per-route headers, CORS); handlers only name their routes.
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
+
+	"github.com/dexidp/dex/server/reqctx"
+)
+
+// Mux registers HTTP routes. New returns the implementation used by the server
+// (path prefixing, per-route headers, CORS); handlers only name their routes.
 type Mux interface {
 	// Handle mounts h at pattern.
 	Handle(pattern string, h http.Handler)
@@ -20,4 +28,73 @@ type Mux interface {
 // Mux. The server collects handlers and calls Mount on each.
 type Handler interface {
 	Mount(Mux)
+}
+
+// Config configures the Mux returned by New.
+type Config struct {
+	// Router is the underlying gorilla router routes are registered on.
+	Router *mux.Router
+	// IssuerPath is prefixed onto every registered route.
+	IssuerPath string
+	// Headers are added to every response.
+	Headers http.Header
+	// RealIPHeader, when set, names the header the real client IP is read from.
+	RealIPHeader string
+	// Instrument wraps a handler with request metrics.
+	Instrument func(name string, h http.Handler) http.HandlerFunc
+	// RealIP extracts the client IP from a request.
+	RealIP func(*http.Request) (string, error)
+	// CORSOrigins / CORSHeaders configure HandleCORS; CORS is skipped when
+	// CORSOrigins is empty.
+	CORSOrigins []string
+	CORSHeaders []string
+}
+
+// New returns a Mux backed by the given config. Handle/HandleFunc/HandleCORS
+// prefix the route with the issuer path and wrap it with the response headers,
+// request-id/real-ip context, and instrumentation. HandlePrefix mounts static
+// asset trees directly (stripped of the prefix) without that wrapping.
+func New(c Config) Mux { return mountMux{c} }
+
+type mountMux struct{ c Config }
+
+// wrap applies the common response headers, request-id/real-ip context, and
+// instrumentation to a handler.
+func (m mountMux) wrap(name string, h http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		for k, v := range m.c.Headers {
+			w.Header()[k] = v
+		}
+		// Context values are used for logging purposes with the log/slog logger.
+		rCtx := reqctx.WithRequestID(r.Context())
+		if m.c.RealIPHeader != "" {
+			if realIP, err := m.c.RealIP(r); err == nil {
+				rCtx = reqctx.WithRemoteIP(rCtx, realIP)
+			}
+		}
+		m.c.Instrument(name, h)(w, r.WithContext(rCtx))
+	}
+}
+
+func (m mountMux) Handle(p string, h http.Handler) {
+	m.c.Router.Handle(path.Join(m.c.IssuerPath, p), m.wrap(p, h))
+}
+
+func (m mountMux) HandleFunc(p string, h http.HandlerFunc) { m.Handle(p, h) }
+
+func (m mountMux) HandlePrefix(p string, h http.Handler) {
+	prefix := path.Join(m.c.IssuerPath, p)
+	m.c.Router.PathPrefix(prefix).Handler(http.StripPrefix(prefix, h))
+}
+
+func (m mountMux) HandleCORS(p string, h http.HandlerFunc) {
+	var handler http.Handler = h
+	if len(m.c.CORSOrigins) > 0 {
+		cors := handlers.CORS(
+			handlers.AllowedOrigins(m.c.CORSOrigins),
+			handlers.AllowedHeaders(m.c.CORSHeaders),
+		)
+		handler = cors(handler)
+	}
+	m.Handle(p, handler)
 }

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -67,7 +67,7 @@ func (m mountMux) wrap(name string, h http.Handler) http.HandlerFunc {
 		}
 		// Context values are used for logging purposes with the log/slog logger.
 		rCtx := reqctx.WithRequestID(r.Context())
-		if m.c.RealIPHeader != "" {
+		if m.c.RealIPHeader != "" && m.c.RealIP != nil {
 			if realIP, err := m.c.RealIP(r); err == nil {
 				rCtx = reqctx.WithRemoteIP(rCtx, realIP)
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -309,7 +309,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		sessionConfig: c.SessionConfig,
 	}
 	s.issuer = tokens.NewIssuer(s.storage, c.Signer, s.issuerURL.URL, idTokensValidFor, now, s.logger)
-	s.connectors = connectors.NewCache(s.storage, connectorResolver(s.storage, s.logger))
+	s.connectors = connectors.NewCache(s.storage, connectors.Resolver(s.storage, s.logger, ConnectorsConfig))
 	// Build the discovery handler once from config; both the mounted HTTP route
 	// and the gRPC API (via Discovery) serve this same handler.
 	s.discovery = &discovery.Handler{

--- a/server/server.go
+++ b/server/server.go
@@ -200,18 +200,7 @@ type Server struct {
 
 	templates *templates.Templates
 
-	// If enabled, don't prompt user for approval after logging in through connector.
-	skipApproval bool
-
-	now func() time.Time
-
-	idTokensValidFor time.Duration
-
-	refreshTokenPolicy *tokens.RefreshStrategy
-
 	logger *slog.Logger
-
-	signer signer.Signer
 
 	// issuer turns an Authorization into a TokenSet.
 	issuer *tokens.Issuer
@@ -394,20 +383,16 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 
 	authRequestsValidFor := value(c.AuthRequestsValidFor, 24*time.Hour)
 	deviceRequestsValidFor := value(c.DeviceRequestsValidFor, 5*time.Minute)
+	idTokensValidFor := value(c.IDTokensValidFor, 24*time.Hour)
 
 	s := &Server{
-		issuerURL:          oauth2.IssuerURL{URL: *issuerURL},
-		storage:            newKeyCacher(c.Storage, now),
-		idTokensValidFor:   value(c.IDTokensValidFor, 24*time.Hour),
-		refreshTokenPolicy: c.RefreshTokenPolicy,
-		skipApproval:       c.SkipApprovalScreen,
-		now:                now,
-		templates:          tmpls,
-		logger:             c.Logger,
-		signer:             c.Signer,
-		sessionConfig:      c.SessionConfig,
+		issuerURL:     oauth2.IssuerURL{URL: *issuerURL},
+		storage:       newKeyCacher(c.Storage, now),
+		templates:     tmpls,
+		logger:        c.Logger,
+		sessionConfig: c.SessionConfig,
 	}
-	s.issuer = tokens.NewIssuer(s.storage, s.signer, s.issuerURL.URL, s.idTokensValidFor, s.now, s.logger)
+	s.issuer = tokens.NewIssuer(s.storage, c.Signer, s.issuerURL.URL, idTokensValidFor, now, s.logger)
 	s.connectors = connectors.NewCache(s.storage, s.resolveConnector)
 	// Build the discovery handler once from config; both the mounted HTTP route
 	// and the gRPC API's ConstructDiscovery serve this same handler.
@@ -415,7 +400,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		Issuer:          s.issuerURL.String(),
 		AbsURL:          s.issuerURL.AbsURL,
 		RenderError:     s.renderError,
-		Signer:          s.signer,
+		Signer:          c.Signer,
 		Logger:          s.logger,
 		ResponseTypes:   supportedRes,
 		GrantTypes:      supportedGrants,
@@ -430,7 +415,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 	sessions := &session.Manager{
 		Storage:   s.storage,
 		Config:    s.sessionConfig,
-		Now:       s.now,
+		Now:       now,
 		Logger:    s.logger,
 		IssuerURL: s.issuerURL,
 	}
@@ -549,30 +534,30 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 			Issuer:              s.issuer,
 			Storage:             s.storage,
 			Connectors:          s.connectors,
-			Now:                 s.now,
+			Now:                 now,
 			Logger:              s.logger,
 			PasswordConnector:   c.PasswordConnector,
-			RefreshPolicy:       s.refreshTokenPolicy,
+			RefreshPolicy:       c.RefreshTokenPolicy,
 			SessionsEnabled:     s.sessionConfig != nil,
 			SupportedGrantTypes: supportedGrants,
 		},
 		&userinfo.Handler{
 			Issuer: s.issuerURL.String(),
-			Signer: s.signer,
+			Signer: c.Signer,
 			Logger: s.logger,
 		},
 		&introspection.Handler{
 			Issuer:        s.issuerURL.String(),
-			Signer:        s.signer,
+			Signer:        c.Signer,
 			Storage:       s.storage,
 			Logger:        s.logger,
-			RefreshPolicy: s.refreshTokenPolicy,
+			RefreshPolicy: c.RefreshTokenPolicy,
 		},
 		&device.Handler{
 			IssuerURL:        s.issuerURL,
 			Storage:          s.storage,
 			Templates:        s.templates,
-			Now:              s.now,
+			Now:              now,
 			RequestsValidFor: deviceRequestsValidFor,
 			Logger:           s.logger,
 			Issuer:           s.issuer,
@@ -590,8 +575,8 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 			Connectors:             s.connectors,
 			Storage:                s.storage,
 			Templates:              s.templates,
-			Signer:                 s.signer,
-			Now:                    s.now,
+			Signer:                 c.Signer,
+			Now:                    now,
 			Logger:                 s.logger,
 			AlwaysShowLogin:        c.AlwaysShowLoginScreen,
 			SupportedResponseTypes: supportedRes,
@@ -601,7 +586,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 			Issuer:                 s.issuer,
 			MFAEnabled:             len(c.MFAProviders) > 0,
 			DefaultMFAChain:        c.DefaultMFAChain,
-			SkipApproval:           s.skipApproval,
+			SkipApproval:           c.SkipApprovalScreen,
 		},
 		&mfa.Handler{
 			Storage:         s.storage,
@@ -610,7 +595,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 			IssuerURL:       s.issuerURL,
 			MFAProviders:    c.MFAProviders,
 			DefaultMFAChain: c.DefaultMFAChain,
-			Now:             s.now,
+			Now:             now,
 			Connectors:      s.connectors,
 		},
 		&consent.Handler{
@@ -619,7 +604,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 			Logger:       s.logger,
 			IssuerURL:    s.issuerURL,
 			Sessions:     sessions,
-			SkipApproval: s.skipApproval,
+			SkipApproval: c.SkipApprovalScreen,
 		},
 		&logout.Handler{
 			Storage:    s.storage,
@@ -628,7 +613,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 			Sessions:   sessions,
 			Connectors: s.connectors,
 			Issuer:     s.issuer,
-			Signer:     s.signer,
+			Signer:     c.Signer,
 			IssuerURL:  s.issuerURL,
 		},
 	} {
@@ -650,7 +635,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 
 	s.mux = r
 
-	s.signer.Start(ctx)
+	c.Signer.Start(ctx)
 	s.startGarbageCollection(ctx, value(c.GCFrequency, 5*time.Minute), now)
 
 	return s, nil

--- a/server/server.go
+++ b/server/server.go
@@ -12,13 +12,11 @@ import (
 	"net/netip"
 	"net/url"
 	"os"
-	"path"
 	"sort"
 	"sync/atomic"
 	"time"
 
 	gosundheit "github.com/AppsFlyer/go-sundheit"
-	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -54,7 +52,6 @@ import (
 	"github.com/dexidp/dex/server/mfa"
 	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/passwords"
-	"github.com/dexidp/dex/server/reqctx"
 	"github.com/dexidp/dex/server/router"
 	"github.com/dexidp/dex/server/session"
 	"github.com/dexidp/dex/server/signer"
@@ -212,63 +209,6 @@ type Server struct {
 	sessionConfig *session.Config
 }
 
-// routeMux implements router.Mux over a gorilla mux.Router: every route is
-// prefixed with the issuer path and wrapped with the common response headers,
-// request-id/real-ip context, and instrumentation; HandleCORS additionally adds
-// CORS for the public endpoints. instrument and realIP are the server's
-// (prometheus- and config-bound) closures.
-type routeMux struct {
-	router       *mux.Router
-	issuerPath   string
-	headers      http.Header
-	realIPHeader string
-	instrument   func(string, http.Handler) http.HandlerFunc
-	realIP       func(*http.Request) (string, error)
-	corsOrigins  []string
-	corsHeaders  []string
-}
-
-// wrap applies the common response headers, request-id/real-ip context, and
-// instrumentation to a handler.
-func (m routeMux) wrap(name string, h http.Handler) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		for k, v := range m.headers {
-			w.Header()[k] = v
-		}
-		// Context values are used for logging purposes with the log/slog logger.
-		rCtx := reqctx.WithRequestID(r.Context())
-		if m.realIPHeader != "" {
-			if realIP, err := m.realIP(r); err == nil {
-				rCtx = reqctx.WithRemoteIP(rCtx, realIP)
-			}
-		}
-		m.instrument(name, h)(w, r.WithContext(rCtx))
-	}
-}
-
-func (m routeMux) Handle(p string, h http.Handler) {
-	m.router.Handle(path.Join(m.issuerPath, p), m.wrap(p, h))
-}
-
-func (m routeMux) HandleFunc(p string, h http.HandlerFunc) { m.Handle(p, h) }
-
-func (m routeMux) HandlePrefix(p string, h http.Handler) {
-	prefix := path.Join(m.issuerPath, p)
-	m.router.PathPrefix(prefix).Handler(http.StripPrefix(prefix, h))
-}
-
-func (m routeMux) HandleCORS(p string, h http.HandlerFunc) {
-	var handler http.Handler = h
-	if len(m.corsOrigins) > 0 {
-		cors := handlers.CORS(
-			handlers.AllowedOrigins(m.corsOrigins),
-			handlers.AllowedHeaders(m.corsHeaders),
-		)
-		handler = cors(handler)
-	}
-	m.Handle(p, handler)
-}
-
 // Connectors is the server's connector cache. The gRPC API needs it to
 // invalidate the cache on connector CRUD.
 func (s *Server) Connectors() *connectors.Cache { return s.connectors }
@@ -395,7 +335,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 	s.issuer = tokens.NewIssuer(s.storage, c.Signer, s.issuerURL.URL, idTokensValidFor, now, s.logger)
 	s.connectors = connectors.NewCache(s.storage, s.resolveConnector)
 	// Build the discovery handler once from config; both the mounted HTTP route
-	// and the gRPC API's ConstructDiscovery serve this same handler.
+	// and the gRPC API (via Discovery) serve this same handler.
 	s.discovery = &discovery.Handler{
 		Issuer:          s.issuerURL.String(),
 		AbsURL:          s.issuerURL.AbsURL,
@@ -516,18 +456,17 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 	r.NotFoundHandler = http.NotFoundHandler()
 
 	// Self-contained domains mount their own routes through the router.Mux
-	// abstraction; this routeMux is the only implementation and the only place
-	// they are wired in.
-	routes := routeMux{
-		router:       r,
-		issuerPath:   issuerURL.Path,
-		headers:      c.Headers,
-		realIPHeader: c.RealIPHeader,
-		instrument:   instrumentHandler,
-		realIP:       parseRealIP,
-		corsOrigins:  c.AllowedOrigins,
-		corsHeaders:  c.AllowedHeaders,
-	}
+	// abstraction; this is the only place they are wired in.
+	routes := router.New(router.Config{
+		Router:       r,
+		IssuerPath:   issuerURL.Path,
+		Headers:      c.Headers,
+		RealIPHeader: c.RealIPHeader,
+		Instrument:   instrumentHandler,
+		RealIP:       parseRealIP,
+		CORSOrigins:  c.AllowedOrigins,
+		CORSHeaders:  c.AllowedHeaders,
+	})
 	for _, h := range []router.Handler{
 		s.discovery,
 		&grants.Handler{
@@ -620,7 +559,6 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		h.Mount(routes)
 	}
 
-	// TODO(ericchiang): rate limit certain paths based on IP.
 	routes.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !c.HealthChecker.IsHealthy() {
 			s.renderError(r, w, http.StatusInternalServerError, "Health check failed.")

--- a/server/server.go
+++ b/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -20,25 +19,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"golang.org/x/crypto/bcrypt"
 
-	"github.com/dexidp/dex/connector"
-	"github.com/dexidp/dex/connector/atlassiancrowd"
-	"github.com/dexidp/dex/connector/authproxy"
-	"github.com/dexidp/dex/connector/bitbucketcloud"
-	"github.com/dexidp/dex/connector/gitea"
-	"github.com/dexidp/dex/connector/github"
-	"github.com/dexidp/dex/connector/gitlab"
-	"github.com/dexidp/dex/connector/google"
-	"github.com/dexidp/dex/connector/keystone"
-	"github.com/dexidp/dex/connector/ldap"
-	"github.com/dexidp/dex/connector/linkedin"
-	"github.com/dexidp/dex/connector/microsoft"
-	"github.com/dexidp/dex/connector/mock"
-	"github.com/dexidp/dex/connector/oauth"
-	"github.com/dexidp/dex/connector/oidc"
-	"github.com/dexidp/dex/connector/openshift"
-	"github.com/dexidp/dex/connector/saml"
 	"github.com/dexidp/dex/pkg/featureflags"
 	"github.com/dexidp/dex/server/authflow"
 	"github.com/dexidp/dex/server/connectors"
@@ -51,7 +32,6 @@ import (
 	"github.com/dexidp/dex/server/logout"
 	"github.com/dexidp/dex/server/mfa"
 	"github.com/dexidp/dex/server/oauth2"
-	"github.com/dexidp/dex/server/passwords"
 	"github.com/dexidp/dex/server/router"
 	"github.com/dexidp/dex/server/session"
 	"github.com/dexidp/dex/server/signer"
@@ -61,10 +41,6 @@ import (
 	"github.com/dexidp/dex/storage"
 	"github.com/dexidp/dex/web"
 )
-
-// LocalConnector is the local passwordDB connector which is an internal
-// connector maintained by the server.
-const LocalConnector = "local"
 
 // Config holds the server's configuration options.
 //
@@ -333,7 +309,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		sessionConfig: c.SessionConfig,
 	}
 	s.issuer = tokens.NewIssuer(s.storage, c.Signer, s.issuerURL.URL, idTokensValidFor, now, s.logger)
-	s.connectors = connectors.NewCache(s.storage, s.resolveConnector)
+	s.connectors = connectors.NewCache(s.storage, connectorResolver(s.storage, s.logger))
 	// Build the discovery handler once from config; both the mounted HTTP route
 	// and the gRPC API (via Discovery) serve this same handler.
 	s.discovery = &discovery.Handler{
@@ -583,89 +559,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.mux.ServeHTTP(w, r)
 }
 
-func newPasswordDB(s storage.Storage) interface {
-	connector.Connector
-	connector.PasswordConnector
-} {
-	return passwordDB{s}
-}
-
-type passwordDB struct {
-	s storage.Storage
-}
-
-func resolvePasswordName(p storage.Password) string {
-	if p.Name != "" {
-		return p.Name
-	}
-	return p.Username
-}
-
-func resolvePasswordEmailVerified(p storage.Password) bool {
-	if p.EmailVerified != nil {
-		return *p.EmailVerified
-	}
-	return true
-}
-
-func (db passwordDB) Login(ctx context.Context, s connector.Scopes, email, password string) (connector.Identity, bool, error) {
-	p, err := db.s.GetPassword(ctx, email)
-	if err != nil {
-		if err != storage.ErrNotFound {
-			return connector.Identity{}, false, fmt.Errorf("get password: %v", err)
-		}
-		return connector.Identity{}, false, nil
-	}
-	// This check prevents dex users from logging in using static passwords
-	// configured with hash costs that are too high or low.
-	if err := passwords.CheckCost(p.Hash); err != nil {
-		return connector.Identity{}, false, err
-	}
-	if err := bcrypt.CompareHashAndPassword(p.Hash, []byte(password)); err != nil {
-		return connector.Identity{}, false, nil
-	}
-	return connector.Identity{
-		UserID:            p.UserID,
-		Username:          resolvePasswordName(p),
-		PreferredUsername: p.PreferredUsername,
-		Email:             p.Email,
-		EmailVerified:     resolvePasswordEmailVerified(p),
-		Groups:            p.Groups,
-	}, true, nil
-}
-
-func (db passwordDB) Refresh(ctx context.Context, s connector.Scopes, identity connector.Identity) (connector.Identity, error) {
-	// If the user has been deleted, the refresh token will be rejected.
-	p, err := db.s.GetPassword(ctx, identity.Email)
-	if err != nil {
-		if err == storage.ErrNotFound {
-			return connector.Identity{}, errors.New("user not found")
-		}
-		return connector.Identity{}, fmt.Errorf("get password: %v", err)
-	}
-
-	// User removed but a new user with the same email exists.
-	if p.UserID != identity.UserID {
-		return connector.Identity{}, errors.New("user not found")
-	}
-
-	// If a user has updated their username, that will be reflected in the
-	// refreshed token.
-	//
-	// No other fields are expected to be refreshable as email is effectively used
-	// as an ID.
-	identity.Username = resolvePasswordName(p)
-	identity.PreferredUsername = p.PreferredUsername
-	identity.EmailVerified = resolvePasswordEmailVerified(p)
-	identity.Groups = p.Groups
-
-	return identity, nil
-}
-
-func (db passwordDB) Prompt() string {
-	return "Email Address"
-}
-
 // newKeyCacher returns a storage which caches keys so long as the next
 func newKeyCacher(s storage.Storage, now func() time.Time) storage.Storage {
 	if now == nil {
@@ -716,69 +609,6 @@ func (s *Server) startGarbageCollection(ctx context.Context, frequency time.Dura
 			}
 		}
 	}()
-}
-
-// ConnectorConfig is a configuration that can open a connector.
-type ConnectorConfig interface {
-	Open(id string, logger *slog.Logger) (connector.Connector, error)
-}
-
-// ConnectorsConfig variable provides an easy way to return a config struct
-// depending on the connector type.
-var ConnectorsConfig = map[string]func() ConnectorConfig{
-	"keystone":        func() ConnectorConfig { return new(keystone.Config) },
-	"mockCallback":    func() ConnectorConfig { return new(mock.CallbackConfig) },
-	"mockPassword":    func() ConnectorConfig { return new(mock.PasswordConfig) },
-	"ldap":            func() ConnectorConfig { return new(ldap.Config) },
-	"gitea":           func() ConnectorConfig { return new(gitea.Config) },
-	"github":          func() ConnectorConfig { return new(github.Config) },
-	"gitlab":          func() ConnectorConfig { return new(gitlab.Config) },
-	"google":          func() ConnectorConfig { return new(google.Config) },
-	"oidc":            func() ConnectorConfig { return new(oidc.Config) },
-	"oauth":           func() ConnectorConfig { return new(oauth.Config) },
-	"saml":            func() ConnectorConfig { return new(saml.Config) },
-	"authproxy":       func() ConnectorConfig { return new(authproxy.Config) },
-	"linkedin":        func() ConnectorConfig { return new(linkedin.Config) },
-	"microsoft":       func() ConnectorConfig { return new(microsoft.Config) },
-	"bitbucket-cloud": func() ConnectorConfig { return new(bitbucketcloud.Config) },
-	"openshift":       func() ConnectorConfig { return new(openshift.Config) },
-	"atlassian-crowd": func() ConnectorConfig { return new(atlassiancrowd.Config) },
-	// Keep around for backwards compatibility.
-	"samlExperimental": func() ConnectorConfig { return new(saml.Config) },
-}
-
-// openConnector will parse the connector config and open the connector.
-func openConnector(logger *slog.Logger, conn storage.Connector) (connector.Connector, error) {
-	var c connector.Connector
-
-	f, ok := ConnectorsConfig[conn.Type]
-	if !ok {
-		return c, fmt.Errorf("unknown connector type %q", conn.Type)
-	}
-
-	connConfig := f()
-	if len(conn.Config) != 0 {
-		data := []byte(string(conn.Config))
-		if err := json.Unmarshal(data, connConfig); err != nil {
-			return c, fmt.Errorf("parse connector config: %v", err)
-		}
-	}
-
-	c, err := connConfig.Open(conn.ID, logger)
-	if err != nil {
-		return c, fmt.Errorf("failed to create connector %s: %v", conn.ID, err)
-	}
-
-	return c, nil
-}
-
-// resolveConnector builds the underlying connector implementation for a stored
-// connector: the built-in local password DB, or a configured connector.
-func (s *Server) resolveConnector(conn storage.Connector) (connector.Connector, error) {
-	if conn.Type == LocalConnector {
-		return newPasswordDB(s.storage), nil
-	}
-	return openConnector(s.logger, conn)
 }
 
 // renderError renders a user-facing error page for the non-flow endpoints the

--- a/server/server.go
+++ b/server/server.go
@@ -203,17 +203,9 @@ type Server struct {
 	// If enabled, don't prompt user for approval after logging in through connector.
 	skipApproval bool
 
-	// If enabled, show the connector selection screen even if there's only one
-	alwaysShowLogin bool
-
-	// Used for password grant
-	passwordConnector string
-
 	now func() time.Time
 
-	idTokensValidFor       time.Duration
-	authRequestsValidFor   time.Duration
-	deviceRequestsValidFor time.Duration
+	idTokensValidFor time.Duration
 
 	refreshTokenPolicy *tokens.RefreshStrategy
 
@@ -225,41 +217,77 @@ type Server struct {
 	issuer *tokens.Issuer
 
 	// discovery is built once from config and shared by the mounted HTTP handler
-	// and the gRPC API's ConstructDiscovery.
+	// and the gRPC API's Discovery accessor.
 	discovery *discovery.Handler
 
 	sessionConfig *session.Config
-
-	mfaProviders    map[string]mfa.Provider
-	defaultMFAChain []string
 }
 
-// routeMux adapts the server's route-registration closures to router.Mux so
-// domain handlers can mount their own routes.
+// routeMux implements router.Mux over a gorilla mux.Router: every route is
+// prefixed with the issuer path and wrapped with the common response headers,
+// request-id/real-ip context, and instrumentation; HandleCORS additionally adds
+// CORS for the public endpoints. instrument and realIP are the server's
+// (prometheus- and config-bound) closures.
 type routeMux struct {
-	handle       func(string, http.Handler)
-	handleFunc   func(string, http.HandlerFunc)
-	handleCORS   func(string, http.HandlerFunc)
-	handlePrefix func(string, http.Handler)
+	router       *mux.Router
+	issuerPath   string
+	headers      http.Header
+	realIPHeader string
+	instrument   func(string, http.Handler) http.HandlerFunc
+	realIP       func(*http.Request) (string, error)
+	corsOrigins  []string
+	corsHeaders  []string
 }
 
-func (m routeMux) Handle(p string, h http.Handler)         { m.handle(p, h) }
-func (m routeMux) HandleFunc(p string, h http.HandlerFunc) { m.handleFunc(p, h) }
-func (m routeMux) HandleCORS(p string, h http.HandlerFunc) { m.handleCORS(p, h) }
-func (m routeMux) HandlePrefix(p string, h http.Handler)   { m.handlePrefix(p, h) }
+// wrap applies the common response headers, request-id/real-ip context, and
+// instrumentation to a handler.
+func (m routeMux) wrap(name string, h http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		for k, v := range m.headers {
+			w.Header()[k] = v
+		}
+		// Context values are used for logging purposes with the log/slog logger.
+		rCtx := reqctx.WithRequestID(r.Context())
+		if m.realIPHeader != "" {
+			if realIP, err := m.realIP(r); err == nil {
+				rCtx = reqctx.WithRemoteIP(rCtx, realIP)
+			}
+		}
+		m.instrument(name, h)(w, r.WithContext(rCtx))
+	}
+}
 
-// newDiscoveryHandler builds a discovery handler from the server's settings. It
-// is shared by the mounted handler and ConstructDiscovery.
+func (m routeMux) Handle(p string, h http.Handler) {
+	m.router.Handle(path.Join(m.issuerPath, p), m.wrap(p, h))
+}
+
+func (m routeMux) HandleFunc(p string, h http.HandlerFunc) { m.Handle(p, h) }
+
+func (m routeMux) HandlePrefix(p string, h http.Handler) {
+	prefix := path.Join(m.issuerPath, p)
+	m.router.PathPrefix(prefix).Handler(http.StripPrefix(prefix, h))
+}
+
+func (m routeMux) HandleCORS(p string, h http.HandlerFunc) {
+	var handler http.Handler = h
+	if len(m.corsOrigins) > 0 {
+		cors := handlers.CORS(
+			handlers.AllowedOrigins(m.corsOrigins),
+			handlers.AllowedHeaders(m.corsHeaders),
+		)
+		handler = cors(handler)
+	}
+	m.Handle(p, handler)
+}
+
 // Connectors is the server's connector cache. The gRPC API needs it to
 // invalidate the cache on connector CRUD.
 func (s *Server) Connectors() *connectors.Cache { return s.connectors }
 
-// ConstructDiscovery builds the OIDC discovery document. The gRPC API's
-// GetDiscovery uses it to return the same document served over HTTP, from the
-// same handler mounted for HTTP.
-func (s *Server) ConstructDiscovery(ctx context.Context) discovery.Document {
-	return s.discovery.Construct(ctx)
-}
+// Discovery is the handler that builds the OIDC discovery document. The gRPC
+// API serves the same handler that is mounted for HTTP, so both return an
+// identical document.
+func (s *Server) Discovery() *discovery.Handler { return s.discovery }
 
 // NewServer constructs a server from the provided config.
 func NewServer(ctx context.Context, c Config) (*Server, error) {
@@ -364,23 +392,20 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		now = time.Now
 	}
 
+	authRequestsValidFor := value(c.AuthRequestsValidFor, 24*time.Hour)
+	deviceRequestsValidFor := value(c.DeviceRequestsValidFor, 5*time.Minute)
+
 	s := &Server{
-		issuerURL:              oauth2.IssuerURL{URL: *issuerURL},
-		storage:                newKeyCacher(c.Storage, now),
-		idTokensValidFor:       value(c.IDTokensValidFor, 24*time.Hour),
-		authRequestsValidFor:   value(c.AuthRequestsValidFor, 24*time.Hour),
-		deviceRequestsValidFor: value(c.DeviceRequestsValidFor, 5*time.Minute),
-		refreshTokenPolicy:     c.RefreshTokenPolicy,
-		skipApproval:           c.SkipApprovalScreen,
-		alwaysShowLogin:        c.AlwaysShowLoginScreen,
-		now:                    now,
-		templates:              tmpls,
-		passwordConnector:      c.PasswordConnector,
-		logger:                 c.Logger,
-		signer:                 c.Signer,
-		sessionConfig:          c.SessionConfig,
-		mfaProviders:           c.MFAProviders,
-		defaultMFAChain:        c.DefaultMFAChain,
+		issuerURL:          oauth2.IssuerURL{URL: *issuerURL},
+		storage:            newKeyCacher(c.Storage, now),
+		idTokensValidFor:   value(c.IDTokensValidFor, 24*time.Hour),
+		refreshTokenPolicy: c.RefreshTokenPolicy,
+		skipApproval:       c.SkipApprovalScreen,
+		now:                now,
+		templates:          tmpls,
+		logger:             c.Logger,
+		signer:             c.Signer,
+		sessionConfig:      c.SessionConfig,
 	}
 	s.issuer = tokens.NewIssuer(s.storage, s.signer, s.issuerURL.URL, s.idTokensValidFor, s.now, s.logger)
 	s.connectors = connectors.NewCache(s.storage, s.resolveConnector)
@@ -502,55 +527,22 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		return remoteAddr, nil
 	}
 
-	handlerWithHeaders := func(handlerName string, handler http.Handler) http.HandlerFunc {
-		return func(w http.ResponseWriter, r *http.Request) {
-			for k, v := range c.Headers {
-				w.Header()[k] = v
-			}
-
-			// Context values are used for logging purposes with the log/slog logger.
-			rCtx := r.Context()
-			rCtx = reqctx.WithRequestID(rCtx)
-
-			if c.RealIPHeader != "" {
-				realIP, err := parseRealIP(r)
-				if err == nil {
-					rCtx = reqctx.WithRemoteIP(rCtx, realIP)
-				}
-			}
-
-			r = r.WithContext(rCtx)
-			instrumentHandler(handlerName, handler)(w, r)
-		}
-	}
-
 	r := mux.NewRouter().SkipClean(true).UseEncodedPath()
-	handle := func(p string, h http.Handler) {
-		r.Handle(path.Join(issuerURL.Path, p), handlerWithHeaders(p, h))
-	}
-	handleFunc := func(p string, h http.HandlerFunc) {
-		handle(p, h)
-	}
-	handlePrefix := func(p string, h http.Handler) {
-		prefix := path.Join(issuerURL.Path, p)
-		r.PathPrefix(prefix).Handler(http.StripPrefix(prefix, h))
-	}
-	handleWithCORS := func(p string, h http.HandlerFunc) {
-		var handler http.Handler = h
-		if len(c.AllowedOrigins) > 0 {
-			cors := handlers.CORS(
-				handlers.AllowedOrigins(c.AllowedOrigins),
-				handlers.AllowedHeaders(c.AllowedHeaders),
-			)
-			handler = cors(handler)
-		}
-		r.Handle(path.Join(issuerURL.Path, p), handlerWithHeaders(p, handler))
-	}
 	r.NotFoundHandler = http.NotFoundHandler()
 
 	// Self-contained domains mount their own routes through the router.Mux
-	// abstraction, so this list is the only place they are wired in.
-	mux := routeMux{handle: handle, handleFunc: handleFunc, handleCORS: handleWithCORS, handlePrefix: handlePrefix}
+	// abstraction; this routeMux is the only implementation and the only place
+	// they are wired in.
+	routes := routeMux{
+		router:       r,
+		issuerPath:   issuerURL.Path,
+		headers:      c.Headers,
+		realIPHeader: c.RealIPHeader,
+		instrument:   instrumentHandler,
+		realIP:       parseRealIP,
+		corsOrigins:  c.AllowedOrigins,
+		corsHeaders:  c.AllowedHeaders,
+	}
 	for _, h := range []router.Handler{
 		s.discovery,
 		&grants.Handler{
@@ -559,7 +551,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 			Connectors:          s.connectors,
 			Now:                 s.now,
 			Logger:              s.logger,
-			PasswordConnector:   s.passwordConnector,
+			PasswordConnector:   c.PasswordConnector,
 			RefreshPolicy:       s.refreshTokenPolicy,
 			SessionsEnabled:     s.sessionConfig != nil,
 			SupportedGrantTypes: supportedGrants,
@@ -581,7 +573,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 			Storage:          s.storage,
 			Templates:        s.templates,
 			Now:              s.now,
-			RequestsValidFor: s.deviceRequestsValidFor,
+			RequestsValidFor: deviceRequestsValidFor,
 			Logger:           s.logger,
 			Issuer:           s.issuer,
 			Connectors:       s.connectors,
@@ -601,14 +593,14 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 			Signer:                 s.signer,
 			Now:                    s.now,
 			Logger:                 s.logger,
-			AlwaysShowLogin:        s.alwaysShowLogin,
+			AlwaysShowLogin:        c.AlwaysShowLoginScreen,
 			SupportedResponseTypes: supportedRes,
 			PKCE:                   c.PKCE,
-			AuthRequestsValidFor:   s.authRequestsValidFor,
+			AuthRequestsValidFor:   authRequestsValidFor,
 			Sessions:               sessions,
 			Issuer:                 s.issuer,
-			MFAEnabled:             len(s.mfaProviders) > 0,
-			DefaultMFAChain:        s.defaultMFAChain,
+			MFAEnabled:             len(c.MFAProviders) > 0,
+			DefaultMFAChain:        c.DefaultMFAChain,
 			SkipApproval:           s.skipApproval,
 		},
 		&mfa.Handler{
@@ -616,8 +608,8 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 			Templates:       s.templates,
 			Logger:          s.logger,
 			IssuerURL:       s.issuerURL,
-			MFAProviders:    s.mfaProviders,
-			DefaultMFAChain: s.defaultMFAChain,
+			MFAProviders:    c.MFAProviders,
+			DefaultMFAChain: c.DefaultMFAChain,
 			Now:             s.now,
 			Connectors:      s.connectors,
 		},
@@ -640,11 +632,11 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 			IssuerURL:  s.issuerURL,
 		},
 	} {
-		h.Mount(mux)
+		h.Mount(routes)
 	}
 
 	// TODO(ericchiang): rate limit certain paths based on IP.
-	handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	routes.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !c.HealthChecker.IsHealthy() {
 			s.renderError(r, w, http.StatusInternalServerError, "Health check failed.")
 			return
@@ -652,9 +644,9 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		fmt.Fprintf(w, "Health check passed")
 	}))
 
-	handlePrefix("/static", static)
-	handlePrefix("/theme", theme)
-	handleFunc("/robots.txt", robots)
+	routes.HandlePrefix("/static", static)
+	routes.HandlePrefix("/theme", theme)
+	routes.HandleFunc("/robots.txt", robots)
 
 	s.mux = r
 

--- a/server/server.go
+++ b/server/server.go
@@ -189,7 +189,7 @@ func value(val, defaultValue time.Duration) time.Duration {
 
 // Server is the top level object.
 type Server struct {
-	issuerURL url.URL
+	issuerURL oauth2.IssuerURL
 
 	// In-memory cache of opened connectors.
 	connectors *connectors.Cache
@@ -209,12 +209,6 @@ type Server struct {
 	// Used for password grant
 	passwordConnector string
 
-	supportedResponseTypes map[string]bool
-
-	supportedGrantTypes []string
-
-	pkce authflow.PKCEConfig
-
 	now func() time.Time
 
 	idTokensValidFor       time.Duration
@@ -229,6 +223,10 @@ type Server struct {
 
 	// issuer turns an Authorization into a TokenSet.
 	issuer *tokens.Issuer
+
+	// discovery is built once from config and shared by the mounted HTTP handler
+	// and the gRPC API's ConstructDiscovery.
+	discovery *discovery.Handler
 
 	sessionConfig *session.Config
 
@@ -252,28 +250,15 @@ func (m routeMux) HandlePrefix(p string, h http.Handler)   { m.handlePrefix(p, h
 
 // newDiscoveryHandler builds a discovery handler from the server's settings. It
 // is shared by the mounted handler and ConstructDiscovery.
-func (s *Server) newDiscoveryHandler() *discovery.Handler {
-	return &discovery.Handler{
-		Issuer:          s.issuerURL.String(),
-		AbsURL:          s.absURL,
-		RenderError:     s.renderError,
-		Signer:          s.signer,
-		Logger:          s.logger,
-		ResponseTypes:   s.supportedResponseTypes,
-		GrantTypes:      s.supportedGrantTypes,
-		PKCEMethods:     s.pkce.CodeChallengeMethodsSupported,
-		SessionsEnabled: s.sessionConfig != nil,
-	}
-}
-
 // Connectors is the server's connector cache. The gRPC API needs it to
 // invalidate the cache on connector CRUD.
 func (s *Server) Connectors() *connectors.Cache { return s.connectors }
 
 // ConstructDiscovery builds the OIDC discovery document. The gRPC API's
-// GetDiscovery uses it to return the same document served over HTTP.
+// GetDiscovery uses it to return the same document served over HTTP, from the
+// same handler mounted for HTTP.
 func (s *Server) ConstructDiscovery(ctx context.Context) discovery.Document {
-	return s.newDiscoveryHandler().Construct(ctx)
+	return s.discovery.Construct(ctx)
 }
 
 // NewServer constructs a server from the provided config.
@@ -380,11 +365,8 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 	}
 
 	s := &Server{
-		issuerURL:              *issuerURL,
+		issuerURL:              oauth2.IssuerURL{URL: *issuerURL},
 		storage:                newKeyCacher(c.Storage, now),
-		supportedResponseTypes: supportedRes,
-		supportedGrantTypes:    supportedGrants,
-		pkce:                   c.PKCE,
 		idTokensValidFor:       value(c.IDTokensValidFor, 24*time.Hour),
 		authRequestsValidFor:   value(c.AuthRequestsValidFor, 24*time.Hour),
 		deviceRequestsValidFor: value(c.DeviceRequestsValidFor, 5*time.Minute),
@@ -400,8 +382,21 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		mfaProviders:           c.MFAProviders,
 		defaultMFAChain:        c.DefaultMFAChain,
 	}
-	s.issuer = tokens.NewIssuer(s.storage, s.signer, s.issuerURL, s.idTokensValidFor, s.now, s.logger)
+	s.issuer = tokens.NewIssuer(s.storage, s.signer, s.issuerURL.URL, s.idTokensValidFor, s.now, s.logger)
 	s.connectors = connectors.NewCache(s.storage, s.resolveConnector)
+	// Build the discovery handler once from config; both the mounted HTTP route
+	// and the gRPC API's ConstructDiscovery serve this same handler.
+	s.discovery = &discovery.Handler{
+		Issuer:          s.issuerURL.String(),
+		AbsURL:          s.issuerURL.AbsURL,
+		RenderError:     s.renderError,
+		Signer:          s.signer,
+		Logger:          s.logger,
+		ResponseTypes:   supportedRes,
+		GrantTypes:      supportedGrants,
+		PKCEMethods:     c.PKCE.CodeChallengeMethodsSupported,
+		SessionsEnabled: s.sessionConfig != nil,
+	}
 	// sessions is shared infrastructure (session cookie, SSO, auth-session CRUD)
 	// referenced by the flow steps mounted below. The steps themselves hold no
 	// reference to one another; the /auth dispatcher decides MFA and consent from
@@ -428,7 +423,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 
 	var failedCount int
 	for _, conn := range storageConnectors {
-		if _, err := s.OpenConnector(conn); err != nil {
+		if _, err := s.connectors.Open(conn); err != nil {
 			failedCount++
 			if c.ContinueOnConnectorFailure {
 				s.logger.Error("server: Failed to open connector", "id", conn.ID, "err", err)
@@ -557,7 +552,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 	// abstraction, so this list is the only place they are wired in.
 	mux := routeMux{handle: handle, handleFunc: handleFunc, handleCORS: handleWithCORS, handlePrefix: handlePrefix}
 	for _, h := range []router.Handler{
-		s.newDiscoveryHandler(),
+		s.discovery,
 		&grants.Handler{
 			Issuer:              s.issuer,
 			Storage:             s.storage,
@@ -567,7 +562,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 			PasswordConnector:   s.passwordConnector,
 			RefreshPolicy:       s.refreshTokenPolicy,
 			SessionsEnabled:     s.sessionConfig != nil,
-			SupportedGrantTypes: s.supportedGrantTypes,
+			SupportedGrantTypes: supportedGrants,
 		},
 		&userinfo.Handler{
 			Issuer: s.issuerURL.String(),
@@ -607,8 +602,8 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 			Now:                    s.now,
 			Logger:                 s.logger,
 			AlwaysShowLogin:        s.alwaysShowLogin,
-			SupportedResponseTypes: s.supportedResponseTypes,
-			PKCE:                   s.pkce,
+			SupportedResponseTypes: supportedRes,
+			PKCE:                   c.PKCE,
 			AuthRequestsValidFor:   s.authRequestsValidFor,
 			Sessions:               sessions,
 			Issuer:                 s.issuer,
@@ -671,19 +666,6 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.mux.ServeHTTP(w, r)
-}
-
-func (s *Server) absPath(pathItems ...string) string {
-	paths := make([]string, len(pathItems)+1)
-	paths[0] = s.issuerURL.Path
-	copy(paths[1:], pathItems)
-	return path.Join(paths...)
-}
-
-func (s *Server) absURL(pathItems ...string) string {
-	u := s.issuerURL
-	u.Path = s.absPath(pathItems...)
-	return u.String()
 }
 
 func newPasswordDB(s storage.Storage) interface {
@@ -882,16 +864,6 @@ func (s *Server) resolveConnector(conn storage.Connector) (connector.Connector, 
 		return newPasswordDB(s.storage), nil
 	}
 	return openConnector(s.logger, conn)
-}
-
-// OpenConnector opens the given connector and records it in the in-memory cache.
-func (s *Server) OpenConnector(conn storage.Connector) (connectors.Connector, error) {
-	return s.connectors.Open(conn)
-}
-
-// CloseConnector removes the connector from the in-memory cache.
-func (s *Server) CloseConnector(id string) {
-	s.connectors.Close(id)
 }
 
 // renderError renders a user-facing error page for the non-flow endpoints the

--- a/server/server_api_cache_test.go
+++ b/server/server_api_cache_test.go
@@ -25,7 +25,9 @@ func TestConnectorCacheInvalidation(t *testing.T) {
 	}
 	serv.connectors = connectors.NewCache(s, serv.resolveConnector)
 
-	apiServer := apiserver.NewAPI(s, logger, "test", serv.connectors, serv.discovery)
+	// This test exercises connector-cache invalidation, not discovery, so no
+	// discovery handler is wired (GetDiscovery guards against nil).
+	apiServer := apiserver.NewAPI(s, logger, "test", serv.connectors, nil)
 	ctx := context.Background()
 
 	connID := "mock-conn"

--- a/server/server_api_cache_test.go
+++ b/server/server_api_cache_test.go
@@ -23,7 +23,7 @@ func TestConnectorCacheInvalidation(t *testing.T) {
 		storage: s,
 		logger:  logger,
 	}
-	serv.connectors = connectors.NewCache(s, serv.resolveConnector)
+	serv.connectors = connectors.NewCache(s, connectorResolver(s, logger))
 
 	// This test exercises connector-cache invalidation, not discovery, so no
 	// discovery handler is wired (GetDiscovery guards against nil).

--- a/server/server_api_cache_test.go
+++ b/server/server_api_cache_test.go
@@ -25,7 +25,7 @@ func TestConnectorCacheInvalidation(t *testing.T) {
 	}
 	serv.connectors = connectors.NewCache(s, serv.resolveConnector)
 
-	apiServer := apiserver.NewAPI(s, logger, "test", serv.connectors, serv.ConstructDiscovery)
+	apiServer := apiserver.NewAPI(s, logger, "test", serv.connectors, serv.discovery)
 	ctx := context.Background()
 
 	connID := "mock-conn"

--- a/server/server_api_cache_test.go
+++ b/server/server_api_cache_test.go
@@ -23,7 +23,7 @@ func TestConnectorCacheInvalidation(t *testing.T) {
 		storage: s,
 		logger:  logger,
 	}
-	serv.connectors = connectors.NewCache(s, connectorResolver(s, logger))
+	serv.connectors = connectors.NewCache(s, connectors.Resolver(s, logger, ConnectorsConfig))
 
 	// This test exercises connector-cache invalidation, not discovery, so no
 	// discovery handler is wired (GetDiscovery guards against nil).

--- a/server/server_authorize_test.go
+++ b/server/server_authorize_test.go
@@ -364,7 +364,7 @@ func TestBackLinkIncludesPromptSelectAccount(t *testing.T) {
 		Config:          []byte(`{"username": "foo", "password": "bar"}`),
 	}
 	require.NoError(t, s.storage.CreateConnector(ctx, pwConn))
-	_, err := s.OpenConnector(pwConn)
+	_, err := s.connectors.Open(pwConn)
 	require.NoError(t, err)
 
 	client := storage.Client{

--- a/server/server_grant_password_test.go
+++ b/server/server_grant_password_test.go
@@ -122,7 +122,7 @@ func TestHandlePassword_LocalPasswordDBClaims(t *testing.T) {
 		ResourceVersion: "1",
 	}
 	require.NoError(t, s.storage.CreateConnector(ctx, localConn))
-	_, err := s.OpenConnector(localConn)
+	_, err := s.connectors.Open(localConn)
 	require.NoError(t, err)
 
 	// Create a user in the password DB with groups and preferred_username.

--- a/server/server_grant_password_test.go
+++ b/server/server_grant_password_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 
+	"github.com/dexidp/dex/server/connectors"
 	"github.com/dexidp/dex/storage"
 )
 
@@ -117,7 +118,7 @@ func TestHandlePassword_LocalPasswordDBClaims(t *testing.T) {
 	// Enable local connector.
 	localConn := storage.Connector{
 		ID:              "local",
-		Type:            LocalConnector,
+		Type:            connectors.LocalConnector,
 		Name:            "Email",
 		ResourceVersion: "1",
 	}

--- a/server/server_introspection_test.go
+++ b/server/server_introspection_test.go
@@ -194,7 +194,7 @@ func TestHandleIntrospect(t *testing.T) {
 		{
 			testName:           "Access Token: active",
 			token:              activeAccessToken,
-			response:           toJSON(getIntrospectionValue(s.issuerURL, t0, expiry, "access_token")),
+			response:           toJSON(getIntrospectionValue(s.issuerURL.URL, t0, expiry, "access_token")),
 			responseStatusCode: 200,
 		},
 		{
@@ -207,7 +207,7 @@ func TestHandleIntrospect(t *testing.T) {
 		{
 			testName:           "Refresh Token: active",
 			token:              activeRefreshToken,
-			response:           toJSON(getIntrospectionValue(s.issuerURL, t0, t0.Add(s.refreshTokenPolicy.AbsoluteLifetime()), "refresh_token")),
+			response:           toJSON(getIntrospectionValue(s.issuerURL.URL, t0, t0.Add(s.refreshTokenPolicy.AbsoluteLifetime()), "refresh_token")),
 			responseStatusCode: 200,
 		},
 		{

--- a/server/server_introspection_test.go
+++ b/server/server_introspection_test.go
@@ -207,7 +207,7 @@ func TestHandleIntrospect(t *testing.T) {
 		{
 			testName:           "Refresh Token: active",
 			token:              activeRefreshToken,
-			response:           toJSON(getIntrospectionValue(s.issuerURL.URL, t0, t0.Add(s.refreshTokenPolicy.AbsoluteLifetime()), "refresh_token")),
+			response:           toJSON(getIntrospectionValue(s.issuerURL.URL, t0, t0.Add(refreshTokenPolicy.AbsoluteLifetime()), "refresh_token")),
 			responseStatusCode: 200,
 		},
 		{

--- a/server/server_login_test.go
+++ b/server/server_login_test.go
@@ -98,7 +98,7 @@ func TestFinalizeLoginCreatesUserIdentity(t *testing.T) {
 		Config:          []byte(`{"username": "foo", "password": "password"}`),
 	}
 	require.NoError(t, s.storage.CreateConnector(ctx, sc))
-	_, err := s.OpenConnector(sc)
+	_, err := s.connectors.Open(sc)
 	require.NoError(t, err)
 
 	authReq := storage.AuthRequest{
@@ -148,7 +148,7 @@ func TestFinalizeLoginUpdatesUserIdentity(t *testing.T) {
 		Config:          []byte(`{"username": "foo", "password": "password"}`),
 	}
 	require.NoError(t, s.storage.CreateConnector(ctx, sc))
-	_, err := s.OpenConnector(sc)
+	_, err := s.connectors.Open(sc)
 	require.NoError(t, err)
 
 	// Pre-create UserIdentity with old data
@@ -211,7 +211,7 @@ func TestFinalizeLoginSkipsUserIdentityWhenDisabled(t *testing.T) {
 		Config:          []byte(`{"username": "foo", "password": "password"}`),
 	}
 	require.NoError(t, s.storage.CreateConnector(ctx, sc))
-	_, err := s.OpenConnector(sc)
+	_, err := s.connectors.Open(sc)
 	require.NoError(t, err)
 
 	authReq := storage.AuthRequest{
@@ -354,7 +354,7 @@ func TestHandlePasswordLoginWithSkipApproval(t *testing.T) {
 			if err := s.storage.CreateConnector(ctx, sc); err != nil {
 				t.Fatalf("create connector: %v", err)
 			}
-			if _, err := s.OpenConnector(sc); err != nil {
+			if _, err := s.connectors.Open(sc); err != nil {
 				t.Fatalf("open connector: %v", err)
 			}
 			if err := s.storage.CreateAuthRequest(ctx, tc.authReq); err != nil {
@@ -541,7 +541,7 @@ func TestHandlePasswordLogin_SPNEGOShortCircuit(t *testing.T) {
 		Config:          []byte("{\"username\": \"foo\", \"password\": \"password\"}"),
 	}
 	require.NoError(t, s.storage.CreateConnector(ctx, sc))
-	_, err := s.OpenConnector(sc)
+	_, err := s.connectors.Open(sc)
 	require.NoError(t, err)
 
 	// Prepare auth request
@@ -611,7 +611,7 @@ func TestHandlePasswordLogin_SPNEGOError(t *testing.T) {
 		Config:          []byte("{\"username\": \"foo\", \"password\": \"password\"}"),
 	}
 	require.NoError(t, s.storage.CreateConnector(ctx, sc))
-	_, err := s.OpenConnector(sc)
+	_, err := s.connectors.Open(sc)
 	require.NoError(t, err)
 
 	// Prepare auth request

--- a/server/server_oauth2_test.go
+++ b/server/server_oauth2_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/signer"
 	"github.com/dexidp/dex/server/tokens"
 	"github.com/dexidp/dex/storage"
@@ -181,19 +180,11 @@ func TestNewIDTokenUsesStoredAlgorithmUntilNextRotation(t *testing.T) {
 	issuerURL, err := url.Parse("https://issuer.example.com")
 	require.NoError(t, err)
 
-	s := &Server{
-		signer:           sig,
-		issuerURL:        oauth2.IssuerURL{URL: *issuerURL},
-		logger:           logger,
-		now:              func() time.Time { return now },
-		idTokensValidFor: time.Hour,
-	}
-
-	s.issuer = tokens.NewIssuer(store, s.signer, s.issuerURL.URL, s.idTokensValidFor, s.now, s.logger)
+	issuer := tokens.NewIssuer(store, sig, *issuerURL, time.Hour, func() time.Time { return now }, logger)
 
 	accessToken := "test-access-token"
 	code := "test-auth-code"
-	idToken, _, err := s.issuer.SignIDToken(ctx, tokens.Authorization{
+	idToken, _, err := issuer.SignIDToken(ctx, tokens.Authorization{
 		Client:      storage.Client{ID: "test-client"},
 		Claims:      storage.Claims{UserID: "1", Username: "jane"},
 		Scopes:      []string{"openid"},
@@ -268,15 +259,7 @@ func TestNewIDTokenContainsJTI(t *testing.T) {
 	issuerURL, err := url.Parse("https://issuer.example.com")
 	require.NoError(t, err)
 
-	s := &Server{
-		signer:           sig,
-		issuerURL:        oauth2.IssuerURL{URL: *issuerURL},
-		logger:           logger,
-		now:              func() time.Time { return now },
-		idTokensValidFor: time.Hour,
-	}
-
-	s.issuer = tokens.NewIssuer(store, s.signer, s.issuerURL.URL, s.idTokensValidFor, s.now, s.logger)
+	issuer := tokens.NewIssuer(store, sig, *issuerURL, time.Hour, func() time.Time { return now }, logger)
 
 	keys, err := sig.ValidationKeys(ctx)
 	require.NoError(t, err)
@@ -298,7 +281,7 @@ func TestNewIDTokenContainsJTI(t *testing.T) {
 
 	mint := func(nonce string) string {
 		t.Helper()
-		token, _, err := s.issuer.SignIDToken(ctx, tokens.Authorization{
+		token, _, err := issuer.SignIDToken(ctx, tokens.Authorization{
 			Client:      storage.Client{ID: "client"},
 			Claims:      storage.Claims{UserID: "1", Username: "alice"},
 			Scopes:      []string{"openid"},

--- a/server/server_oauth2_test.go
+++ b/server/server_oauth2_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/signer"
 	"github.com/dexidp/dex/server/tokens"
 	"github.com/dexidp/dex/storage"
@@ -182,13 +183,13 @@ func TestNewIDTokenUsesStoredAlgorithmUntilNextRotation(t *testing.T) {
 
 	s := &Server{
 		signer:           sig,
-		issuerURL:        *issuerURL,
+		issuerURL:        oauth2.IssuerURL{URL: *issuerURL},
 		logger:           logger,
 		now:              func() time.Time { return now },
 		idTokensValidFor: time.Hour,
 	}
 
-	s.issuer = tokens.NewIssuer(store, s.signer, s.issuerURL, s.idTokensValidFor, s.now, s.logger)
+	s.issuer = tokens.NewIssuer(store, s.signer, s.issuerURL.URL, s.idTokensValidFor, s.now, s.logger)
 
 	accessToken := "test-access-token"
 	code := "test-auth-code"
@@ -269,13 +270,13 @@ func TestNewIDTokenContainsJTI(t *testing.T) {
 
 	s := &Server{
 		signer:           sig,
-		issuerURL:        *issuerURL,
+		issuerURL:        oauth2.IssuerURL{URL: *issuerURL},
 		logger:           logger,
 		now:              func() time.Time { return now },
 		idTokensValidFor: time.Hour,
 	}
 
-	s.issuer = tokens.NewIssuer(store, s.signer, s.issuerURL, s.idTokensValidFor, s.now, s.logger)
+	s.issuer = tokens.NewIssuer(store, s.signer, s.issuerURL.URL, s.idTokensValidFor, s.now, s.logger)
 
 	keys, err := sig.ValidationKeys(ctx)
 	require.NoError(t, err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/dexidp/dex/connector"
 	"github.com/dexidp/dex/connector/mock"
 	"github.com/dexidp/dex/pkg/featureflags"
+	"github.com/dexidp/dex/server/connectors"
 	"github.com/dexidp/dex/server/device"
 	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/session"
@@ -1298,7 +1299,7 @@ func TestPasswordDB(t *testing.T) {
 
 	logger := newLogger(t)
 	s := memory.New(logger)
-	conn := newPasswordDB(s)
+	conn := connectors.NewPasswordDB(s)
 
 	pw := "hi"
 
@@ -1388,7 +1389,7 @@ func TestPasswordDB(t *testing.T) {
 func TestPasswordDBUsernamePrompt(t *testing.T) {
 	logger := newLogger(t)
 	s := memory.New(logger)
-	conn := newPasswordDB(s)
+	conn := connectors.NewPasswordDB(s)
 
 	expected := "Email Address"
 	if actual := conn.Prompt(); actual != expected {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -173,6 +173,7 @@ func newTestServerMultipleConnectors(t *testing.T, updateConfig func(c *Config))
 		Logger:             logger,
 		PrometheusRegistry: prometheus.NewRegistry(),
 		Signer:             sig,
+		SkipApprovalScreen: true, // Don't prompt for approval, just immediately redirect with code.
 	}
 	if updateConfig != nil {
 		updateConfig(&config)
@@ -210,7 +211,6 @@ func newTestServerMultipleConnectors(t *testing.T, updateConfig func(c *Config))
 	if server, err = newServer(ctx, config); err != nil {
 		t.Fatal(err)
 	}
-	server.skipApproval = true // Don't prompt for approval, just immediately redirect with code.
 	return s, server
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1652,7 +1652,7 @@ func TestOAuth2DeviceFlow(t *testing.T) {
 				// Add the Clients to the test server
 				client := storage.Client{
 					ID:           clientID,
-					RedirectURIs: []string{s.absPath(oauth2.DeviceCallbackURI)},
+					RedirectURIs: []string{s.issuerURL.AbsPath(oauth2.DeviceCallbackURI)},
 					Public:       true,
 				}
 				if err := s.storage.CreateClient(ctx, client); err != nil {
@@ -1763,7 +1763,7 @@ func TestOAuth2DeviceFlow(t *testing.T) {
 					ClientSecret: client.Secret,
 					Endpoint:     p.Endpoint(),
 					Scopes:       requestedScopes,
-					RedirectURL:  s.absURL(oauth2.DeviceCallbackURI),
+					RedirectURL:  s.issuerURL.AbsURL(oauth2.DeviceCallbackURI),
 				}
 				if len(tc.scopes) != 0 {
 					oauth2Config.Scopes = tc.scopes
@@ -1832,7 +1832,7 @@ func TestServerSupportedGrants(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			_, srv := newTestServer(t, tc.config)
-			require.Equal(t, tc.resGrants, srv.supportedGrantTypes)
+			require.Equal(t, tc.resGrants, srv.discovery.GrantTypes)
 		})
 	}
 }

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/dexidp/dex/server/internal"
+	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/reqctx"
 	"github.com/dexidp/dex/storage"
 )
@@ -33,7 +33,7 @@ type Manager struct {
 	Config    *Config
 	Now       func() time.Time
 	Logger    *slog.Logger
-	IssuerURL url.URL
+	IssuerURL oauth2.IssuerURL
 }
 
 // Enabled reports whether sessions are configured.


### PR DESCRIPTION
#### Overview

Housekeeping on the `server` package after the handler-extraction refactor: the `Server` struct had accumulated fields and methods that no longer earn their place, the issuer-URL path helpers were copy-pasted across every handler, and the gRPC API reached back into the Server for discovery.

#### What this PR does / why we need it

- **One issuer-URL helper.** New `oauth2.IssuerURL` wraps `url.URL` with `AbsPath`/`AbsURL`. Handlers hold it instead of a bare `url.URL`, replacing four identical `absPath` and three `absURL` implementations (authflow, consent, mfa, logout, and `Server`) with a single one.
- **Drop dead connector methods.** `Server.CloseConnector` had no callers left — the connector cache was extracted into `connectors.Cache`, and the gRPC API invalidates it directly (`d.connectors.Close`). `Server.OpenConnector` was a thin pass-through; its callers now use `s.connectors.Open`. Both removed.
- **Build discovery once, hand it to the API.** The discovery handler was reconstructed from scattered `Server` fields on every call; it is now built once and stored. `apiserver.NewAPI` takes the `*discovery.Handler` directly (symmetric with the `*connectors.Cache` it already holds) instead of a `func(ctx) Document` that called back into the Server, and `Server.ConstructDiscovery` becomes a plain `Discovery()` accessor.
- **Slim the Server struct.** Six construction-only fields (`alwaysShowLogin`, `passwordConnector`, `auth`/`deviceRequestsValidFor`, `mfaProviders`, `defaultMFAChain`) only ever fed a handler at wiring time and are now locals / direct config reads. Together with the discovery change, the struct drops from 20 fields to 14 — the ones actually read after construction, plus a few the in-package tests use.
- **Concrete `routeMux`.** It was a bundle of four closures with four delegating methods over a fifth header-wrapping closure. It is now a real `router.Mux` implementation: issuer-path prefixing, header/context wrapping, and CORS live in its methods, and the direct routes (`/healthz`, `/static`, `/robots.txt`) go through it too.

No behavior change; existing tests cover the affected paths.

#### Special notes for your reviewer

Tests that constructed handlers with a raw `url.URL` were updated to `oauth2.IssuerURL{...}`.
