### PR TITLE
refactor(server): untangle what the package split left behind

### DIFF
--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -442,6 +442,11 @@ func runServe(options serveOptions) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse client remote IP settings: %v", err)
 	}
+	if serverConfig.RealIPHeader != "" && len(serverConfig.TrustedRealIPCIDRs) == 0 {
+		logger.Warn("web.clientRemoteIP.header is set without web.clientRemoteIP.trustedProxies; "+
+			"the header is ignored because any client could spoof it",
+			"header", serverConfig.RealIPHeader)
+	}
 
 	serv, err := server.NewServer(context.Background(), serverConfig)
 	if err != nil {

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -58,6 +58,8 @@ web:
   #   X-XSS-Protection: "1; mode=block"
   #   Content-Security-Policy: "default-src 'self'"
   #   Strict-Transport-Security: "max-age=31536000; includeSubDomains"
+  # The header is read only for requests arriving from one of trustedProxies;
+  # without them any client could spoof it, so it is ignored.
   # clientRemoteIP:
   #   header: X-Forwarded-For
   #   trustedProxies:

--- a/server/apiserver/api_test.go
+++ b/server/apiserver/api_test.go
@@ -1,4 +1,4 @@
-package server
+package apiserver
 
 import (
 	"bytes"
@@ -13,7 +13,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/dexidp/dex/api/v2"
-	"github.com/dexidp/dex/server/apiserver"
 	"github.com/dexidp/dex/server/internal"
 	"github.com/dexidp/dex/storage"
 	"github.com/dexidp/dex/storage/memory"
@@ -42,7 +41,7 @@ func newAPI(t *testing.T, s storage.Storage, logger *slog.Logger) *apiClient {
 	}
 
 	serv := grpc.NewServer()
-	api.RegisterDexServer(serv, apiserver.NewAPI(s, logger, "test", nil, nil))
+	api.RegisterDexServer(serv, NewAPI(s, logger, "test", nil, nil))
 	go serv.Serve(l)
 
 	// NewClient will retry automatically if the serv.Serve() goroutine

--- a/server/apiserver/connectors_test.go
+++ b/server/apiserver/connectors_test.go
@@ -1,4 +1,4 @@
-package server
+package apiserver
 
 import (
 	"context"
@@ -8,7 +8,6 @@ import (
 	"github.com/dexidp/dex/api/v2"
 	"github.com/dexidp/dex/connector"
 	"github.com/dexidp/dex/connector/mock"
-	"github.com/dexidp/dex/server/apiserver"
 	"github.com/dexidp/dex/server/connectors"
 	"github.com/dexidp/dex/storage/memory"
 )
@@ -19,15 +18,15 @@ func TestConnectorCacheInvalidation(t *testing.T) {
 	logger := newLogger(t)
 	s := memory.New(logger)
 
-	serv := &Server{
-		storage: s,
-		logger:  logger,
-	}
-	serv.connectors = connectors.NewCache(s, connectors.Resolver(s, logger, ConnectorsConfig))
+	// Only the connector type this test creates needs to resolve; the config map
+	// is injected, so the API's tests need none of dex's real connectors.
+	conns := connectors.NewCache(s, connectors.Resolver(s, logger, map[string]func() connectors.ConnectorConfig{
+		"mockPassword": func() connectors.ConnectorConfig { return new(mock.PasswordConfig) },
+	}))
 
 	// This test exercises connector-cache invalidation, not discovery, so no
 	// discovery handler is wired (GetDiscovery guards against nil).
-	apiServer := apiserver.NewAPI(s, logger, "test", serv.connectors, nil)
+	apiServer := NewAPI(s, logger, "test", conns, nil)
 	ctx := context.Background()
 
 	connID := "mock-conn"
@@ -52,7 +51,7 @@ func TestConnectorCacheInvalidation(t *testing.T) {
 	}
 
 	// 2. Load it into server cache
-	c1, err := serv.connectors.Get(ctx, connID)
+	c1, err := conns.Get(ctx, connID)
 	if err != nil {
 		t.Fatalf("failed to get connector: %v", err)
 	}
@@ -89,7 +88,7 @@ func TestConnectorCacheInvalidation(t *testing.T) {
 	}
 
 	// 5. Load it again
-	c2, err := serv.connectors.Get(ctx, connID)
+	c2, err := conns.Get(ctx, connID)
 	if err != nil {
 		t.Fatalf("failed to get connector second time: %v", err)
 	}
@@ -123,7 +122,7 @@ func TestConnectorCacheInvalidation(t *testing.T) {
 	}
 
 	// 7. Load it again
-	c3, err := serv.connectors.Get(ctx, connID)
+	c3, err := conns.Get(ctx, connID)
 	if err != nil {
 		t.Fatalf("failed to get connector third time: %v", err)
 	}

--- a/server/authflow/callback.go
+++ b/server/authflow/callback.go
@@ -105,7 +105,8 @@ func (h *Handler) handleConnectorCallback(w http.ResponseWriter, r *http.Request
 
 	// Connector callbacks don't render the remember_me checkbox, so we use the server default.
 	// The password login handler reads r.FormValue("remember_me") from the submitted form instead.
-	if err := h.Sessions.CreateOrUpdateAuthSession(ctx, r, w, authReq, h.Sessions.DefaultRememberMe()); err != nil {
+	rememberMe := h.Sessions.RememberMeDefault()
+	if err := h.Sessions.CreateOrUpdateAuthSession(ctx, r, w, authReq, rememberMe != nil && *rememberMe); err != nil {
 		h.Logger.ErrorContext(ctx, "failed to create/update auth session", "err", err)
 	}
 

--- a/server/authflow/dispatch.go
+++ b/server/authflow/dispatch.go
@@ -43,8 +43,8 @@ func (h *Handler) handleContinue(w http.ResponseWriter, r *http.Request) {
 	// A step returns with the "continue" verifier (login, MFA) or the "approved"
 	// verifier (consent). The latter proves the user just approved, so consent is
 	// resolved for this request even under prompt=consent / ForceApprovalPrompt.
-	consentApproved := internal.VerifyHMAC(authReq.HMACKey, mac, authReq.ID, "approved")
-	if !consentApproved && !internal.VerifyHMAC(authReq.HMACKey, mac, authReq.ID, "continue") {
+	consentApproved := internal.VerifyStep(authReq, mac, internal.StepApproved)
+	if !consentApproved && !internal.VerifyStep(authReq, mac, internal.StepContinue) {
 		h.renderError(r, w, http.StatusUnauthorized, "Unauthorized request")
 		return
 	}

--- a/server/authflow/render.go
+++ b/server/authflow/render.go
@@ -2,11 +2,11 @@ package authflow
 
 import (
 	"net/http"
+
+	"github.com/dexidp/dex/server/templates"
 )
 
 // renderError renders a user-facing HTML error page.
 func (h *Handler) renderError(r *http.Request, w http.ResponseWriter, status int, description string) {
-	if err := h.Templates.Err(r, w, status, description); err != nil {
-		h.Logger.ErrorContext(r.Context(), "server template error", "err", err)
-	}
+	templates.RenderError(h.Templates, h.Logger, r, w, status, description)
 }

--- a/server/authflow/response.go
+++ b/server/authflow/response.go
@@ -185,7 +185,7 @@ func (h *Handler) issueAccessToken(ctx context.Context, w http.ResponseWriter, r
 	})
 	if err != nil {
 		h.Logger.ErrorContext(r.Context(), "failed to create new access token", "err", err)
-		h.tokenErrHelper(w, oauth2.ServerError, "", http.StatusInternalServerError)
+		h.writeError(w, oauth2.ServerError, "", http.StatusInternalServerError)
 		return false
 	}
 	resp.accessToken = accessToken
@@ -209,7 +209,7 @@ func (h *Handler) issueIDToken(ctx context.Context, w http.ResponseWriter, r *ht
 	}, resp.accessToken, resp.code.ID)
 	if err != nil {
 		h.Logger.ErrorContext(r.Context(), "failed to create ID token", "err", err)
-		h.tokenErrHelper(w, oauth2.ServerError, "", http.StatusInternalServerError)
+		h.writeError(w, oauth2.ServerError, "", http.StatusInternalServerError)
 		return false
 	}
 	resp.idToken = idToken
@@ -217,9 +217,7 @@ func (h *Handler) issueIDToken(ctx context.Context, w http.ResponseWriter, r *ht
 	return true
 }
 
-// tokenErrHelper writes an OAuth2 error response for the token-bearing flows.
-func (h *Handler) tokenErrHelper(w http.ResponseWriter, typ string, description string, statusCode int) {
-	if err := oauth2.WriteError(w, typ, description, statusCode); err != nil {
-		h.Logger.Error("token error response", "err", err)
-	}
+// writeError writes an OAuth2 error response for the token-bearing flows.
+func (h *Handler) writeError(w http.ResponseWriter, typ string, description string, statusCode int) {
+	oauth2.WriteErrorResponse(h.Logger, w, typ, description, statusCode)
 }

--- a/server/authflow/urls.go
+++ b/server/authflow/urls.go
@@ -1,8 +1,6 @@
 package authflow
 
 import (
-	"net/url"
-
 	"github.com/dexidp/dex/server/internal"
 	"github.com/dexidp/dex/storage"
 )
@@ -10,10 +8,7 @@ import (
 // buildContinueURL builds the HMAC-protected URL that returns to the /auth
 // dispatcher, used once login completes so the dispatcher can pick the next step.
 func (h *Handler) buildContinueURL(authReq storage.AuthRequest) string {
-	v := url.Values{}
-	v.Set("req", authReq.ID)
-	v.Set("hmac", internal.ComputeHMAC(authReq.HMACKey, authReq.ID, "continue"))
-	return h.IssuerURL.AbsPath("/auth") + "?" + v.Encode()
+	return internal.StepURL(h.IssuerURL.AbsPath("/auth"), authReq, internal.StepContinue, nil)
 }
 
 // buildMFAURL builds the HMAC-protected URL of the MFA entry, where the
@@ -21,17 +16,11 @@ func (h *Handler) buildContinueURL(authReq storage.AuthRequest) string {
 // effective chain and picks the factor; the dispatcher only decides that MFA
 // applies.
 func (h *Handler) buildMFAURL(authReq storage.AuthRequest) string {
-	v := url.Values{}
-	v.Set("req", authReq.ID)
-	v.Set("hmac", internal.ComputeHMAC(authReq.HMACKey, authReq.ID, "mfa"))
-	return h.IssuerURL.AbsPath("/mfa") + "?" + v.Encode()
+	return internal.StepURL(h.IssuerURL.AbsPath("/mfa"), authReq, internal.StepMFA, nil)
 }
 
 // buildApprovalURL builds the HMAC-protected URL of the consent screen, where the
 // dispatcher sends the user when consent is required.
 func (h *Handler) buildApprovalURL(authReq storage.AuthRequest) string {
-	v := url.Values{}
-	v.Set("req", authReq.ID)
-	v.Set("hmac", internal.ComputeHMAC(authReq.HMACKey, authReq.ID, "approval"))
-	return h.IssuerURL.AbsPath("/approval") + "?" + v.Encode()
+	return internal.StepURL(h.IssuerURL.AbsPath("/approval"), authReq, internal.StepApproval, nil)
 }

--- a/server/config.go
+++ b/server/config.go
@@ -1,0 +1,293 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"os"
+	"sort"
+	"time"
+
+	gosundheit "github.com/AppsFlyer/go-sundheit"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/dexidp/dex/server/authflow"
+	"github.com/dexidp/dex/server/mfa"
+	"github.com/dexidp/dex/server/oauth2"
+	"github.com/dexidp/dex/server/session"
+	"github.com/dexidp/dex/server/signer"
+	"github.com/dexidp/dex/server/templates"
+	"github.com/dexidp/dex/server/tokens"
+	"github.com/dexidp/dex/storage"
+	"github.com/dexidp/dex/web"
+)
+
+// Config holds the server's configuration options.
+//
+// Multiple servers using the same storage are expected to be configured identically.
+type Config struct {
+	Issuer string
+
+	// The backing persistence layer.
+	Storage storage.Storage
+
+	AllowedGrantTypes []string
+
+	// Valid values are "code" to enable the code flow and "token" to enable the implicit
+	// flow. If no response types are supplied this value defaults to "code".
+	SupportedResponseTypes []string
+
+	// Headers is a map of headers to be added to the all responses.
+	Headers http.Header
+
+	// Header to extract real ip from.
+	RealIPHeader       string
+	TrustedRealIPCIDRs []netip.Prefix
+
+	// List of allowed origins for CORS requests on discovery, token and keys endpoint.
+	// If none are indicated, CORS requests are disabled. Passing in "*" will allow any
+	// domain.
+	AllowedOrigins []string
+
+	// List of allowed headers for CORS requests on discovery, token, and keys endpoint.
+	AllowedHeaders []string
+
+	// If enabled, the server won't prompt the user to approve authorization requests.
+	// Logging in implies approval.
+	SkipApprovalScreen bool
+
+	// If enabled, the connectors selection page will always be shown even if there's only one
+	AlwaysShowLoginScreen bool
+
+	IDTokensValidFor       time.Duration // Defaults to 24 hours
+	AuthRequestsValidFor   time.Duration // Defaults to 24 hours
+	DeviceRequestsValidFor time.Duration // Defaults to 5 minutes
+
+	// Refresh token expiration settings
+	RefreshTokenPolicy *tokens.RefreshStrategy
+
+	// If set, the server will use this connector to handle password grants
+	PasswordConnector string
+
+	// PKCE configuration
+	PKCE authflow.PKCEConfig
+
+	GCFrequency time.Duration // Defaults to 5 minutes
+
+	// If specified, the server will use this function for determining time.
+	Now func() time.Time
+
+	Web WebConfig
+
+	Logger *slog.Logger
+
+	// Signer is used to sign tokens.
+	Signer signer.Signer
+
+	PrometheusRegistry *prometheus.Registry
+
+	HealthChecker gosundheit.Health
+
+	// If enabled, the server will continue starting even if some connectors fail to initialize.
+	// This allows the server to operate with a subset of connectors if some are misconfigured.
+	ContinueOnConnectorFailure bool
+
+	// SessionConfig holds session settings. Nil when sessions are disabled.
+	SessionConfig *session.Config
+
+	// MFAProviders maps authenticator IDs to their provider implementations.
+	MFAProviders map[string]mfa.Provider
+
+	// DefaultMFAChain is applied to clients that don't specify their own mfaChain.
+	DefaultMFAChain []string
+}
+
+// WebConfig holds the server's frontend templates and asset configuration.
+type WebConfig struct {
+	// A file path to static web assets.
+	//
+	// It is expected to contain the following directories:
+	//
+	//   * static - Static static served at "( issuer URL )/static".
+	//   * templates - HTML templates controlled by dex.
+	//   * themes/(theme) - Static static served at "( issuer URL )/theme".
+	Dir string
+
+	// Alternative way to programmatically configure static web assets.
+	// If Dir is specified, WebFS is ignored.
+	// It's expected to contain the same files and directories as mentioned above.
+	//
+	// Note: this is experimental. Might get removed without notice!
+	WebFS fs.FS
+
+	// Defaults to "( issuer URL )/theme/logo.png"
+	LogoURL string
+
+	// Defaults to "dex"
+	Issuer string
+
+	// Defaults to "light"
+	Theme string
+
+	// Map of extra values passed into the templates
+	Extra map[string]string
+}
+
+func value(val, defaultValue time.Duration) time.Duration {
+	if val == 0 {
+		return defaultValue
+	}
+	return val
+}
+
+// resolvedConfig is Config after defaults are filled in and values validated:
+// everything the handlers are wired from, derived once so newServer only has to
+// hand the pieces out.
+type resolvedConfig struct {
+	issuerURL oauth2.IssuerURL
+	now       func() time.Time
+
+	// responseTypes and grantTypes are what the server advertises and accepts,
+	// narrowed to the configured subset.
+	responseTypes map[string]bool
+	grantTypes    []string
+
+	authRequestsValidFor   time.Duration
+	deviceRequestsValidFor time.Duration
+	idTokensValidFor       time.Duration
+
+	templates *templates.Templates
+	static    http.Handler
+	theme     http.Handler
+	robots    http.HandlerFunc
+}
+
+// normalizeConfig validates c and derives everything the server is built from.
+// It fills c's own defaults in place (response types, allowed headers, PKCE
+// methods), because the handlers read those fields directly.
+func normalizeConfig(c *Config) (resolvedConfig, error) {
+	if c.Storage == nil {
+		return resolvedConfig{}, errors.New("server: storage cannot be nil")
+	}
+
+	issuerURL, err := url.Parse(c.Issuer)
+	if err != nil {
+		return resolvedConfig{}, fmt.Errorf("server: can't parse issuer URL")
+	}
+
+	if len(c.SupportedResponseTypes) == 0 {
+		c.SupportedResponseTypes = []string{oauth2.ResponseTypeCode}
+	}
+	if len(c.AllowedHeaders) == 0 {
+		c.AllowedHeaders = []string{"Authorization"}
+	}
+	if len(c.PKCE.CodeChallengeMethodsSupported) == 0 {
+		c.PKCE.CodeChallengeMethodsSupported = []string{oauth2.PKCEMethodS256, oauth2.PKCEMethodPlain}
+	}
+	for _, m := range c.PKCE.CodeChallengeMethodsSupported {
+		if m != oauth2.PKCEMethodS256 && m != oauth2.PKCEMethodPlain {
+			return resolvedConfig{}, fmt.Errorf("unsupported PKCE challenge method %q", m)
+		}
+	}
+
+	responseTypes, grantTypes, err := supportedTypes(c)
+	if err != nil {
+		return resolvedConfig{}, err
+	}
+
+	static, theme, robots, tmpls, err := templates.LoadWebConfig(webConfig(c))
+	if err != nil {
+		return resolvedConfig{}, fmt.Errorf("server: failed to load web static: %v", err)
+	}
+
+	now := c.Now
+	if now == nil {
+		now = time.Now
+	}
+
+	return resolvedConfig{
+		issuerURL:              oauth2.IssuerURL{URL: *issuerURL},
+		now:                    now,
+		responseTypes:          responseTypes,
+		grantTypes:             grantTypes,
+		authRequestsValidFor:   value(c.AuthRequestsValidFor, 24*time.Hour),
+		deviceRequestsValidFor: value(c.DeviceRequestsValidFor, 5*time.Minute),
+		idTokensValidFor:       value(c.IDTokensValidFor, 24*time.Hour),
+		templates:              tmpls,
+		static:                 static,
+		theme:                  theme,
+		robots:                 robots,
+	}, nil
+}
+
+// supportedTypes resolves the response types the server accepts and the grant
+// types it advertises. A response type enabling the implicit flow adds the
+// implicit grant; AllowedGrantTypes, when set, narrows the result to it.
+func supportedTypes(c *Config) (map[string]bool, []string, error) {
+	allGrants := map[string]bool{
+		oauth2.GrantTypeAuthorizationCode: true,
+		oauth2.GrantTypeRefreshToken:      true,
+		oauth2.GrantTypeDeviceCode:        true,
+		oauth2.GrantTypeTokenExchange:     true,
+		oauth2.GrantTypeClientCredentials: true,
+	}
+	responseTypes := make(map[string]bool)
+
+	for _, respType := range c.SupportedResponseTypes {
+		switch respType {
+		case oauth2.ResponseTypeCode, oauth2.ResponseTypeIDToken, oauth2.ResponseTypeCodeIDToken:
+			// continue
+		case oauth2.ResponseTypeToken, oauth2.ResponseTypeCodeToken, oauth2.ResponseTypeIDTokenToken, oauth2.ResponseTypeCodeIDTokenToken:
+			// response_type=token is an implicit flow, let's add it to the discovery info
+			// https://datatracker.ietf.org/doc/html/rfc6749#section-4.2.1
+			allGrants[oauth2.GrantTypeImplicit] = true
+		default:
+			return nil, nil, fmt.Errorf("unsupported response_type %q", respType)
+		}
+		responseTypes[respType] = true
+	}
+
+	if c.PasswordConnector != "" {
+		allGrants[oauth2.GrantTypePassword] = true
+	}
+
+	var grantTypes []string
+	if len(c.AllowedGrantTypes) > 0 {
+		for _, grant := range c.AllowedGrantTypes {
+			if allGrants[grant] {
+				grantTypes = append(grantTypes, grant)
+			}
+		}
+	} else {
+		for grant := range allGrants {
+			grantTypes = append(grantTypes, grant)
+		}
+	}
+	sort.Strings(grantTypes)
+
+	return responseTypes, grantTypes, nil
+}
+
+// webConfig resolves where the frontend assets are loaded from: an explicit
+// directory, a caller-supplied filesystem, or the assets embedded in dex.
+func webConfig(c *Config) templates.Config {
+	webFS := web.FS()
+	if c.Web.Dir != "" {
+		webFS = os.DirFS(c.Web.Dir)
+	} else if c.Web.WebFS != nil {
+		webFS = c.Web.WebFS
+	}
+
+	return templates.Config{
+		WebFS:     webFS,
+		LogoURL:   c.Web.LogoURL,
+		IssuerURL: c.Issuer,
+		Issuer:    c.Web.Issuer,
+		Theme:     c.Web.Theme,
+		Extra:     c.Web.Extra,
+	}
+}

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dexidp/dex/server/oauth2"
+	"github.com/dexidp/dex/storage/memory"
+)
+
+// baseConfig is the minimum normalizeConfig accepts: storage and an issuer.
+// Building it needs no server, so the config rules can be tested on their own.
+func baseConfig(t *testing.T) Config {
+	return Config{
+		Issuer:  "https://dex.example.com",
+		Storage: memory.New(newLogger(t)),
+		Web:     WebConfig{Dir: "../web"},
+	}
+}
+
+func TestNormalizeConfigDefaults(t *testing.T) {
+	c := baseConfig(t)
+
+	rc, err := normalizeConfig(&c)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{oauth2.ResponseTypeCode}, c.SupportedResponseTypes)
+	require.Equal(t, []string{"Authorization"}, c.AllowedHeaders)
+	require.Equal(t, []string{oauth2.PKCEMethodS256, oauth2.PKCEMethodPlain}, c.PKCE.CodeChallengeMethodsSupported)
+
+	require.Equal(t, "https://dex.example.com", rc.issuerURL.String())
+	require.NotNil(t, rc.now)
+	require.NotNil(t, rc.templates)
+	require.Equal(t, map[string]bool{oauth2.ResponseTypeCode: true}, rc.responseTypes)
+
+	// Without AllowedGrantTypes every implemented grant is advertised, sorted,
+	// and the implicit grant is absent because no implicit response type is set.
+	// Sorted by value, so the two grant-type URNs come last.
+	require.Equal(t, []string{
+		oauth2.GrantTypeAuthorizationCode,
+		oauth2.GrantTypeClientCredentials,
+		oauth2.GrantTypeRefreshToken,
+		oauth2.GrantTypeDeviceCode,
+		oauth2.GrantTypeTokenExchange,
+	}, rc.grantTypes)
+}
+
+func TestNormalizeConfigGrantTypes(t *testing.T) {
+	t.Run("an implicit response type adds the implicit grant", func(t *testing.T) {
+		c := baseConfig(t)
+		c.SupportedResponseTypes = []string{oauth2.ResponseTypeCode, oauth2.ResponseTypeToken}
+
+		rc, err := normalizeConfig(&c)
+		require.NoError(t, err)
+		require.Contains(t, rc.grantTypes, oauth2.GrantTypeImplicit)
+	})
+
+	t.Run("a password connector adds the password grant", func(t *testing.T) {
+		c := baseConfig(t)
+		c.PasswordConnector = "local"
+
+		rc, err := normalizeConfig(&c)
+		require.NoError(t, err)
+		require.Contains(t, rc.grantTypes, oauth2.GrantTypePassword)
+	})
+
+	t.Run("AllowedGrantTypes narrows the set", func(t *testing.T) {
+		c := baseConfig(t)
+		c.AllowedGrantTypes = []string{oauth2.GrantTypeRefreshToken, "not-a-grant"}
+
+		rc, err := normalizeConfig(&c)
+		require.NoError(t, err)
+		require.Equal(t, []string{oauth2.GrantTypeRefreshToken}, rc.grantTypes)
+	})
+}
+
+func TestNormalizeConfigRejects(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+		errMsg string
+	}{
+		{
+			name:   "nil storage",
+			mutate: func(c *Config) { c.Storage = nil },
+			errMsg: "storage cannot be nil",
+		},
+		{
+			name:   "unparseable issuer",
+			mutate: func(c *Config) { c.Issuer = "://" },
+			errMsg: "can't parse issuer URL",
+		},
+		{
+			name:   "unknown response type",
+			mutate: func(c *Config) { c.SupportedResponseTypes = []string{"nonsense"} },
+			errMsg: `unsupported response_type "nonsense"`,
+		},
+		{
+			name: "unknown PKCE method",
+			mutate: func(c *Config) {
+				c.PKCE.CodeChallengeMethodsSupported = []string{"S512"}
+			},
+			errMsg: `unsupported PKCE challenge method "S512"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := baseConfig(t)
+			tc.mutate(&c)
+
+			_, err := normalizeConfig(&c)
+			require.ErrorContains(t, err, tc.errMsg)
+		})
+	}
+}

--- a/server/consent/consent.go
+++ b/server/consent/consent.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
-	"net/url"
 
 	"github.com/dexidp/dex/server/internal"
 	"github.com/dexidp/dex/server/oauth2"
@@ -42,10 +41,7 @@ func (h *Handler) Mount(mux router.Mux) {
 // dispatcher (/auth) with the "approved" verifier, so the dispatcher knows the
 // user consented and can issue.
 func (h *Handler) buildApprovedURL(authReq storage.AuthRequest) string {
-	v := url.Values{}
-	v.Set("req", authReq.ID)
-	v.Set("hmac", internal.ComputeHMAC(authReq.HMACKey, authReq.ID, "approved"))
-	return h.IssuerURL.AbsPath("/auth") + "?" + v.Encode()
+	return internal.StepURL(h.IssuerURL.AbsPath("/auth"), authReq, internal.StepApproved, nil)
 }
 
 // Satisfied reports whether the approval screen can be skipped: the client did
@@ -87,7 +83,7 @@ func (h *Handler) handleApproval(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !internal.VerifyHMAC(authReq.HMACKey, macEncoded, authReq.ID, "approval") {
+	if !internal.VerifyStep(authReq, macEncoded, internal.StepApproval) {
 		h.renderError(r, w, http.StatusUnauthorized, "Unauthorized request")
 		return
 	}

--- a/server/consent/consent.go
+++ b/server/consent/consent.go
@@ -30,9 +30,7 @@ type Handler struct {
 
 // renderError renders a user-facing HTML error page.
 func (h *Handler) renderError(r *http.Request, w http.ResponseWriter, status int, description string) {
-	if err := h.Templates.Err(r, w, status, description); err != nil {
-		h.Logger.ErrorContext(r.Context(), "server template error", "err", err)
-	}
+	templates.RenderError(h.Templates, h.Logger, r, w, status, description)
 }
 
 // Mount registers the consent endpoint.

--- a/server/device/device.go
+++ b/server/device/device.go
@@ -89,9 +89,7 @@ func (h *Handler) writeError(w http.ResponseWriter, typ, description string, sta
 
 // renderError renders an HTML error page.
 func (h *Handler) renderError(r *http.Request, w http.ResponseWriter, status int, description string) {
-	if err := h.Templates.Err(r, w, status, description); err != nil {
-		h.Logger.ErrorContext(r.Context(), "server template error", "err", err)
-	}
+	templates.RenderError(h.Templates, h.Logger, r, w, status, description)
 }
 
 func (h *Handler) getDeviceVerificationURI() string {

--- a/server/device/device.go
+++ b/server/device/device.go
@@ -82,9 +82,7 @@ func (h *Handler) writeFlowError(r *http.Request, w http.ResponseWriter, e *devi
 
 // writeError writes a JSON OAuth2 error response.
 func (h *Handler) writeError(w http.ResponseWriter, typ, description string, statusCode int) {
-	if err := oauth2.WriteError(w, typ, description, statusCode); err != nil {
-		h.Logger.Error("device error response", "err", err)
-	}
+	oauth2.WriteErrorResponse(h.Logger, w, typ, description, statusCode)
 }
 
 // renderError renders an HTML error page.

--- a/server/device/device.go
+++ b/server/device/device.go
@@ -169,7 +169,7 @@ func (h *Handler) createDeviceAuthorization(ctx context.Context, req deviceCodeR
 
 	deviceCode := storage.NewDeviceCode()
 	userCode := storage.NewUserCode()
-	expireTime := time.Now().Add(h.RequestsValidFor)
+	expireTime := h.Now().Add(h.RequestsValidFor)
 
 	if err := h.Storage.CreateDeviceRequest(ctx, storage.DeviceRequest{
 		UserCode:     userCode,

--- a/server/device/device_test.go
+++ b/server/device/device_test.go
@@ -1,12 +1,16 @@
 package device
 
 import (
+	"io"
+	"log/slog"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/dexidp/dex/server/oauth2"
+	"github.com/dexidp/dex/storage/memory"
 )
 
 func TestGetDeviceVerificationURI(t *testing.T) {
@@ -15,4 +19,41 @@ func TestGetDeviceVerificationURI(t *testing.T) {
 
 	h := &Handler{IssuerURL: oauth2.IssuerURL{URL: *u}}
 	require.Equal(t, "/non-root-path/device/auth/verify_code", h.getDeviceVerificationURI())
+}
+
+// TestCreateDeviceAuthorizationUsesInjectedClock pins the device request and
+// token expiry to the handler's clock. Both were minted from a mix of
+// time.Now() and h.Now(), which made the two expiries drift apart under a
+// fixed test clock.
+func TestCreateDeviceAuthorizationUsesInjectedClock(t *testing.T) {
+	u, err := url.Parse("https://dex.example.com")
+	require.NoError(t, err)
+
+	fixed := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	h := &Handler{
+		IssuerURL:        oauth2.IssuerURL{URL: *u},
+		Storage:          memory.New(logger),
+		Logger:           logger,
+		Now:              func() time.Time { return fixed },
+		RequestsValidFor: 5 * time.Minute,
+	}
+
+	resp, ferr := h.createDeviceAuthorization(t.Context(), deviceCodeRequest{
+		clientID: "test",
+		scopes:   []string{"openid"},
+	})
+	require.Nil(t, ferr)
+
+	want := fixed.Add(5 * time.Minute)
+
+	req, err := h.Storage.GetDeviceRequest(t.Context(), resp.UserCode)
+	require.NoError(t, err)
+	require.WithinDuration(t, want, req.Expiry, 0)
+
+	token, err := h.Storage.GetDeviceToken(t.Context(), resp.DeviceCode)
+	require.NoError(t, err)
+	require.WithinDuration(t, want, token.Expiry, 0)
+	require.WithinDuration(t, fixed, token.LastRequestTime, 0)
 }

--- a/server/discovery/discovery.go
+++ b/server/discovery/discovery.go
@@ -39,9 +39,7 @@ type Handler struct {
 
 // renderError renders a user-facing HTML error page.
 func (h *Handler) renderError(r *http.Request, w http.ResponseWriter, status int, description string) {
-	if err := h.Templates.Err(r, w, status, description); err != nil {
-		h.Logger.ErrorContext(r.Context(), "server template error", "err", err)
-	}
+	templates.RenderError(h.Templates, h.Logger, r, w, status, description)
 }
 
 // Mount registers the discovery routes.

--- a/server/discovery/discovery.go
+++ b/server/discovery/discovery.go
@@ -13,17 +13,18 @@ import (
 
 	jose "github.com/go-jose/go-jose/v4"
 
+	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/router"
 	"github.com/dexidp/dex/server/signer"
+	"github.com/dexidp/dex/server/templates"
 )
 
-// Handler serves the discovery document and the JWKS. AbsURL builds an absolute
-// URL under the issuer; RenderError renders an HTML error page. Both are
-// supplied by the server so the handler does not depend on the whole Server.
+// Handler serves the discovery document and the JWKS. Like every other domain
+// handler it takes the issuer URL and the templates directly, so it can be
+// built without a Server.
 type Handler struct {
-	Issuer          string
-	AbsURL          func(...string) string
-	RenderError     func(*http.Request, http.ResponseWriter, int, string)
+	IssuerURL       oauth2.IssuerURL
+	Templates       *templates.Templates
 	Signer          signer.Signer
 	Logger          *slog.Logger
 	ResponseTypes   map[string]bool
@@ -34,6 +35,13 @@ type Handler struct {
 	docOnce sync.Once
 	docData []byte
 	docErr  error
+}
+
+// renderError renders a user-facing HTML error page.
+func (h *Handler) renderError(r *http.Request, w http.ResponseWriter, status int, description string) {
+	if err := h.Templates.Err(r, w, status, description); err != nil {
+		h.Logger.ErrorContext(r.Context(), "server template error", "err", err)
+	}
 }
 
 // Mount registers the discovery routes.
@@ -69,13 +77,13 @@ func (h *Handler) Keys(w http.ResponseWriter, r *http.Request) {
 	keys, err := h.Signer.ValidationKeys(ctx)
 	if err != nil {
 		h.Logger.ErrorContext(ctx, "failed to get keys", "err", err)
-		h.RenderError(r, w, http.StatusInternalServerError, "Internal server error.")
+		h.renderError(r, w, http.StatusInternalServerError, "Internal server error.")
 		return
 	}
 
 	if len(keys) == 0 {
 		h.Logger.ErrorContext(ctx, "no public keys found.")
-		h.RenderError(r, w, http.StatusInternalServerError, "Internal server error.")
+		h.renderError(r, w, http.StatusInternalServerError, "Internal server error.")
 		return
 	}
 
@@ -89,7 +97,7 @@ func (h *Handler) Keys(w http.ResponseWriter, r *http.Request) {
 	data, err := json.MarshalIndent(jwks, "", "  ")
 	if err != nil {
 		h.Logger.ErrorContext(ctx, "failed to marshal discovery data", "err", err)
-		h.RenderError(r, w, http.StatusInternalServerError, "Internal server error.")
+		h.renderError(r, w, http.StatusInternalServerError, "Internal server error.")
 		return
 	}
 
@@ -110,7 +118,7 @@ func (h *Handler) serveDocument(w http.ResponseWriter, r *http.Request) {
 	})
 	if h.docErr != nil {
 		h.Logger.ErrorContext(r.Context(), "failed to marshal discovery data", "err", h.docErr)
-		h.RenderError(r, w, http.StatusInternalServerError, "Internal server error.")
+		h.renderError(r, w, http.StatusInternalServerError, "Internal server error.")
 		return
 	}
 
@@ -122,13 +130,13 @@ func (h *Handler) serveDocument(w http.ResponseWriter, r *http.Request) {
 // Construct builds the discovery document from the current configuration.
 func (h *Handler) Construct(ctx context.Context) Document {
 	d := Document{
-		Issuer:            h.Issuer,
-		Auth:              h.AbsURL("/auth"),
-		Token:             h.AbsURL("/token"),
-		Keys:              h.AbsURL("/keys"),
-		UserInfo:          h.AbsURL("/userinfo"),
-		DeviceEndpoint:    h.AbsURL("/device/code"),
-		Introspect:        h.AbsURL("/token/introspect"),
+		Issuer:            h.IssuerURL.String(),
+		Auth:              h.IssuerURL.AbsURL("/auth"),
+		Token:             h.IssuerURL.AbsURL("/token"),
+		Keys:              h.IssuerURL.AbsURL("/keys"),
+		UserInfo:          h.IssuerURL.AbsURL("/userinfo"),
+		DeviceEndpoint:    h.IssuerURL.AbsURL("/device/code"),
+		Introspect:        h.IssuerURL.AbsURL("/token/introspect"),
 		Subjects:          []string{"public"},
 		IDTokenAlgs:       []string{string(jose.RS256)},
 		CodeChallengeAlgs: h.PKCEMethods,
@@ -156,7 +164,7 @@ func (h *Handler) Construct(ctx context.Context) Document {
 	d.GrantTypes = h.GrantTypes
 
 	if h.SessionsEnabled {
-		d.EndSession = h.AbsURL("/logout")
+		d.EndSession = h.IssuerURL.AbsURL("/logout")
 	}
 
 	return d

--- a/server/discovery/discovery_test.go
+++ b/server/discovery/discovery_test.go
@@ -5,12 +5,13 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"log/slog"
-	"strings"
+	"net/url"
 	"testing"
 
 	jose "github.com/go-jose/go-jose/v4"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/signer"
 )
 
@@ -21,9 +22,11 @@ func testHandler(t *testing.T, sessionsEnabled bool) *Handler {
 	sig, err := signer.NewMockSigner(key)
 	require.NoError(t, err)
 
+	u, err := url.Parse("https://dex.example.com")
+	require.NoError(t, err)
+
 	return &Handler{
-		Issuer:          "https://dex.example.com",
-		AbsURL:          func(p ...string) string { return "https://dex.example.com" + strings.Join(p, "") },
+		IssuerURL:       oauth2.IssuerURL{URL: *u},
 		Signer:          sig,
 		Logger:          slog.New(slog.DiscardHandler),
 		ResponseTypes:   map[string]bool{"id_token": true, "code": true},

--- a/server/grants/grants.go
+++ b/server/grants/grants.go
@@ -373,9 +373,7 @@ func (h *Handler) writeError(ctx context.Context, w http.ResponseWriter, err err
 		h.Logger.ErrorContext(ctx, "token request failed", "err", err)
 		oerr = &oauth2.Error{Type: oauth2.ServerError, Status: http.StatusInternalServerError}
 	}
-	if werr := oauth2.WriteError(w, oerr.Type, oerr.Description, oerr.Status); werr != nil {
-		h.Logger.ErrorContext(ctx, "failed to write token error response", "err", werr)
-	}
+	oauth2.WriteErrorResponse(h.Logger, w, oerr.Type, oerr.Description, oerr.Status)
 }
 
 // issue mints the standard token response — the single mint every standard grant

--- a/server/helpers_test.go
+++ b/server/helpers_test.go
@@ -7,12 +7,21 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
+	gosundheit "github.com/AppsFlyer/go-sundheit"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dexidp/dex/connector"
+	"github.com/dexidp/dex/pkg/featureflags"
 	"github.com/dexidp/dex/server/connectors"
+	"github.com/dexidp/dex/server/oauth2"
+	"github.com/dexidp/dex/server/session"
+	"github.com/dexidp/dex/server/signer"
+	"github.com/dexidp/dex/server/tokens"
 	"github.com/dexidp/dex/storage"
+	"github.com/dexidp/dex/storage/memory"
 )
 
 func boolPtr(v bool) *bool {
@@ -190,4 +199,127 @@ func (m *mockSAMLRefreshConnector) HandlePOST(s connector.Scopes, samlResponse, 
 
 func (m *mockSAMLRefreshConnector) Refresh(ctx context.Context, s connector.Scopes, ident connector.Identity) (connector.Identity, error) {
 	return m.refreshIdentity, nil
+}
+
+// testSessionKey is the AES key the test servers encrypt session cookies with.
+// Tests that forge a session cookie sign it with this key rather than reading
+// the key back off the server they are exercising.
+var testSessionKey = []byte("0123456789abcdef0123456789abcdef")
+
+// mockConnector is the connector every test server serves.
+func mockConnector(id string) storage.Connector {
+	return storage.Connector{
+		ID:              id,
+		Type:            "mockCallback",
+		Name:            "Mock",
+		ResourceVersion: "1",
+	}
+}
+
+// testSessionConfig is the session config the test servers run with.
+func testSessionConfig() *session.Config {
+	return &session.Config{
+		CookieName:          "dex_session",
+		CookieEncryptionKey: testSessionKey,
+		AbsoluteLifetime:    24 * time.Hour,
+		ValidIfNotUsedFor:   time.Hour,
+	}
+}
+
+// newTestServerWith builds a server serving conns, behind an httptest.Server
+// that dispatches to it. updateConfig adjusts the shared default config before
+// the server is built; the caller-facing constructors below are thin wrappers
+// that differ only in the connectors and the grant types they enable.
+func newTestServerWith(t *testing.T, conns []storage.Connector, updateConfig func(c *Config)) (*httptest.Server, *Server) {
+	t.Helper()
+
+	var server *Server
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server.ServeHTTP(w, r)
+	}))
+
+	logger := newLogger(t)
+	ctx := t.Context()
+
+	sig, err := signer.NewMockSigner(testKey)
+	require.NoError(t, err, "failed to create mock signer")
+
+	config := Config{
+		Issuer:  s.URL,
+		Storage: memory.New(logger),
+		Web: WebConfig{
+			Dir: "../web",
+		},
+		Logger:             logger,
+		PrometheusRegistry: prometheus.NewRegistry(),
+		HealthChecker:      gosundheit.New(),
+		SkipApprovalScreen: true, // Don't prompt for approval, just immediately redirect with code.
+		Signer:             sig,
+	}
+	if updateConfig != nil {
+		updateConfig(&config)
+	}
+	s.URL = config.Issuer
+
+	// Default rotation policy, set before the server is built so the token
+	// endpoint captures it.
+	if config.RefreshTokenPolicy == nil {
+		config.RefreshTokenPolicy = tokens.NewRefreshStrategy(true, 0, 0, 0, config.Now)
+	}
+
+	// Mirror cmd: the session config is present iff the sessions feature flag is on.
+	if featureflags.SessionsEnabled.Enabled() && config.SessionConfig == nil {
+		config.SessionConfig = testSessionConfig()
+	}
+
+	for _, conn := range conns {
+		require.NoError(t, config.Storage.CreateConnector(ctx, conn), "create connector")
+	}
+
+	server, err = newServer(ctx, config)
+	require.NoError(t, err)
+
+	return s, server
+}
+
+// newTestServer serves one mock connector with every implemented grant enabled.
+func newTestServer(t *testing.T, updateConfig func(c *Config)) (*httptest.Server, *Server) {
+	return newTestServerWith(t, []storage.Connector{mockConnector("mock")}, func(c *Config) {
+		c.AllowedGrantTypes = []string{ // all implemented types
+			oauth2.GrantTypeDeviceCode,
+			oauth2.GrantTypeAuthorizationCode,
+			oauth2.GrantTypeClientCredentials,
+			oauth2.GrantTypeRefreshToken,
+			oauth2.GrantTypeTokenExchange,
+			oauth2.GrantTypeImplicit,
+			oauth2.GrantTypePassword,
+		}
+		if updateConfig != nil {
+			updateConfig(c)
+		}
+	})
+}
+
+// newTestServerMultipleConnectors serves two mock connectors, for the paths that
+// depend on the connector selection screen.
+func newTestServerMultipleConnectors(t *testing.T, updateConfig func(c *Config)) (*httptest.Server, *Server) {
+	return newTestServerWith(t, []storage.Connector{mockConnector("mock"), mockConnector("mock2")}, updateConfig)
+}
+
+// newTestServerWithSessions serves one mock connector with sessions always on,
+// regardless of the feature flag.
+func newTestServerWithSessions(t *testing.T, updateConfig func(c *Config)) (*httptest.Server, *Server) {
+	return newTestServerWith(t, []storage.Connector{mockConnector("mock")}, func(c *Config) {
+		c.AllowedGrantTypes = []string{
+			oauth2.GrantTypeAuthorizationCode,
+			oauth2.GrantTypeClientCredentials,
+			oauth2.GrantTypeRefreshToken,
+			oauth2.GrantTypeTokenExchange,
+			oauth2.GrantTypeDeviceCode,
+		}
+		c.SessionConfig = testSessionConfig()
+		if updateConfig != nil {
+			updateConfig(c)
+		}
+	})
 }

--- a/server/helpers_test.go
+++ b/server/helpers_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -23,6 +24,10 @@ import (
 	"github.com/dexidp/dex/storage"
 	"github.com/dexidp/dex/storage/memory"
 )
+
+func newLogger(t *testing.T) *slog.Logger {
+	return slog.New(slog.NewTextHandler(t.Output(), &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
 
 func boolPtr(v bool) *bool {
 	return &v

--- a/server/home/home.go
+++ b/server/home/home.go
@@ -33,9 +33,7 @@ func (h *Handler) Mount(m router.Mux) {
 }
 
 func (h *Handler) renderError(r *http.Request, w http.ResponseWriter, status int, description string) {
-	if err := h.Templates.Err(r, w, status, description); err != nil {
-		h.Logger.ErrorContext(r.Context(), "server template error", "err", err)
-	}
+	templates.RenderError(h.Templates, h.Logger, r, w, status, description)
 }
 
 func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/flowstep.go
+++ b/server/internal/flowstep.go
@@ -1,0 +1,56 @@
+package internal
+
+import (
+	"maps"
+	"net/url"
+
+	"github.com/dexidp/dex/storage"
+)
+
+// Step names one hop of the interactive login flow. Every redirect between the
+// /auth dispatcher and a step (MFA, consent) carries an HMAC over the auth
+// request ID and the step it is good for, so a verifier minted for one hop
+// cannot be replayed against another.
+//
+// The labels are namespaced. Authenticator IDs come from the operator's config
+// and are signed the same way, so without the prefixes an authenticator named
+// "approved" would hand the user a valid consent verifier and let them skip the
+// approval screen.
+type Step string
+
+const (
+	// StepContinue returns to the /auth dispatcher so it can pick the next step.
+	// Login and every completed MFA factor use it.
+	StepContinue Step = "step:continue"
+	// StepMFA enters the MFA handler, which resolves the chain and picks a factor.
+	StepMFA Step = "step:mfa"
+	// StepApproval enters the consent screen.
+	StepApproval Step = "step:approval"
+	// StepApproved returns to the dispatcher from the consent screen and proves
+	// the user just approved, resolving consent for this request.
+	StepApproved Step = "step:approved"
+)
+
+// Authenticator returns the step of one MFA factor. The id comes from the
+// server's MFA config, so it is namespaced away from the flow's own steps.
+func Authenticator(id string) Step { return Step("authenticator:" + id) }
+
+// SignStep returns the verifier proving a redirect to step belongs to authReq.
+func SignStep(authReq storage.AuthRequest, step Step) string {
+	return ComputeHMAC(authReq.HMACKey, authReq.ID, string(step))
+}
+
+// VerifyStep reports whether mac is the verifier for step on authReq.
+func VerifyStep(authReq storage.AuthRequest, mac string, step Step) bool {
+	return VerifyHMAC(authReq.HMACKey, mac, authReq.ID, string(step))
+}
+
+// StepURL builds the URL of a flow step under base, carrying the auth request
+// ID and its verifier. extra adds step-specific query parameters and may be nil.
+func StepURL(base string, authReq storage.AuthRequest, step Step, extra url.Values) string {
+	v := url.Values{}
+	maps.Copy(v, extra)
+	v.Set("req", authReq.ID)
+	v.Set("hmac", SignStep(authReq, step))
+	return base + "?" + v.Encode()
+}

--- a/server/introspection/introspection.go
+++ b/server/introspection/introspection.go
@@ -333,10 +333,10 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		if intErr, ok := err.(*introspectionError); ok {
-			h.introspectErrHelper(w, intErr.typ, intErr.desc, intErr.code)
+			h.writeError(w, intErr.typ, intErr.desc, intErr.code)
 		} else {
 			h.Logger.ErrorContext(ctx, "an unknown error occurred", "err", err.Error())
-			h.introspectErrHelper(w, oauth2.ServerError, "An unknown error occurred", http.StatusInternalServerError)
+			h.writeError(w, oauth2.ServerError, "An unknown error occurred", http.StatusInternalServerError)
 		}
 
 		return
@@ -345,7 +345,7 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	rawJSON, jsonErr := json.Marshal(introspect)
 	if jsonErr != nil {
 		h.Logger.ErrorContext(ctx, "failed to marshal introspection response", "err", jsonErr)
-		h.introspectErrHelper(w, oauth2.ServerError, "", http.StatusInternalServerError)
+		h.writeError(w, oauth2.ServerError, "", http.StatusInternalServerError)
 		return
 	}
 
@@ -353,15 +353,14 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	w.Write(rawJSON)
 }
 
-func (h *Handler) introspectErrHelper(w http.ResponseWriter, typ, description string, statusCode int) {
+// writeError writes an OAuth2 error response. An inactive token is not an
+// error to the caller: RFC 7662 answers it with a 200 and active=false.
+func (h *Handler) writeError(w http.ResponseWriter, typ, description string, statusCode int) {
 	if typ == oauth2.InactiveToken {
 		introspectInactiveErr(w)
 		return
 	}
-
-	if err := oauth2.WriteError(w, typ, description, statusCode); err != nil {
-		h.Logger.Error("introspect error response", "err", err)
-	}
+	oauth2.WriteErrorResponse(h.Logger, w, typ, description, statusCode)
 }
 
 func introspectInactiveErr(w http.ResponseWriter) {

--- a/server/introspection/introspection_test.go
+++ b/server/introspection/introspection_test.go
@@ -158,7 +158,7 @@ func TestIntrospectErrHelper(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			w1 := httptest.NewRecorder()
 
-			h.introspectErrHelper(w1, tc.err.typ, tc.err.desc, tc.err.code)
+			h.writeError(w1, tc.err.typ, tc.err.desc, tc.err.code)
 
 			res := w1.Result()
 			require.Equal(t, tc.resStatusCode, res.StatusCode)

--- a/server/logout/logout.go
+++ b/server/logout/logout.go
@@ -39,9 +39,7 @@ type Handler struct {
 
 // renderError renders a user-facing HTML error page.
 func (h *Handler) renderError(r *http.Request, w http.ResponseWriter, status int, description string) {
-	if err := h.Templates.Err(r, w, status, description); err != nil {
-		h.Logger.ErrorContext(r.Context(), "server template error", "err", err)
-	}
+	templates.RenderError(h.Templates, h.Logger, r, w, status, description)
 }
 
 // Mount registers the logout endpoints. Logout requires an active session, so it

--- a/server/mfa/handler.go
+++ b/server/mfa/handler.go
@@ -74,7 +74,7 @@ func (h *Handler) validateMFARequest(w http.ResponseWriter, r *http.Request) (*m
 
 	authenticatorID := r.FormValue("authenticator")
 
-	if !internal.VerifyHMAC(authReq.HMACKey, macEncoded, authReq.ID, authenticatorID) {
+	if !internal.VerifyStep(authReq, macEncoded, internal.Authenticator(authenticatorID)) {
 		h.renderError(r, w, http.StatusUnauthorized, "Unauthorized request.")
 		return nil, false
 	}
@@ -208,7 +208,7 @@ func (h *Handler) handleMFA(w http.ResponseWriter, r *http.Request) {
 		h.renderError(r, w, http.StatusInternalServerError, "Login process not yet finalized.")
 		return
 	}
-	if !internal.VerifyHMAC(authReq.HMACKey, r.FormValue("hmac"), authReq.ID, "mfa") {
+	if !internal.VerifyStep(authReq, r.FormValue("hmac"), internal.StepMFA) {
 		h.renderError(r, w, http.StatusUnauthorized, "Unauthorized request.")
 		return
 	}
@@ -240,20 +240,18 @@ func (h *Handler) handleMFA(w http.ResponseWriter, r *http.Request) {
 
 // buildRedirectURL builds an HMAC-protected redirect URL for the given authenticator.
 func (h *Handler) buildRedirectURL(authReq storage.AuthRequest, authenticatorID string) string {
-	v := url.Values{}
-	v.Set("req", authReq.ID)
-	v.Set("hmac", internal.ComputeHMAC(authReq.HMACKey, authReq.ID, authenticatorID))
-	v.Set("authenticator", authenticatorID)
-	return h.IssuerURL.AbsPath(h.mfaPagePath(authenticatorID)) + "?" + v.Encode()
+	return internal.StepURL(
+		h.IssuerURL.AbsPath(h.mfaPagePath(authenticatorID)),
+		authReq,
+		internal.Authenticator(authenticatorID),
+		url.Values{"authenticator": {authenticatorID}},
+	)
 }
 
 // buildContinueURL builds the HMAC-protected URL that returns to the authorize
 // dispatcher (/auth) once a factor is done, so it can decide the next step.
 func (h *Handler) buildContinueURL(authReq storage.AuthRequest) string {
-	v := url.Values{}
-	v.Set("req", authReq.ID)
-	v.Set("hmac", internal.ComputeHMAC(authReq.HMACKey, authReq.ID, "continue"))
-	return h.IssuerURL.AbsPath("/auth") + "?" + v.Encode()
+	return internal.StepURL(h.IssuerURL.AbsPath("/auth"), authReq, internal.StepContinue, nil)
 }
 
 // Mount registers the MFA factor endpoints, only when at least one authenticator

--- a/server/mfa/handler.go
+++ b/server/mfa/handler.go
@@ -48,9 +48,7 @@ type Handler struct {
 
 // renderError renders a user-facing HTML error page.
 func (h *Handler) renderError(r *http.Request, w http.ResponseWriter, status int, description string) {
-	if err := h.Templates.Err(r, w, status, description); err != nil {
-		h.Logger.ErrorContext(r.Context(), "server template error", "err", err)
-	}
+	templates.RenderError(h.Templates, h.Logger, r, w, status, description)
 }
 
 func (h *Handler) validateMFARequest(w http.ResponseWriter, r *http.Request) (*mfaRequestContext, bool) {

--- a/server/mfa/handler_test.go
+++ b/server/mfa/handler_test.go
@@ -154,7 +154,7 @@ func TestMFAEntry(t *testing.T) {
 	}
 
 	get := func(router http.Handler, authReq storage.AuthRequest, hmacKey []byte) *httptest.ResponseRecorder {
-		hmacVal := internal.ComputeHMAC(hmacKey, authReq.ID, "mfa")
+		hmacVal := internal.SignStep(authReq, internal.StepMFA)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/mfa?req="+authReq.ID+"&hmac="+hmacVal, nil))
 		return w

--- a/server/mfa/webauthn_test.go
+++ b/server/mfa/webauthn_test.go
@@ -66,7 +66,7 @@ func TestWebAuthnVerifyPageRender(t *testing.T) {
 		LastLogin:           time.Now(),
 	}))
 
-	hmacVal := internal.ComputeHMAC(hmacKey, authReq.ID, "webauthn-1")
+	hmacVal := internal.SignStep(authReq, internal.Authenticator("webauthn-1"))
 
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet,

--- a/server/oauth2/error.go
+++ b/server/oauth2/error.go
@@ -3,6 +3,7 @@ package oauth2
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 )
@@ -26,6 +27,15 @@ func (e *Error) Error() string {
 // Errorf builds an *Error with a formatted description.
 func Errorf(typ string, status int, format string, args ...any) *Error {
 	return &Error{Type: typ, Description: fmt.Sprintf(format, args...), Status: status}
+}
+
+// WriteErrorResponse writes an OAuth2 error response, reporting a failure to
+// write it to the logger. Endpoints that answer in JSON call this rather than
+// each deciding how to handle a write failure.
+func WriteErrorResponse(logger *slog.Logger, w http.ResponseWriter, typ, description string, statusCode int) {
+	if err := WriteError(w, typ, description, statusCode); err != nil {
+		logger.Error("failed to write oauth2 error response", "err", err)
+	}
 }
 
 // WriteError writes an OAuth2 error response: a JSON body with the error code

--- a/server/router/realip.go
+++ b/server/router/realip.go
@@ -1,0 +1,41 @@
+package router
+
+import (
+	"net"
+	"net/http"
+	"net/netip"
+	"slices"
+)
+
+// ParseRealIP returns the resolver that Config.RealIP is set to: it reports the
+// client's IP for a request, reading it from the named header when — and only
+// when — the request reached dex through a trusted proxy.
+//
+// A request's peer address is trusted if it falls inside any one of the trusted
+// prefixes. The header is attacker-controlled for everyone else, so an untrusted
+// peer (including every peer when trusted is empty) is reported by its own
+// address. Callers that set a header without declaring trusted proxies get the
+// peer address, never the header.
+func ParseRealIP(header string, trusted []netip.Prefix) func(*http.Request) (string, error) {
+	return func(r *http.Request) (string, error) {
+		remoteAddr, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			return "", err
+		}
+
+		remoteIP, err := netip.ParseAddr(remoteAddr)
+		if err != nil {
+			return "", err
+		}
+
+		if !slices.ContainsFunc(trusted, func(n netip.Prefix) bool { return n.Contains(remoteIP) }) {
+			return remoteAddr, nil
+		}
+
+		if ip, err := netip.ParseAddr(r.Header.Get(header)); err == nil {
+			return ip.String(), nil
+		}
+
+		return remoteAddr, nil
+	}
+}

--- a/server/router/realip.go
+++ b/server/router/realip.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/netip"
 	"slices"
+	"strings"
 )
 
 // ParseRealIP returns the resolver that Config.RealIP is set to: it reports the
@@ -16,7 +17,19 @@ import (
 // peer (including every peer when trusted is empty) is reported by its own
 // address. Callers that set a header without declaring trusted proxies get the
 // peer address, never the header.
+//
+// The header may carry a chain of hops (X-Forwarded-For appends one per proxy,
+// left to right, so the rightmost is the closest). Only the hops added by the
+// trusted proxies can be believed: the client controls everything to the left of
+// its first trusted proxy and can prepend whatever it likes. So the chain is
+// walked from the right, skipping trusted hops, and the first untrusted one is
+// the client. A single-valued header (X-Real-IP) is a chain of one and needs no
+// special case.
 func ParseRealIP(header string, trusted []netip.Prefix) func(*http.Request) (string, error) {
+	isTrusted := func(ip netip.Addr) bool {
+		return slices.ContainsFunc(trusted, func(n netip.Prefix) bool { return n.Contains(ip) })
+	}
+
 	return func(r *http.Request) (string, error) {
 		remoteAddr, _, err := net.SplitHostPort(r.RemoteAddr)
 		if err != nil {
@@ -28,14 +41,24 @@ func ParseRealIP(header string, trusted []netip.Prefix) func(*http.Request) (str
 			return "", err
 		}
 
-		if !slices.ContainsFunc(trusted, func(n netip.Prefix) bool { return n.Contains(remoteIP) }) {
+		if !isTrusted(remoteIP) {
 			return remoteAddr, nil
 		}
 
-		if ip, err := netip.ParseAddr(r.Header.Get(header)); err == nil {
-			return ip.String(), nil
+		hops := strings.Split(r.Header.Get(header), ",")
+		for _, hop := range slices.Backward(hops) {
+			ip, err := netip.ParseAddr(strings.TrimSpace(hop))
+			if err != nil {
+				// A malformed hop breaks the chain: nothing to its left can be
+				// attributed to a trusted proxy, so stop and fall back.
+				break
+			}
+			if !isTrusted(ip) {
+				return ip.String(), nil
+			}
 		}
 
+		// Every hop was a trusted proxy, or the header was absent or malformed.
 		return remoteAddr, nil
 	}
 }

--- a/server/router/realip_test.go
+++ b/server/router/realip_test.go
@@ -81,6 +81,46 @@ func TestParseRealIP(t *testing.T) {
 			headerVal:  "203.0.113.9",
 			want:       "203.0.113.9",
 		},
+		{
+			// The whole header used to go to netip.ParseAddr, so any chain was
+			// unparseable and the header was dropped for the peer address.
+			name:       "chain through one trusted proxy",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: "10.1.2.3:1234",
+			headerVal:  "203.0.113.9, 10.1.2.3",
+			want:       "203.0.113.9",
+		},
+		{
+			name:       "chain through several trusted proxies",
+			trusted:    []string{"10.0.0.0/8", "192.168.0.0/16"},
+			remoteAddr: "10.1.2.3:1234",
+			headerVal:  "203.0.113.9, 192.168.1.1, 10.9.9.9",
+			want:       "203.0.113.9",
+		},
+		{
+			// The client prepended a hop of its own. Everything left of the first
+			// untrusted hop is its invention, so the untrusted hop is the client.
+			name:       "client-spoofed hops left of the real client",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: "10.1.2.3:1234",
+			headerVal:  "1.2.3.4, 198.51.100.7, 10.1.2.3",
+			want:       "198.51.100.7",
+		},
+		{
+			// Nothing left of a malformed hop can be attributed to a proxy.
+			name:       "malformed hop breaks the chain",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: "10.1.2.3:1234",
+			headerVal:  "203.0.113.9, garbage, 10.1.2.3",
+			want:       "10.1.2.3",
+		},
+		{
+			name:       "every hop is a trusted proxy",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: "10.1.2.3:1234",
+			headerVal:  "10.9.9.9, 10.1.2.3",
+			want:       "10.1.2.3",
+		},
 	}
 
 	for _, tc := range tests {

--- a/server/router/realip_test.go
+++ b/server/router/realip_test.go
@@ -31,7 +31,7 @@ func TestParseRealIP(t *testing.T) {
 		want       string
 	}{
 		{
-			name:       "trusted proxy, header honoured",
+			name:       "trusted proxy, header honored",
 			trusted:    []string{"10.0.0.0/8"},
 			remoteAddr: "10.1.2.3:1234",
 			headerVal:  "203.0.113.9",
@@ -40,7 +40,7 @@ func TestParseRealIP(t *testing.T) {
 		{
 			// The resolver used to return on the first prefix that did not match,
 			// so only the first entry of trustedProxies ever took effect.
-			name:       "trusted proxy in a later prefix, header honoured",
+			name:       "trusted proxy in a later prefix, header honored",
 			trusted:    []string{"10.0.0.0/8", "192.168.0.0/16"},
 			remoteAddr: "192.168.5.5:1234",
 			headerVal:  "203.0.113.9",

--- a/server/router/realip_test.go
+++ b/server/router/realip_test.go
@@ -1,0 +1,111 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func prefixes(t *testing.T, cidrs ...string) []netip.Prefix {
+	t.Helper()
+	out := make([]netip.Prefix, 0, len(cidrs))
+	for _, c := range cidrs {
+		p, err := netip.ParsePrefix(c)
+		require.NoError(t, err)
+		out = append(out, p)
+	}
+	return out
+}
+
+func TestParseRealIP(t *testing.T) {
+	const header = "X-Forwarded-For"
+
+	tests := []struct {
+		name       string
+		trusted    []string
+		remoteAddr string
+		headerVal  string
+		want       string
+	}{
+		{
+			name:       "trusted proxy, header honoured",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: "10.1.2.3:1234",
+			headerVal:  "203.0.113.9",
+			want:       "203.0.113.9",
+		},
+		{
+			// The resolver used to return on the first prefix that did not match,
+			// so only the first entry of trustedProxies ever took effect.
+			name:       "trusted proxy in a later prefix, header honoured",
+			trusted:    []string{"10.0.0.0/8", "192.168.0.0/16"},
+			remoteAddr: "192.168.5.5:1234",
+			headerVal:  "203.0.113.9",
+			want:       "203.0.113.9",
+		},
+		{
+			name:       "untrusted peer, header ignored",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: "203.0.113.1:1234",
+			headerVal:  "198.51.100.7",
+			want:       "203.0.113.1",
+		},
+		{
+			// Nothing is trusted, so the header is spoofable by any client.
+			name:       "no trusted proxies, header ignored",
+			trusted:    nil,
+			remoteAddr: "203.0.113.1:1234",
+			headerVal:  "198.51.100.7",
+			want:       "203.0.113.1",
+		},
+		{
+			name:       "trusted proxy, no header",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: "10.1.2.3:1234",
+			want:       "10.1.2.3",
+		},
+		{
+			name:       "trusted proxy, unparseable header",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: "10.1.2.3:1234",
+			headerVal:  "not-an-ip",
+			want:       "10.1.2.3",
+		},
+		{
+			name:       "IPv6 trusted proxy",
+			trusted:    []string{"2001:db8::/32"},
+			remoteAddr: "[2001:db8::1]:1234",
+			headerVal:  "203.0.113.9",
+			want:       "203.0.113.9",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resolve := ParseRealIP(header, prefixes(t, tc.trusted...))
+
+			r := httptest.NewRequest(http.MethodGet, "/auth", nil)
+			r.RemoteAddr = tc.remoteAddr
+			if tc.headerVal != "" {
+				r.Header.Set(header, tc.headerVal)
+			}
+
+			got, err := resolve(r)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestParseRealIPMalformedRemoteAddr(t *testing.T) {
+	resolve := ParseRealIP("X-Forwarded-For", prefixes(t, "10.0.0.0/8"))
+
+	r := httptest.NewRequest(http.MethodGet, "/auth", nil)
+	r.RemoteAddr = "no-port"
+
+	_, err := resolve(r)
+	require.Error(t, err)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/netip"
 	"net/url"
@@ -400,34 +399,6 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		}
 	}
 
-	parseRealIP := func(r *http.Request) (string, error) {
-		remoteAddr, _, err := net.SplitHostPort(r.RemoteAddr)
-		if err != nil {
-			return "", err
-		}
-
-		remoteIP, err := netip.ParseAddr(remoteAddr)
-		if err != nil {
-			return "", err
-		}
-
-		for _, n := range c.TrustedRealIPCIDRs {
-			if !n.Contains(remoteIP) {
-				return remoteAddr, nil // Fallback to the address from the request if the header is provided
-			}
-		}
-
-		ipVal := r.Header.Get(c.RealIPHeader)
-		if ipVal != "" {
-			ip, err := netip.ParseAddr(ipVal)
-			if err == nil {
-				return ip.String(), nil
-			}
-		}
-
-		return remoteAddr, nil
-	}
-
 	r := mux.NewRouter().SkipClean(true).UseEncodedPath()
 	r.NotFoundHandler = http.NotFoundHandler()
 
@@ -439,7 +410,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		Headers:      c.Headers,
 		RealIPHeader: c.RealIPHeader,
 		Instrument:   instrumentHandler,
-		RealIP:       parseRealIP,
+		RealIP:       router.ParseRealIP(c.RealIPHeader, c.TrustedRealIPCIDRs),
 		CORSOrigins:  c.AllowedOrigins,
 		CORSHeaders:  c.AllowedHeaders,
 	})

--- a/server/server.go
+++ b/server/server.go
@@ -312,9 +312,8 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 	// Build the discovery handler once from config; both the mounted HTTP route
 	// and the gRPC API (via Discovery) serve this same handler.
 	s.discovery = &discovery.Handler{
-		Issuer:          s.issuerURL.String(),
-		AbsURL:          s.issuerURL.AbsURL,
-		RenderError:     s.renderError,
+		IssuerURL:       s.issuerURL,
+		Templates:       s.templates,
 		Signer:          c.Signer,
 		Logger:          s.logger,
 		ResponseTypes:   supportedRes,

--- a/server/server.go
+++ b/server/server.go
@@ -584,7 +584,5 @@ func (s *Server) startGarbageCollection(ctx context.Context, frequency time.Dura
 // renderError renders a user-facing error page for the non-flow endpoints the
 // server still serves directly (e.g. /healthz).
 func (s *Server) renderError(r *http.Request, w http.ResponseWriter, status int, description string) {
-	if err := s.templates.Err(r, w, status, description); err != nil {
-		s.logger.ErrorContext(r.Context(), "server template error", "err", err)
-	}
+	templates.RenderError(s.templates, s.logger, r, w, status, description)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -4,17 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"log/slog"
 	"net/http"
-	"net/netip"
-	"net/url"
-	"os"
-	"sort"
 	"sync/atomic"
 	"time"
 
-	gosundheit "github.com/AppsFlyer/go-sundheit"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -33,131 +27,11 @@ import (
 	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/router"
 	"github.com/dexidp/dex/server/session"
-	"github.com/dexidp/dex/server/signer"
 	"github.com/dexidp/dex/server/templates"
 	"github.com/dexidp/dex/server/tokens"
 	"github.com/dexidp/dex/server/userinfo"
 	"github.com/dexidp/dex/storage"
-	"github.com/dexidp/dex/web"
 )
-
-// Config holds the server's configuration options.
-//
-// Multiple servers using the same storage are expected to be configured identically.
-type Config struct {
-	Issuer string
-
-	// The backing persistence layer.
-	Storage storage.Storage
-
-	AllowedGrantTypes []string
-
-	// Valid values are "code" to enable the code flow and "token" to enable the implicit
-	// flow. If no response types are supplied this value defaults to "code".
-	SupportedResponseTypes []string
-
-	// Headers is a map of headers to be added to the all responses.
-	Headers http.Header
-
-	// Header to extract real ip from.
-	RealIPHeader       string
-	TrustedRealIPCIDRs []netip.Prefix
-
-	// List of allowed origins for CORS requests on discovery, token and keys endpoint.
-	// If none are indicated, CORS requests are disabled. Passing in "*" will allow any
-	// domain.
-	AllowedOrigins []string
-
-	// List of allowed headers for CORS requests on discovery, token, and keys endpoint.
-	AllowedHeaders []string
-
-	// If enabled, the server won't prompt the user to approve authorization requests.
-	// Logging in implies approval.
-	SkipApprovalScreen bool
-
-	// If enabled, the connectors selection page will always be shown even if there's only one
-	AlwaysShowLoginScreen bool
-
-	IDTokensValidFor       time.Duration // Defaults to 24 hours
-	AuthRequestsValidFor   time.Duration // Defaults to 24 hours
-	DeviceRequestsValidFor time.Duration // Defaults to 5 minutes
-
-	// Refresh token expiration settings
-	RefreshTokenPolicy *tokens.RefreshStrategy
-
-	// If set, the server will use this connector to handle password grants
-	PasswordConnector string
-
-	// PKCE configuration
-	PKCE authflow.PKCEConfig
-
-	GCFrequency time.Duration // Defaults to 5 minutes
-
-	// If specified, the server will use this function for determining time.
-	Now func() time.Time
-
-	Web WebConfig
-
-	Logger *slog.Logger
-
-	// Signer is used to sign tokens.
-	Signer signer.Signer
-
-	PrometheusRegistry *prometheus.Registry
-
-	HealthChecker gosundheit.Health
-
-	// If enabled, the server will continue starting even if some connectors fail to initialize.
-	// This allows the server to operate with a subset of connectors if some are misconfigured.
-	ContinueOnConnectorFailure bool
-
-	// SessionConfig holds session settings. Nil when sessions are disabled.
-	SessionConfig *session.Config
-
-	// MFAProviders maps authenticator IDs to their provider implementations.
-	MFAProviders map[string]mfa.Provider
-
-	// DefaultMFAChain is applied to clients that don't specify their own mfaChain.
-	DefaultMFAChain []string
-}
-
-// WebConfig holds the server's frontend templates and asset configuration.
-type WebConfig struct {
-	// A file path to static web assets.
-	//
-	// It is expected to contain the following directories:
-	//
-	//   * static - Static static served at "( issuer URL )/static".
-	//   * templates - HTML templates controlled by dex.
-	//   * themes/(theme) - Static static served at "( issuer URL )/theme".
-	Dir string
-
-	// Alternative way to programmatically configure static web assets.
-	// If Dir is specified, WebFS is ignored.
-	// It's expected to contain the same files and directories as mentioned above.
-	//
-	// Note: this is experimental. Might get removed without notice!
-	WebFS fs.FS
-
-	// Defaults to "( issuer URL )/theme/logo.png"
-	LogoURL string
-
-	// Defaults to "dex"
-	Issuer string
-
-	// Defaults to "light"
-	Theme string
-
-	// Map of extra values passed into the templates
-	Extra map[string]string
-}
-
-func value(val, defaultValue time.Duration) time.Duration {
-	if val == 0 {
-		return defaultValue
-	}
-	return val
-}
 
 // Server is the top level object.
 type Server struct {
@@ -199,115 +73,19 @@ func NewServer(ctx context.Context, c Config) (*Server, error) {
 }
 
 func newServer(ctx context.Context, c Config) (*Server, error) {
-	issuerURL, err := url.Parse(c.Issuer)
+	rc, err := normalizeConfig(&c)
 	if err != nil {
-		return nil, fmt.Errorf("server: can't parse issuer URL")
+		return nil, err
 	}
-
-	if c.Storage == nil {
-		return nil, errors.New("server: storage cannot be nil")
-	}
-
-	if len(c.SupportedResponseTypes) == 0 {
-		c.SupportedResponseTypes = []string{oauth2.ResponseTypeCode}
-	}
-	if len(c.AllowedHeaders) == 0 {
-		c.AllowedHeaders = []string{"Authorization"}
-	}
-
-	supportedChallengeMethods := map[string]bool{
-		oauth2.PKCEMethodS256:  true,
-		oauth2.PKCEMethodPlain: true,
-	}
-	if len(c.PKCE.CodeChallengeMethodsSupported) == 0 {
-		c.PKCE.CodeChallengeMethodsSupported = []string{oauth2.PKCEMethodS256, oauth2.PKCEMethodPlain}
-	}
-	for _, m := range c.PKCE.CodeChallengeMethodsSupported {
-		if !supportedChallengeMethods[m] {
-			return nil, fmt.Errorf("unsupported PKCE challenge method %q", m)
-		}
-	}
-
-	allSupportedGrants := map[string]bool{
-		oauth2.GrantTypeAuthorizationCode: true,
-		oauth2.GrantTypeRefreshToken:      true,
-		oauth2.GrantTypeDeviceCode:        true,
-		oauth2.GrantTypeTokenExchange:     true,
-	}
-	supportedRes := make(map[string]bool)
-
-	for _, respType := range c.SupportedResponseTypes {
-		switch respType {
-		case oauth2.ResponseTypeCode, oauth2.ResponseTypeIDToken, oauth2.ResponseTypeCodeIDToken:
-			// continue
-		case oauth2.ResponseTypeToken, oauth2.ResponseTypeCodeToken, oauth2.ResponseTypeIDTokenToken, oauth2.ResponseTypeCodeIDTokenToken:
-			// response_type=token is an implicit flow, let's add it to the discovery info
-			// https://datatracker.ietf.org/doc/html/rfc6749#section-4.2.1
-			allSupportedGrants[oauth2.GrantTypeImplicit] = true
-		default:
-			return nil, fmt.Errorf("unsupported response_type %q", respType)
-		}
-		supportedRes[respType] = true
-	}
-
-	if c.PasswordConnector != "" {
-		allSupportedGrants[oauth2.GrantTypePassword] = true
-	}
-
-	allSupportedGrants[oauth2.GrantTypeClientCredentials] = true
-
-	var supportedGrants []string
-	if len(c.AllowedGrantTypes) > 0 {
-		for _, grant := range c.AllowedGrantTypes {
-			if allSupportedGrants[grant] {
-				supportedGrants = append(supportedGrants, grant)
-			}
-		}
-	} else {
-		for grant := range allSupportedGrants {
-			supportedGrants = append(supportedGrants, grant)
-		}
-	}
-	sort.Strings(supportedGrants)
-
-	webFS := web.FS()
-	if c.Web.Dir != "" {
-		webFS = os.DirFS(c.Web.Dir)
-	} else if c.Web.WebFS != nil {
-		webFS = c.Web.WebFS
-	}
-
-	web := templates.Config{
-		WebFS:     webFS,
-		LogoURL:   c.Web.LogoURL,
-		IssuerURL: c.Issuer,
-		Issuer:    c.Web.Issuer,
-		Theme:     c.Web.Theme,
-		Extra:     c.Web.Extra,
-	}
-
-	static, theme, robots, tmpls, err := templates.LoadWebConfig(web)
-	if err != nil {
-		return nil, fmt.Errorf("server: failed to load web static: %v", err)
-	}
-
-	now := c.Now
-	if now == nil {
-		now = time.Now
-	}
-
-	authRequestsValidFor := value(c.AuthRequestsValidFor, 24*time.Hour)
-	deviceRequestsValidFor := value(c.DeviceRequestsValidFor, 5*time.Minute)
-	idTokensValidFor := value(c.IDTokensValidFor, 24*time.Hour)
 
 	s := &Server{
-		issuerURL:     oauth2.IssuerURL{URL: *issuerURL},
-		storage:       newKeyCacher(c.Storage, now),
-		templates:     tmpls,
+		issuerURL:     rc.issuerURL,
+		storage:       newKeyCacher(c.Storage, rc.now),
+		templates:     rc.templates,
 		logger:        c.Logger,
 		sessionConfig: c.SessionConfig,
 	}
-	s.issuer = tokens.NewIssuer(s.storage, c.Signer, s.issuerURL.URL, idTokensValidFor, now, s.logger)
+	s.issuer = tokens.NewIssuer(s.storage, c.Signer, s.issuerURL.URL, rc.idTokensValidFor, rc.now, s.logger)
 	s.connectors = connectors.NewCache(s.storage, connectors.Resolver(s.storage, s.logger, ConnectorsConfig))
 	// Build the discovery handler once from config; both the mounted HTTP route
 	// and the gRPC API (via Discovery) serve this same handler.
@@ -316,33 +94,53 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		Templates:       s.templates,
 		Signer:          c.Signer,
 		Logger:          s.logger,
-		ResponseTypes:   supportedRes,
-		GrantTypes:      supportedGrants,
+		ResponseTypes:   rc.responseTypes,
+		GrantTypes:      rc.grantTypes,
 		PKCEMethods:     c.PKCE.CodeChallengeMethodsSupported,
 		SessionsEnabled: s.sessionConfig != nil,
 	}
-	// sessions is shared infrastructure (session cookie, SSO, auth-session CRUD)
-	// referenced by the flow steps mounted below. The steps themselves hold no
-	// reference to one another; the /auth dispatcher decides MFA and consent from
-	// persisted state and config, so mfa and consent are mounted inline like the
-	// rest.
-	sessions := &session.Manager{
-		Storage:   s.storage,
-		Config:    s.sessionConfig,
-		Now:       now,
-		Logger:    s.logger,
-		IssuerURL: s.issuerURL,
+
+	if err := s.openConnectors(ctx, c); err != nil {
+		return nil, err
 	}
 
-	// Retrieves connector objects in backend storage. This list includes the static connectors
-	// defined in the ConfigMap and dynamic connectors retrieved from the storage.
+	if featureflags.SessionsEnabled.Enabled() {
+		s.logger.InfoContext(ctx, "sessions feature flag is enabled")
+	}
+
+	r := mux.NewRouter().SkipClean(true).UseEncodedPath()
+	r.NotFoundHandler = http.NotFoundHandler()
+	s.mount(router.New(router.Config{
+		Router:       r,
+		IssuerPath:   s.issuerURL.Path,
+		Headers:      c.Headers,
+		RealIPHeader: c.RealIPHeader,
+		Instrument:   instrumentHandler(c.PrometheusRegistry),
+		RealIP:       router.ParseRealIP(c.RealIPHeader, c.TrustedRealIPCIDRs),
+		CORSOrigins:  c.AllowedOrigins,
+		CORSHeaders:  c.AllowedHeaders,
+	}), c, rc)
+	s.mux = r
+
+	c.Signer.Start(ctx)
+	s.startGarbageCollection(ctx, value(c.GCFrequency, 5*time.Minute), rc.now)
+
+	return s, nil
+}
+
+// openConnectors opens every connector in storage into the cache. Nothing is
+// served without at least one, so an empty set is an error; so is a single
+// failure, unless the server is configured to start on a subset.
+func (s *Server) openConnectors(ctx context.Context, c Config) error {
+	// This list includes the static connectors defined in the ConfigMap and
+	// dynamic connectors retrieved from the storage.
 	storageConnectors, err := c.Storage.ListConnectors(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("server: failed to list connector objects from storage: %v", err)
+		return fmt.Errorf("server: failed to list connector objects from storage: %v", err)
 	}
 
 	if len(storageConnectors) == 0 && s.connectors.Len() == 0 {
-		return nil, errors.New("server: no connectors specified")
+		return errors.New("server: no connectors specified")
 	}
 
 	var failedCount int
@@ -353,78 +151,81 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 				s.logger.Error("server: Failed to open connector", "id", conn.ID, "err", err)
 				continue
 			}
-			return nil, fmt.Errorf("server: Failed to open connector %s: %v", conn.ID, err)
+			return fmt.Errorf("server: Failed to open connector %s: %v", conn.ID, err)
 		}
 	}
 
 	if c.ContinueOnConnectorFailure && failedCount == len(storageConnectors) {
-		return nil, fmt.Errorf("server: failed to open all connectors (%d/%d)", failedCount, len(storageConnectors))
+		return fmt.Errorf("server: failed to open all connectors (%d/%d)", failedCount, len(storageConnectors))
 	}
 
-	if featureflags.SessionsEnabled.Enabled() {
-		s.logger.InfoContext(ctx, "sessions feature flag is enabled")
+	return nil
+}
+
+// instrumentHandler returns the per-route metrics wrapper the mux applies. With
+// no registry it is the identity wrapper, so metrics stay opt-in.
+func instrumentHandler(registry *prometheus.Registry) func(string, http.Handler) http.HandlerFunc {
+	if registry == nil {
+		return func(_ string, handler http.Handler) http.HandlerFunc { return handler.ServeHTTP }
 	}
 
-	instrumentHandler := func(_ string, handler http.Handler) http.HandlerFunc {
-		return handler.ServeHTTP
+	requestCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "http_requests_total",
+		Help: "Count of all HTTP requests.",
+	}, []string{"code", "method", "handler"})
+
+	durationHist := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "request_duration_seconds",
+		Help:    "A histogram of latencies for requests.",
+		Buckets: []float64{.25, .5, 1, 2.5, 5, 10},
+	}, []string{"code", "method", "handler"})
+
+	sizeHist := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "response_size_bytes",
+		Help:    "A histogram of response sizes for requests.",
+		Buckets: []float64{200, 500, 900, 1500},
+	}, []string{"code", "method", "handler"})
+
+	registry.MustRegister(requestCounter, durationHist, sizeHist)
+
+	return func(handlerName string, handler http.Handler) http.HandlerFunc {
+		return promhttp.InstrumentHandlerDuration(durationHist.MustCurryWith(prometheus.Labels{"handler": handlerName}),
+			promhttp.InstrumentHandlerCounter(requestCounter.MustCurryWith(prometheus.Labels{"handler": handlerName}),
+				promhttp.InstrumentHandlerResponseSize(sizeHist.MustCurryWith(prometheus.Labels{"handler": handlerName}), handler),
+			),
+		)
+	}
+}
+
+// mount wires every domain onto routes. Self-contained domains mount their own
+// routes through the router.Mux abstraction; this is the only place they are
+// wired in.
+func (s *Server) mount(routes router.Mux, c Config, rc resolvedConfig) {
+	// sessions is shared infrastructure (session cookie, SSO, auth-session CRUD)
+	// referenced by the flow steps mounted below. The steps themselves hold no
+	// reference to one another; the /auth dispatcher decides MFA and consent from
+	// persisted state and config, so mfa and consent are mounted inline like the
+	// rest.
+	sessions := &session.Manager{
+		Storage:   s.storage,
+		Config:    s.sessionConfig,
+		Now:       rc.now,
+		Logger:    s.logger,
+		IssuerURL: s.issuerURL,
 	}
 
-	if c.PrometheusRegistry != nil {
-		requestCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "http_requests_total",
-			Help: "Count of all HTTP requests.",
-		}, []string{"code", "method", "handler"})
-
-		durationHist := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "request_duration_seconds",
-			Help:    "A histogram of latencies for requests.",
-			Buckets: []float64{.25, .5, 1, 2.5, 5, 10},
-		}, []string{"code", "method", "handler"})
-
-		sizeHist := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "response_size_bytes",
-			Help:    "A histogram of response sizes for requests.",
-			Buckets: []float64{200, 500, 900, 1500},
-		}, []string{"code", "method", "handler"})
-
-		c.PrometheusRegistry.MustRegister(requestCounter, durationHist, sizeHist)
-
-		instrumentHandler = func(handlerName string, handler http.Handler) http.HandlerFunc {
-			return promhttp.InstrumentHandlerDuration(durationHist.MustCurryWith(prometheus.Labels{"handler": handlerName}),
-				promhttp.InstrumentHandlerCounter(requestCounter.MustCurryWith(prometheus.Labels{"handler": handlerName}),
-					promhttp.InstrumentHandlerResponseSize(sizeHist.MustCurryWith(prometheus.Labels{"handler": handlerName}), handler),
-				),
-			)
-		}
-	}
-
-	r := mux.NewRouter().SkipClean(true).UseEncodedPath()
-	r.NotFoundHandler = http.NotFoundHandler()
-
-	// Self-contained domains mount their own routes through the router.Mux
-	// abstraction; this is the only place they are wired in.
-	routes := router.New(router.Config{
-		Router:       r,
-		IssuerPath:   issuerURL.Path,
-		Headers:      c.Headers,
-		RealIPHeader: c.RealIPHeader,
-		Instrument:   instrumentHandler,
-		RealIP:       router.ParseRealIP(c.RealIPHeader, c.TrustedRealIPCIDRs),
-		CORSOrigins:  c.AllowedOrigins,
-		CORSHeaders:  c.AllowedHeaders,
-	})
 	for _, h := range []router.Handler{
 		s.discovery,
 		&grants.Handler{
 			Issuer:              s.issuer,
 			Storage:             s.storage,
 			Connectors:          s.connectors,
-			Now:                 now,
+			Now:                 rc.now,
 			Logger:              s.logger,
 			PasswordConnector:   c.PasswordConnector,
 			RefreshPolicy:       c.RefreshTokenPolicy,
 			SessionsEnabled:     s.sessionConfig != nil,
-			SupportedGrantTypes: supportedGrants,
+			SupportedGrantTypes: rc.grantTypes,
 		},
 		&userinfo.Handler{
 			Issuer: s.issuerURL.String(),
@@ -442,8 +243,8 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 			IssuerURL:        s.issuerURL,
 			Storage:          s.storage,
 			Templates:        s.templates,
-			Now:              now,
-			RequestsValidFor: deviceRequestsValidFor,
+			Now:              rc.now,
+			RequestsValidFor: rc.deviceRequestsValidFor,
 			Logger:           s.logger,
 			Issuer:           s.issuer,
 			Connectors:       s.connectors,
@@ -461,12 +262,12 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 			Storage:                s.storage,
 			Templates:              s.templates,
 			Signer:                 c.Signer,
-			Now:                    now,
+			Now:                    rc.now,
 			Logger:                 s.logger,
 			AlwaysShowLogin:        c.AlwaysShowLoginScreen,
-			SupportedResponseTypes: supportedRes,
+			SupportedResponseTypes: rc.responseTypes,
 			PKCE:                   c.PKCE,
-			AuthRequestsValidFor:   authRequestsValidFor,
+			AuthRequestsValidFor:   rc.authRequestsValidFor,
 			Sessions:               sessions,
 			Issuer:                 s.issuer,
 			MFAEnabled:             len(c.MFAProviders) > 0,
@@ -480,7 +281,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 			IssuerURL:       s.issuerURL,
 			MFAProviders:    c.MFAProviders,
 			DefaultMFAChain: c.DefaultMFAChain,
-			Now:             now,
+			Now:             rc.now,
 			Connectors:      s.connectors,
 		},
 		&consent.Handler{
@@ -513,16 +314,9 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		fmt.Fprintf(w, "Health check passed")
 	}))
 
-	routes.HandlePrefix("/static", static)
-	routes.HandlePrefix("/theme", theme)
-	routes.HandleFunc("/robots.txt", robots)
-
-	s.mux = r
-
-	c.Signer.Start(ctx)
-	s.startGarbageCollection(ctx, value(c.GCFrequency, 5*time.Minute), now)
-
-	return s, nil
+	routes.HandlePrefix("/static", rc.static)
+	routes.HandlePrefix("/theme", rc.theme)
+	routes.HandleFunc("/robots.txt", rc.robots)
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/server/server.go
+++ b/server/server.go
@@ -54,8 +54,6 @@ type Server struct {
 	// discovery is built once from config and shared by the mounted HTTP handler
 	// and the gRPC API's Discovery accessor.
 	discovery *discovery.Handler
-
-	sessionConfig *session.Config
 }
 
 // Connectors is the server's connector cache. The gRPC API needs it to
@@ -79,11 +77,10 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 	}
 
 	s := &Server{
-		issuerURL:     rc.issuerURL,
-		storage:       newKeyCacher(c.Storage, rc.now),
-		templates:     rc.templates,
-		logger:        c.Logger,
-		sessionConfig: c.SessionConfig,
+		issuerURL: rc.issuerURL,
+		storage:   newKeyCacher(c.Storage, rc.now),
+		templates: rc.templates,
+		logger:    c.Logger,
 	}
 	s.issuer = tokens.NewIssuer(s.storage, c.Signer, s.issuerURL.URL, rc.idTokensValidFor, rc.now, s.logger)
 	s.connectors = connectors.NewCache(s.storage, connectors.Resolver(s.storage, s.logger, ConnectorsConfig))
@@ -97,7 +94,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		ResponseTypes:   rc.responseTypes,
 		GrantTypes:      rc.grantTypes,
 		PKCEMethods:     c.PKCE.CodeChallengeMethodsSupported,
-		SessionsEnabled: s.sessionConfig != nil,
+		SessionsEnabled: c.SessionConfig != nil,
 	}
 
 	if err := s.openConnectors(ctx, c); err != nil {
@@ -208,7 +205,7 @@ func (s *Server) mount(routes router.Mux, c Config, rc resolvedConfig) {
 	// rest.
 	sessions := &session.Manager{
 		Storage:   s.storage,
-		Config:    s.sessionConfig,
+		Config:    c.SessionConfig,
 		Now:       rc.now,
 		Logger:    s.logger,
 		IssuerURL: s.issuerURL,
@@ -224,7 +221,7 @@ func (s *Server) mount(routes router.Mux, c Config, rc resolvedConfig) {
 			Logger:              s.logger,
 			PasswordConnector:   c.PasswordConnector,
 			RefreshPolicy:       c.RefreshTokenPolicy,
-			SessionsEnabled:     s.sessionConfig != nil,
+			SessionsEnabled:     c.SessionConfig != nil,
 			SupportedGrantTypes: rc.grantTypes,
 		},
 		&userinfo.Handler{

--- a/server/server_approval_test.go
+++ b/server/server_approval_test.go
@@ -160,7 +160,7 @@ func TestConsentPersistedOnApproval(t *testing.T) {
 	}
 	require.NoError(t, s.storage.CreateAuthRequest(ctx, authReq))
 
-	mac := internal.ComputeHMAC(authReq.HMACKey, authReq.ID, "approval")
+	mac := internal.SignStep(authReq, internal.StepApproval)
 
 	form := url.Values{
 		"approval": {"approve"},
@@ -292,7 +292,7 @@ func TestHandleApprovalDoubleSubmitPOST(t *testing.T) {
 	}
 	require.NoError(t, server.storage.CreateAuthRequest(ctx, authReq))
 
-	mac := internal.ComputeHMAC(authReq.HMACKey, authReq.ID, "approval")
+	mac := internal.SignStep(authReq, internal.StepApproval)
 
 	form := url.Values{
 		"approval": {"approve"},

--- a/server/server_flow_test.go
+++ b/server/server_flow_test.go
@@ -39,7 +39,13 @@ func TestFlowStepsRequireHMAC(t *testing.T) {
 
 	// The dispatcher accepts only the "continue" and "approved" verifiers; a value
 	// minted for a different step (or none) is rejected.
-	wrongStepMAC := internal.ComputeHMAC(authReq.HMACKey, authReq.ID, "mfa")
+	wrongStepMAC := internal.SignStep(authReq, internal.StepMFA)
+
+	// Authenticator IDs are operator config and are signed the same way. They
+	// live in their own namespace, so an authenticator named after a step cannot
+	// hand the user that step's verifier — an "approved" authenticator must not
+	// let its factor URL double as a consent approval.
+	collidingMAC := internal.SignStep(authReq, internal.Authenticator("approved"))
 
 	for _, tc := range []struct {
 		name string
@@ -47,6 +53,7 @@ func TestFlowStepsRequireHMAC(t *testing.T) {
 	}{
 		{"dispatcher without hmac", "/auth?req=" + authReq.ID},
 		{"dispatcher with wrong-step hmac", "/auth?req=" + authReq.ID + "&hmac=" + wrongStepMAC},
+		{"dispatcher with authenticator hmac named after a step", "/auth?req=" + authReq.ID + "&hmac=" + collidingMAC},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rr := httptest.NewRecorder()
@@ -58,7 +65,7 @@ func TestFlowStepsRequireHMAC(t *testing.T) {
 	// With no MFA configured and the "approved" verifier resolving consent, the
 	// dispatcher issues the code to the client.
 	rr := httptest.NewRecorder()
-	approvedMAC := internal.ComputeHMAC(authReq.HMACKey, authReq.ID, "approved")
+	approvedMAC := internal.SignStep(authReq, internal.StepApproved)
 	s.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/auth?req="+authReq.ID+"&hmac="+approvedMAC, nil))
 	require.Equal(t, http.StatusSeeOther, rr.Code)
 	require.Contains(t, rr.Header().Get("Location"), "https://client.example/callback")

--- a/server/server_home_test.go
+++ b/server/server_home_test.go
@@ -6,79 +6,11 @@ import (
 	"testing"
 	"time"
 
-	gosundheit "github.com/AppsFlyer/go-sundheit"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dexidp/dex/server/internal"
-	"github.com/dexidp/dex/server/oauth2"
-	"github.com/dexidp/dex/server/session"
-	"github.com/dexidp/dex/server/signer"
-	"github.com/dexidp/dex/server/tokens"
 	"github.com/dexidp/dex/storage"
-	"github.com/dexidp/dex/storage/memory"
 )
-
-func newTestServerWithSessions(t *testing.T, updateConfig func(c *Config)) (*httptest.Server, *Server) {
-	t.Helper()
-
-	var server *Server
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		server.ServeHTTP(w, r)
-	}))
-
-	logger := newLogger(t)
-	ctx := t.Context()
-
-	sig, err := signer.NewMockSigner(testKey)
-	require.NoError(t, err)
-
-	config := Config{
-		Issuer:  s.URL,
-		Storage: memory.New(logger),
-		Web: WebConfig{
-			Dir: "../web",
-		},
-		Logger:             logger,
-		PrometheusRegistry: prometheus.NewRegistry(),
-		HealthChecker:      gosundheit.New(),
-		SkipApprovalScreen: true,
-		AllowedGrantTypes: []string{
-			oauth2.GrantTypeAuthorizationCode,
-			oauth2.GrantTypeClientCredentials,
-			oauth2.GrantTypeRefreshToken,
-			oauth2.GrantTypeTokenExchange,
-			oauth2.GrantTypeDeviceCode,
-		},
-		Signer: sig,
-		SessionConfig: &session.Config{
-			CookieName:        "dex_session",
-			AbsoluteLifetime:  24 * time.Hour,
-			ValidIfNotUsedFor: 1 * time.Hour,
-		},
-	}
-	if updateConfig != nil {
-		updateConfig(&config)
-	}
-	s.URL = config.Issuer
-
-	if config.RefreshTokenPolicy == nil {
-		config.RefreshTokenPolicy = tokens.NewRefreshStrategy(true, 0, 0, 0, config.Now)
-	}
-
-	connector := storage.Connector{
-		ID:              "mock",
-		Type:            "mockCallback",
-		Name:            "Mock",
-		ResourceVersion: "1",
-	}
-	require.NoError(t, config.Storage.CreateConnector(ctx, connector))
-
-	server, err = newServer(ctx, config)
-	require.NoError(t, err)
-
-	return s, server
-}
 
 func TestHomeNoSessions(t *testing.T) {
 	httpServer, server := newTestServer(t, nil)
@@ -143,7 +75,7 @@ func TestHomeLoggedIn(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "dex_session",
-		Value: internal.SessionCookieValue(userID, connectorID, nonce, nil),
+		Value: internal.SessionCookieValue(userID, connectorID, nonce, testSessionKey),
 	})
 
 	rr := httptest.NewRecorder()

--- a/server/server_logout_test.go
+++ b/server/server_logout_test.go
@@ -82,7 +82,7 @@ func TestHandleLogoutNoHintPOSTPerformsLogout(t *testing.T) {
 	req := httptest.NewRequest("POST", "/logout", nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "dex_session",
-		Value: internal.SessionCookieValue(userID, connectorID, nonce, server.sessionConfig.CookieEncryptionKey),
+		Value: internal.SessionCookieValue(userID, connectorID, nonce, testSessionKey),
 	})
 	server.ServeHTTP(rr, req)
 
@@ -372,7 +372,7 @@ func TestHandleLogoutFromCookie(t *testing.T) {
 	req := httptest.NewRequest("POST", "/logout", nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "dex_session",
-		Value: internal.SessionCookieValue(userID, connectorID, nonce, server.sessionConfig.CookieEncryptionKey),
+		Value: internal.SessionCookieValue(userID, connectorID, nonce, testSessionKey),
 	})
 	server.ServeHTTP(rr, req)
 
@@ -402,7 +402,7 @@ func TestLogoutCallbackWithExpiredSession(t *testing.T) {
 	req := httptest.NewRequest("GET", "/logout/callback", nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "dex_session",
-		Value: internal.SessionCookieValue("user-1", "mock", "nonce", server.sessionConfig.CookieEncryptionKey),
+		Value: internal.SessionCookieValue("user-1", "mock", "nonce", testSessionKey),
 	})
 	server.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusBadRequest, rr.Code)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -32,11 +32,9 @@ import (
 
 	"github.com/dexidp/dex/connector"
 	"github.com/dexidp/dex/connector/mock"
-	"github.com/dexidp/dex/pkg/featureflags"
 	"github.com/dexidp/dex/server/connectors"
 	"github.com/dexidp/dex/server/device"
 	"github.com/dexidp/dex/server/oauth2"
-	"github.com/dexidp/dex/server/session"
 	"github.com/dexidp/dex/server/signer"
 	"github.com/dexidp/dex/server/tokens"
 	"github.com/dexidp/dex/storage"
@@ -82,138 +80,6 @@ E2qpAoGAZo5Wwwk7q8b1n9n/ACh4LpE+QgbFdlJxlfFLJCKstl37atzS8UewOSZj
 FDWV28nTP9sqbtsmU8Tem2jzMvZ7C/Q0AuDoKELFUpux8shm8wfIhyaPnXUGZoAZ
 Np4vUwMSYV5mopESLWOg3loBxKyLGFtgGKVCjGiQvy6zISQ4fQo=
 -----END RSA PRIVATE KEY-----`)
-
-func newTestServer(t *testing.T, updateConfig func(c *Config)) (*httptest.Server, *Server) {
-	var server *Server
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		server.ServeHTTP(w, r)
-	}))
-
-	logger := newLogger(t)
-	ctx := t.Context()
-
-	sig, err := signer.NewMockSigner(testKey)
-	if err != nil {
-		t.Fatalf("failed to create mock signer: %v", err)
-	}
-
-	config := Config{
-		Issuer:  s.URL,
-		Storage: memory.New(logger),
-		Web: WebConfig{
-			Dir: "../web",
-		},
-		Logger:             logger,
-		PrometheusRegistry: prometheus.NewRegistry(),
-		HealthChecker:      gosundheit.New(),
-		SkipApprovalScreen: true, // Don't prompt for approval, just immediately redirect with code.
-		AllowedGrantTypes: []string{ // all implemented types
-			oauth2.GrantTypeDeviceCode,
-			oauth2.GrantTypeAuthorizationCode,
-			oauth2.GrantTypeClientCredentials,
-			oauth2.GrantTypeRefreshToken,
-			oauth2.GrantTypeTokenExchange,
-			oauth2.GrantTypeImplicit,
-			oauth2.GrantTypePassword,
-		},
-		Signer: sig,
-	}
-	if updateConfig != nil {
-		updateConfig(&config)
-	}
-	s.URL = config.Issuer
-
-	// Default rotation policy, set before the server is built so the token
-	// endpoint captures it.
-	if config.RefreshTokenPolicy == nil {
-		config.RefreshTokenPolicy = tokens.NewRefreshStrategy(true, 0, 0, 0, config.Now)
-	}
-
-	// Mirror cmd: the session config is present iff the sessions feature flag is on.
-	if featureflags.SessionsEnabled.Enabled() && config.SessionConfig == nil {
-		config.SessionConfig = &session.Config{CookieName: "dex_session", AbsoluteLifetime: 24 * time.Hour, ValidIfNotUsedFor: time.Hour}
-	}
-
-	connector := storage.Connector{
-		ID:              "mock",
-		Type:            "mockCallback",
-		Name:            "Mock",
-		ResourceVersion: "1",
-	}
-	if err := config.Storage.CreateConnector(ctx, connector); err != nil {
-		t.Fatalf("create connector: %v", err)
-	}
-
-	if server, err = newServer(ctx, config); err != nil {
-		t.Fatal(err)
-	}
-
-	return s, server
-}
-
-func newTestServerMultipleConnectors(t *testing.T, updateConfig func(c *Config)) (*httptest.Server, *Server) {
-	var server *Server
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		server.ServeHTTP(w, r)
-	}))
-
-	logger := newLogger(t)
-	ctx := t.Context()
-
-	sig, err := signer.NewMockSigner(testKey)
-	if err != nil {
-		t.Fatalf("failed to create mock signer: %v", err)
-	}
-
-	config := Config{
-		Issuer:  s.URL,
-		Storage: memory.New(logger),
-		Web: WebConfig{
-			Dir: "../web",
-		},
-		Logger:             logger,
-		PrometheusRegistry: prometheus.NewRegistry(),
-		Signer:             sig,
-		SkipApprovalScreen: true, // Don't prompt for approval, just immediately redirect with code.
-	}
-	if updateConfig != nil {
-		updateConfig(&config)
-	}
-	s.URL = config.Issuer
-
-	if config.RefreshTokenPolicy == nil {
-		config.RefreshTokenPolicy = tokens.NewRefreshStrategy(true, 0, 0, 0, config.Now)
-	}
-
-	// Mirror cmd: the session config is present iff the sessions feature flag is on.
-	if featureflags.SessionsEnabled.Enabled() && config.SessionConfig == nil {
-		config.SessionConfig = &session.Config{CookieName: "dex_session", AbsoluteLifetime: 24 * time.Hour, ValidIfNotUsedFor: time.Hour}
-	}
-
-	connector := storage.Connector{
-		ID:              "mock",
-		Type:            "mockCallback",
-		Name:            "Mock",
-		ResourceVersion: "1",
-	}
-	connector2 := storage.Connector{
-		ID:              "mock2",
-		Type:            "mockCallback",
-		Name:            "Mock",
-		ResourceVersion: "1",
-	}
-	if err := config.Storage.CreateConnector(ctx, connector); err != nil {
-		t.Fatalf("create connector: %v", err)
-	}
-	if err := config.Storage.CreateConnector(ctx, connector2); err != nil {
-		t.Fatalf("create connector: %v", err)
-	}
-
-	if server, err = newServer(ctx, config); err != nil {
-		t.Fatal(err)
-	}
-	return s, server
-}
 
 func TestNewTestServer(t *testing.T) {
 	newTestServer(t, nil)

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -39,6 +39,10 @@ type Manager struct {
 // Enabled reports whether sessions are configured.
 func (m *Manager) Enabled() bool { return m.Config != nil }
 
+// RememberMeDefault reports the configured default for the remember-me choice,
+// or nil when sessions are disabled. The password form renders it as the
+// checkbox's initial state; callers that need a plain bool (connector callbacks,
+// which render no checkbox) treat nil as false.
 func (m *Manager) RememberMeDefault() *bool {
 	if m.Config == nil {
 		return nil
@@ -89,7 +93,7 @@ func (m *Manager) ClearCookie(w http.ResponseWriter) {
 	})
 }
 
-// getValidSession returns a valid, non-expired session or nil.
+// ValidSession returns a valid, non-expired session or nil.
 // It parses the session cookie to extract (userID, connectorID, nonce),
 // looks up the session by composite key, and verifies the nonce.
 // Invalid or expired session cookies are cleared automatically.
@@ -155,7 +159,7 @@ func (m *Manager) ValidSession(ctx context.Context, w http.ResponseWriter, r *ht
 	return &session
 }
 
-// getValidAuthSession returns a valid session matching the auth request's connector, or nil.
+// ValidAuthSession returns a valid session matching the auth request's connector, or nil.
 func (m *Manager) ValidAuthSession(ctx context.Context, w http.ResponseWriter, r *http.Request, authReq *storage.AuthRequest) *storage.AuthSession {
 	session := m.ValidSession(ctx, w, r)
 	if session == nil {
@@ -170,7 +174,7 @@ func (m *Manager) ValidAuthSession(ctx context.Context, w http.ResponseWriter, r
 	return session
 }
 
-// createOrUpdateAuthSession creates a new session or updates an existing one
+// CreateOrUpdateAuthSession creates a new session or updates an existing one
 // after a successful login, and sets the session cookie.
 // rememberMe controls whether the cookie is persistent (survives browser close).
 func (m *Manager) CreateOrUpdateAuthSession(ctx context.Context, r *http.Request, w http.ResponseWriter, authReq storage.AuthRequest, rememberMe bool) error {
@@ -242,9 +246,9 @@ func (m *Manager) CreateOrUpdateAuthSession(ctx context.Context, r *http.Request
 	return nil
 }
 
-// trySessionLogin checks if the user has a valid session for the same connector.
-// If so, it finalizes login from the stored identity and returns a redirect URL.
-// Returns ("", false) if session-based login is not possible.
+// ClientSharesWith reports whether sourceClient's ssoSharedWith policy lets its
+// authenticated state be reused for targetClientID. A nil policy falls back to
+// the server-wide SSOSharedWithDefault; an explicit empty slice shares with no one.
 func (m *Manager) ClientSharesWith(sourceClient storage.Client, targetClientID string) bool {
 	ssoSharedWith := sourceClient.SSOSharedWith
 
@@ -271,7 +275,7 @@ func (m *Manager) ClientSharesWith(sourceClient storage.Client, targetClientID s
 	return false
 }
 
-// findSSOSession checks whether any active client in the session shares its
+// FindSSO checks whether any active client in the session shares its
 // authentication with targetClientID via the ssoSharedWith policy.
 //
 // Note: the caller already has the target client loaded (for AllowedConnectors
@@ -310,9 +314,9 @@ func (m *Manager) FindSSO(ctx context.Context, session *storage.AuthSession, tar
 	return nil
 }
 
-// trySessionLoginWithSession is like trySessionLogin but accepts a pre-retrieved session.
-// This allows callers to inspect the session (e.g., for id_token_hint comparison) before
-// attempting session-based login.
+// UpdateTokenIssuedAt records that a token was just issued to clientID: it
+// refreshes the session's idle timeout and the client state's last-issued
+// timestamp. A missing, undecodable or superseded cookie is a no-op.
 func (m *Manager) UpdateTokenIssuedAt(r *http.Request, clientID string) {
 	if m.Config == nil {
 		return
@@ -374,9 +378,4 @@ func (m *Manager) AbsoluteExpiry(now time.Time) time.Time {
 // IdleExpiry returns the idle-timeout expiry measured from now.
 func (m *Manager) IdleExpiry(now time.Time) time.Time {
 	return now.Add(m.Config.ValidIfNotUsedFor)
-}
-
-// DefaultRememberMe reports the configured default for the remember-me choice.
-func (m *Manager) DefaultRememberMe() bool {
-	return m.Config != nil && m.Config.RememberMeCheckedByDefault
 }

--- a/server/templates/templates.go
+++ b/server/templates/templates.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"io"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path"
@@ -428,6 +429,15 @@ func (t *Templates) OOB(r *http.Request, w http.ResponseWriter, code string) err
 		ReqPath string
 	}{code, r.URL.Path}
 	return renderTemplate(w, t.oobTmpl, data)
+}
+
+// RenderError renders the user-facing error page and reports a template failure
+// to the logger. Every domain handler's renderError delegates here, so the
+// error page and the way a failed render is reported stay in one place.
+func RenderError(t *Templates, logger *slog.Logger, r *http.Request, w http.ResponseWriter, status int, description string) {
+	if err := t.Err(r, w, status, description); err != nil {
+		logger.ErrorContext(r.Context(), "server template error", "err", err)
+	}
 }
 
 func (t *Templates) Err(r *http.Request, w http.ResponseWriter, errCode int, errMsg string) error {

--- a/server/userinfo/userinfo.go
+++ b/server/userinfo/userinfo.go
@@ -57,7 +57,5 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) writeError(w http.ResponseWriter, typ, description string, statusCode int) {
-	if err := oauth2.WriteError(w, typ, description, statusCode); err != nil {
-		h.Logger.Error("userinfo error response", "err", err)
-	}
+	oauth2.WriteErrorResponse(h.Logger, w, typ, description, statusCode)
 }


### PR DESCRIPTION
#### Overview

Follow-up to #4929. That PR slimmed the `Server`; this one goes after what the
split left tangled: a handler that could only be built from a `Server`, a
cross-package protocol carried in bare string literals, and three bugs found
while tracing it.

#### What this PR does / why we need it

Four fixes:

- **The real-IP resolver honored only the first trusted proxy CIDR.** It
  returned on the first prefix that did not contain the peer address, so a
  request from a proxy listed second was reported by its own address. With no
  `trustedProxies` configured at all the loop never ran and the header was taken
  from any client, putting a spoofable value into the session audit record. The
  header is now honored only when the peer falls inside one of the configured
  prefixes.
- **The forwarded-for chain was never parsed.** `X-Forwarded-For` appends one
  hop per proxy, but the entire header value went to `netip.ParseAddr`, so any
  request through more than one proxy was unparseable and silently fell back to
  the peer address — the closest proxy, recorded as the client. The chain is now
  walked from the right, skipping hops added by trusted proxies; the first
  untrusted hop is the client, and everything to its left is client-controlled.
- **The device authorization minted its expiry from `time.Now()`** while the
  device token one line below used the injected clock, so the two drift apart
  under a fixed test clock.
- **MFA authenticator IDs shared a namespace with the flow's step labels.**
  Authenticator IDs come from the operator's config and are signed into the same
  HMAC, so an authenticator named `approved` handed the user a verifier the
  `/auth` dispatcher accepts as proof of consent, skipping the approval screen.
  The labels are now namespaced.

Refactors:

- `discovery.Handler` took `AbsURL` and `RenderError` as function fields bound to
  `Server` methods. It was the one domain handler that could not be constructed
  without a `Server`, and its test stubbed `AbsURL`, so the real path joining was
  never exercised. It now takes `oauth2.IssuerURL` and the templates directly.
- The flow-step verifiers become a typed protocol in `server/internal`. The step
  labels were bare literals repeated across `authflow`, `mfa` and `consent`, and
  three packages each carried their own copy of the same signed-URL builder.
- `newServer` ran to 350 lines with no seam between config validation, asset
  loading, connector bootstrapping, metrics registration and handler wiring. The
  config half moves to `normalizeConfig` in `config.go`, which is testable on its
  own — the response-type, grant-type and PKCE rules had no tests because
  reaching them meant constructing a whole server.
- Eight handlers carried a byte-identical `renderError`, and five endpoints
  spelled "write an OAuth2 error" five different ways. Both collapse to one
  implementation each.

Tests:

- The gRPC API's 27 tests lived in the `server` package, so `server/apiserver`
  had none of its own. They need no `Server`, so they move across as-is.
- Three near-identical test-server constructors had drifted apart — one set no
  health checker, another enabled a different set of grants. They collapse onto
  one builder.

#### Special notes for your reviewer

**Two behaviour changes, both in what gets recorded as the client IP:**

- Setting `web.clientRemoteIP.header` without `trustedProxies` now ignores the
  header instead of trusting it from any client. Dex logs a warning at startup
  for that combination, and the example config documents it.
- A request through a chain of proxies is now attributed to the client rather
  than to the nearest proxy. Deployments behind more than one proxy will see
  different addresses in the session audit record and the request logs — the
  correct ones, but different.

Neither affects authentication or authorization; the client IP is used for the
session audit record and log attributes.

**One upgrade note:** the flow-step HMAC labels changed, so a login already
mid-flow across a rolling upgrade fails its next hop and has to restart. Auth
requests are short-lived and the user simply logs in again.

Each of the four bug fixes has a test that was verified to fail without the
fix. `server.go` goes from 620 to 380 lines, `newServer` from 350 to 55.

Happy to relabel as `release-note/breaking-change` if maintainers read the
client-IP changes that way.
