### PR TITLE
fix(web): rebuild the home page around the signed-in identity

### DIFF
--- a/server/home/home.go
+++ b/server/home/home.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/router"
@@ -58,12 +59,24 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 		data.UserAgent = session.UserAgent
 		data.SessionExpiresEpoch, data.SessionExpiryIsIdle = sessionExpiry(session)
 		h.populateData(ctx, &data, session.UserID, session.ConnectorID)
+		data.LastLoginText = utcText(data.LastLoginEpoch)
+		data.SessionExpiresText = utcText(data.SessionExpiresEpoch)
 	}
 
 	if err := h.Templates.Home(r, w, data); err != nil {
 		h.Logger.ErrorContext(ctx, "failed to render home template", "err", err)
 		h.renderError(r, w, http.StatusInternalServerError, "Internal server error.")
 	}
+}
+
+// utcText renders an epoch for readers whose browser will not run the page's
+// script, which otherwise restates these times in the local timezone. Without
+// it those rows are an em dash. Empty for 0, which drops the row entirely.
+func utcText(epoch int64) string {
+	if epoch == 0 {
+		return ""
+	}
+	return time.Unix(epoch, 0).UTC().Format("2 Jan 2006, 15:04 UTC")
 }
 
 // sessionExpiry reports when the session ends: the earlier of its absolute

--- a/server/home/home.go
+++ b/server/home/home.go
@@ -56,6 +56,7 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 		data.LoggedIn = true
 		data.IPAddress = session.IPAddress
 		data.UserAgent = session.UserAgent
+		data.SessionExpiresEpoch = sessionExpiry(session)
 		h.populateData(ctx, &data, session.UserID, session.ConnectorID)
 	}
 
@@ -63,6 +64,20 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 		h.Logger.ErrorContext(ctx, "failed to render home template", "err", err)
 		h.renderError(r, w, http.StatusInternalServerError, "Internal server error.")
 	}
+}
+
+// sessionExpiry reports when the session ends: the earlier of its absolute
+// lifetime and its idle timeout, since whichever comes first logs the user out.
+// It returns 0 when neither is set, which drops the row from the page.
+func sessionExpiry(s *storage.AuthSession) int64 {
+	expiry := s.AbsoluteExpiry
+	if expiry.IsZero() || (!s.IdleExpiry.IsZero() && s.IdleExpiry.Before(expiry)) {
+		expiry = s.IdleExpiry
+	}
+	if expiry.IsZero() {
+		return 0
+	}
+	return expiry.Unix()
 }
 
 func (h *Handler) handleInline(w http.ResponseWriter, r *http.Request) {

--- a/server/home/home.go
+++ b/server/home/home.go
@@ -57,9 +57,12 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 		data.LoggedIn = true
 		data.IPAddress = session.IPAddress
 		data.UserAgent = session.UserAgent
+		if !session.CreatedAt.IsZero() {
+			data.SignedInEpoch = session.CreatedAt.Unix()
+		}
 		data.SessionExpiresEpoch, data.SessionExpiryIsIdle = sessionExpiry(session)
 		h.populateData(ctx, &data, session.UserID, session.ConnectorID)
-		data.LastLoginText = utcText(data.LastLoginEpoch)
+		data.SignedInText = utcText(data.SignedInEpoch)
 		data.SessionExpiresText = utcText(data.SessionExpiresEpoch)
 	}
 
@@ -127,9 +130,6 @@ func (h *Handler) populateData(ctx context.Context, data *templates.HomeData, us
 	data.Email = ui.Claims.Email
 	data.EmailVerified = ui.Claims.EmailVerified
 	data.Groups = ui.Claims.Groups
-	if !ui.LastLogin.IsZero() {
-		data.LastLoginEpoch = ui.LastLogin.Unix()
-	}
 
 	conn, err := h.Storage.GetConnector(ctx, connectorID)
 	if err == nil {

--- a/server/home/home.go
+++ b/server/home/home.go
@@ -57,13 +57,11 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 		data.LoggedIn = true
 		data.IPAddress = session.IPAddress
 		data.UserAgent = session.UserAgent
-		if !session.CreatedAt.IsZero() {
-			data.SignedInEpoch = session.CreatedAt.Unix()
-		}
-		data.SessionExpiresEpoch, data.SessionExpiryIsIdle = sessionExpiry(session)
+		data.SignedInISO, data.SignedInText = timeFields(session.CreatedAt)
+		expiry, idle := sessionExpiry(session)
+		data.SessionExpiresISO, data.SessionExpiresText = timeFields(expiry)
+		data.SessionExpiryIsIdle = idle
 		h.populateData(ctx, &data, session.UserID, session.ConnectorID)
-		data.SignedInText = utcText(data.SignedInEpoch)
-		data.SessionExpiresText = utcText(data.SessionExpiresEpoch)
 	}
 
 	if err := h.Templates.Home(r, w, data); err != nil {
@@ -72,33 +70,34 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// utcText renders an epoch for readers whose browser will not run the page's
-// script, which otherwise restates these times in the local timezone. Without
-// it those rows are an em dash. Empty for 0, which drops the row entirely.
-func utcText(epoch int64) string {
-	if epoch == 0 {
-		return ""
+// timeFields renders a timestamp for the page: an ISO 8601 string for the <time>
+// element's datetime attribute, and the UTC text shown to readers whose browser
+// will not run the script that restates it in their own timezone. Both are empty
+// for the zero time, which drops the row entirely.
+func timeFields(t time.Time) (iso, text string) {
+	if t.IsZero() {
+		return "", ""
 	}
-	return time.Unix(epoch, 0).UTC().Format("2 Jan 2006, 15:04 UTC")
+	return t.UTC().Format(time.RFC3339), t.UTC().Format("2 Jan 2006, 15:04 UTC")
 }
 
 // sessionExpiry reports when the session ends: the earlier of its absolute
 // lifetime and its idle timeout, since whichever comes first logs the user out.
-// It returns 0 when neither is set, which drops the row from the page.
+// It returns the zero time when neither is set, which drops the row.
 //
 // The second return says the idle timeout won. That distinction has to reach
 // the page: the absolute expiry is a fixed moment, while the idle one slides
 // forward every time the session is used, so labeling both "session ends"
 // would state a deadline that is not one.
-func sessionExpiry(s *storage.AuthSession) (int64, bool) {
+func sessionExpiry(s *storage.AuthSession) (time.Time, bool) {
 	expiry, idle := s.AbsoluteExpiry, false
 	if expiry.IsZero() || (!s.IdleExpiry.IsZero() && s.IdleExpiry.Before(expiry)) {
 		expiry, idle = s.IdleExpiry, true
 	}
 	if expiry.IsZero() {
-		return 0, false
+		return time.Time{}, false
 	}
-	return expiry.Unix(), idle
+	return expiry, idle
 }
 
 func (h *Handler) handleInline(w http.ResponseWriter, r *http.Request) {

--- a/server/home/home.go
+++ b/server/home/home.go
@@ -56,7 +56,7 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 		data.LoggedIn = true
 		data.IPAddress = session.IPAddress
 		data.UserAgent = session.UserAgent
-		data.SessionExpiresEpoch = sessionExpiry(session)
+		data.SessionExpiresEpoch, data.SessionExpiryIsIdle = sessionExpiry(session)
 		h.populateData(ctx, &data, session.UserID, session.ConnectorID)
 	}
 
@@ -69,15 +69,20 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 // sessionExpiry reports when the session ends: the earlier of its absolute
 // lifetime and its idle timeout, since whichever comes first logs the user out.
 // It returns 0 when neither is set, which drops the row from the page.
-func sessionExpiry(s *storage.AuthSession) int64 {
-	expiry := s.AbsoluteExpiry
+//
+// The second return says the idle timeout won. That distinction has to reach
+// the page: the absolute expiry is a fixed moment, while the idle one slides
+// forward every time the session is used, so labeling both "session ends"
+// would state a deadline that is not one.
+func sessionExpiry(s *storage.AuthSession) (int64, bool) {
+	expiry, idle := s.AbsoluteExpiry, false
 	if expiry.IsZero() || (!s.IdleExpiry.IsZero() && s.IdleExpiry.Before(expiry)) {
-		expiry = s.IdleExpiry
+		expiry, idle = s.IdleExpiry, true
 	}
 	if expiry.IsZero() {
-		return 0
+		return 0, false
 	}
-	return expiry.Unix()
+	return expiry.Unix(), idle
 }
 
 func (h *Handler) handleInline(w http.ResponseWriter, r *http.Request) {

--- a/server/home/home_test.go
+++ b/server/home/home_test.go
@@ -1,0 +1,85 @@
+package home
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dexidp/dex/storage"
+)
+
+func TestSessionExpiry(t *testing.T) {
+	absolute := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		session  storage.AuthSession
+		want     time.Time
+		wantIdle bool
+	}{
+		{
+			name:     "idle first",
+			session:  storage.AuthSession{AbsoluteExpiry: absolute, IdleExpiry: absolute.Add(-time.Hour)},
+			want:     absolute.Add(-time.Hour),
+			wantIdle: true,
+		},
+		{
+			name:     "absolute first",
+			session:  storage.AuthSession{AbsoluteExpiry: absolute, IdleExpiry: absolute.Add(time.Hour)},
+			want:     absolute,
+			wantIdle: false,
+		},
+		{
+			// Equal deadlines are the absolute one: it cannot move, so it is the
+			// honest label of the two.
+			name:     "equal",
+			session:  storage.AuthSession{AbsoluteExpiry: absolute, IdleExpiry: absolute},
+			want:     absolute,
+			wantIdle: false,
+		},
+		{
+			name:     "only idle set",
+			session:  storage.AuthSession{IdleExpiry: absolute},
+			want:     absolute,
+			wantIdle: true,
+		},
+		{
+			name:     "only absolute set",
+			session:  storage.AuthSession{AbsoluteExpiry: absolute},
+			want:     absolute,
+			wantIdle: false,
+		},
+		{
+			name:    "neither set",
+			session: storage.AuthSession{},
+			want:    time.Time{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, idle := sessionExpiry(&tc.session)
+			assert.Equal(t, tc.want, got)
+			assert.Equal(t, tc.wantIdle, idle)
+		})
+	}
+}
+
+func TestTimeFields(t *testing.T) {
+	iso, text := timeFields(time.Date(2026, 7, 28, 9, 5, 0, 0, time.UTC))
+	// The attribute has to parse as a date/time for <time> to mean anything.
+	assert.Equal(t, "2026-07-28T09:05:00Z", iso)
+	assert.Equal(t, "28 Jul 2026, 09:05 UTC", text)
+
+	// A different zone is still reported as the same instant in UTC.
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	assert.NoError(t, err)
+	iso, text = timeFields(time.Date(2026, 7, 28, 18, 5, 0, 0, tokyo))
+	assert.Equal(t, "2026-07-28T09:05:00Z", iso)
+	assert.Equal(t, "28 Jul 2026, 09:05 UTC", text)
+
+	iso, text = timeFields(time.Time{})
+	assert.Empty(t, iso)
+	assert.Empty(t, text)
+}

--- a/server/server_home_test.go
+++ b/server/server_home_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 	"time"
 
@@ -57,12 +56,19 @@ func TestHomeLoggedIn(t *testing.T) {
 	sessionStart := now.Add(-3 * time.Hour)
 	lastLogin := now.Add(-5 * time.Minute)
 
+	// The idle deadline is the earlier of the two, so that is the one the page
+	// has to report — and it has to say the deadline is the sliding one.
+	idleExpiry := now.Add(30 * time.Minute)
+	absoluteExpiry := now.Add(21 * time.Hour)
+
 	require.NoError(t, server.storage.CreateAuthSession(ctx, storage.AuthSession{
-		UserID:       userID,
-		ConnectorID:  connectorID,
-		Nonce:        nonce,
-		CreatedAt:    sessionStart,
-		LastActivity: now,
+		UserID:         userID,
+		ConnectorID:    connectorID,
+		Nonce:          nonce,
+		CreatedAt:      sessionStart,
+		LastActivity:   now,
+		IdleExpiry:     idleExpiry,
+		AbsoluteExpiry: absoluteExpiry,
 	}))
 
 	require.NoError(t, server.storage.CreateUserIdentity(ctx, storage.UserIdentity{
@@ -100,11 +106,17 @@ func TestHomeLoggedIn(t *testing.T) {
 	require.Contains(t, body, ".well-known/openid-configuration")
 	require.NotContains(t, body, "Not signed in")
 
-	// Both the machine-readable epoch and the text a reader without JavaScript
-	// sees have to be the session's start.
-	require.Contains(t, body, strconv.FormatInt(sessionStart.Unix(), 10))
+	// Both the datetime attribute and the text a reader without JavaScript sees
+	// have to be the session's start, not the identity's last login.
+	require.Contains(t, body, sessionStart.UTC().Format(time.RFC3339))
 	require.Contains(t, body, sessionStart.UTC().Format("2 Jan 2006, 15:04 UTC"))
-	require.NotContains(t, body, strconv.FormatInt(lastLogin.Unix(), 10))
+	require.NotContains(t, body, lastLogin.UTC().Format(time.RFC3339))
+
+	// The expiry row reports the earlier deadline and names it as the idle one.
+	require.Contains(t, body, "Expires if idle")
+	require.NotContains(t, body, "Session ends")
+	require.Contains(t, body, idleExpiry.UTC().Format(time.RFC3339))
+	require.NotContains(t, body, absoluteExpiry.UTC().Format(time.RFC3339))
 }
 
 func TestHomeInvalidCookie(t *testing.T) {

--- a/server/server_home_test.go
+++ b/server/server_home_test.go
@@ -23,7 +23,7 @@ func TestHomeNoSessions(t *testing.T) {
 	body := rr.Body.String()
 	require.Contains(t, body, "Dex IdP")
 	require.Contains(t, body, "Discovery")
-	require.NotContains(t, body, "Logout")
+	require.NotContains(t, body, "/logout")
 }
 
 func TestHomeNotLoggedIn(t *testing.T) {
@@ -35,9 +35,9 @@ func TestHomeNotLoggedIn(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 
 	body := rr.Body.String()
-	require.Contains(t, body, "Discovery")
-	require.Contains(t, body, "Not logged in")
-	require.NotContains(t, body, "Logout")
+	require.Contains(t, body, ".well-known/openid-configuration")
+	require.Contains(t, body, "Not signed in")
+	require.NotContains(t, body, "/logout")
 }
 
 func TestHomeLoggedIn(t *testing.T) {
@@ -83,14 +83,15 @@ func TestHomeLoggedIn(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 
 	body := rr.Body.String()
-	require.Contains(t, body, "Logout")
 	require.Contains(t, body, "/logout")
 	require.Contains(t, body, "testuser")
 	require.Contains(t, body, "test@example.com")
 	require.Contains(t, body, "Mock")
+	// Groups are listed outright rather than hidden behind a disclosure.
 	require.Contains(t, body, "admins")
-	require.Contains(t, body, "Discovery")
-	require.NotContains(t, body, "Not logged in")
+	require.Contains(t, body, "devs")
+	require.Contains(t, body, ".well-known/openid-configuration")
+	require.NotContains(t, body, "Not signed in")
 }
 
 func TestHomeInvalidCookie(t *testing.T) {
@@ -108,7 +109,7 @@ func TestHomeInvalidCookie(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 
 	body := rr.Body.String()
-	require.NotContains(t, body, "Logout")
-	require.Contains(t, body, "Not logged in")
-	require.Contains(t, body, "Discovery")
+	require.NotContains(t, body, "/logout")
+	require.Contains(t, body, "Not signed in")
+	require.Contains(t, body, ".well-known/openid-configuration")
 }

--- a/server/server_home_test.go
+++ b/server/server_home_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -50,11 +51,17 @@ func TestHomeLoggedIn(t *testing.T) {
 	nonce := "testnonce"
 	now := time.Now()
 
+	// The identity's last login is deliberately later than this session's start:
+	// the page reports the session it is describing, not the last time the same
+	// user signed in somewhere else.
+	sessionStart := now.Add(-3 * time.Hour)
+	lastLogin := now.Add(-5 * time.Minute)
+
 	require.NoError(t, server.storage.CreateAuthSession(ctx, storage.AuthSession{
 		UserID:       userID,
 		ConnectorID:  connectorID,
 		Nonce:        nonce,
-		CreatedAt:    now,
+		CreatedAt:    sessionStart,
 		LastActivity: now,
 	}))
 
@@ -69,7 +76,7 @@ func TestHomeLoggedIn(t *testing.T) {
 			EmailVerified:     true,
 			Groups:            []string{"admins", "devs"},
 		},
-		LastLogin: now,
+		LastLogin: lastLogin,
 	}))
 
 	req := httptest.NewRequest("GET", "/", nil)
@@ -92,6 +99,12 @@ func TestHomeLoggedIn(t *testing.T) {
 	require.Contains(t, body, "devs")
 	require.Contains(t, body, ".well-known/openid-configuration")
 	require.NotContains(t, body, "Not signed in")
+
+	// Both the machine-readable epoch and the text a reader without JavaScript
+	// sees have to be the session's start.
+	require.Contains(t, body, strconv.FormatInt(sessionStart.Unix(), 10))
+	require.Contains(t, body, sessionStart.UTC().Format("2 Jan 2006, 15:04 UTC"))
+	require.NotContains(t, body, strconv.FormatInt(lastLogin.Unix(), 10))
 }
 
 func TestHomeInvalidCookie(t *testing.T) {

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 
@@ -55,6 +56,12 @@ func (m *Manager) RememberMeDefault() *bool {
 func remoteIP(r *http.Request) string {
 	if ip, ok := r.Context().Value(reqctx.RequestKeyRemoteIP).(string); ok && ip != "" {
 		return ip
+	}
+	// RemoteAddr carries the ephemeral source port, which is noise in an audit
+	// record: it identifies the connection, not the client. The resolver behind
+	// the context value already strips it, so strip it here too.
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
 	}
 	return r.RemoteAddr
 }

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -52,7 +52,9 @@ func (m *Manager) RememberMeDefault() *bool {
 	return &v
 }
 
-// remoteIP returns the real IP from context (set by parseRealIP middleware) or falls back to r.RemoteAddr.
+// remoteIP returns the real IP from context (set by the real-IP resolver) or,
+// failing that, the host part of r.RemoteAddr. Either way the result carries no
+// port; only an address that parses as neither is returned verbatim.
 func remoteIP(r *http.Request) string {
 	if ip, ok := r.Context().Value(reqctx.RequestKeyRemoteIP).(string); ok && ip != "" {
 		return ip

--- a/server/session/session_test.go
+++ b/server/session/session_test.go
@@ -1,0 +1,75 @@
+package session
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dexidp/dex/server/reqctx"
+)
+
+// The address stored on a session is an audit record, so it has to be the
+// client's address and nothing else — in particular not the ephemeral source
+// port, which identifies the connection rather than the client.
+func TestRemoteIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		ctxIP      string
+		want       string
+	}{
+		{
+			name:       "resolver value wins",
+			remoteAddr: "10.0.0.1:4711",
+			ctxIP:      "203.0.113.7",
+			want:       "203.0.113.7",
+		},
+		{
+			name:       "empty resolver value falls through",
+			remoteAddr: "10.0.0.1:4711",
+			ctxIP:      "",
+			want:       "10.0.0.1",
+		},
+		{
+			name:       "ipv4 with port",
+			remoteAddr: "192.168.1.10:54321",
+			want:       "192.168.1.10",
+		},
+		{
+			name:       "ipv6 with port",
+			remoteAddr: "[2001:db8::1]:54321",
+			want:       "2001:db8::1",
+		},
+		{
+			name:       "ipv6 zone with port",
+			remoteAddr: "[fe80::1%eth0]:8080",
+			want:       "fe80::1%eth0",
+		},
+		{
+			// Not something net/http produces, but the fallback must not turn an
+			// unexpected value into an empty audit record.
+			name:       "no port",
+			remoteAddr: "192.168.1.10",
+			want:       "192.168.1.10",
+		},
+		{
+			name:       "unix socket",
+			remoteAddr: "@",
+			want:       "@",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/", nil)
+			r.RemoteAddr = tc.remoteAddr
+			if tc.ctxIP != "" {
+				r = r.WithContext(context.WithValue(r.Context(), reqctx.RequestKeyRemoteIP, tc.ctxIP))
+			}
+
+			assert.Equal(t, tc.want, remoteIP(r))
+		})
+	}
+}

--- a/server/templates/templates.go
+++ b/server/templates/templates.go
@@ -378,18 +378,33 @@ func (t *Templates) TOTPVerify(r *http.Request, w http.ResponseWriter, postURL, 
 }
 
 type HomeData struct {
-	LoggedIn       bool
-	Username       string
-	Email          string
-	EmailVerified  bool
-	Groups         []string
-	ConnectorName  string
-	LastLoginEpoch int64
-	IPAddress      string
-	UserAgent      string
-	LogoutURL      string
-	DiscoveryURL   string
-	ReqPath        string
+	LoggedIn      bool
+	Username      string
+	Email         string
+	EmailVerified bool
+	Groups        []string
+	ConnectorName string
+	// LastLoginEpoch and SessionExpiresEpoch are Unix seconds, rendered as local
+	// time by the page's script. Zero means the row is omitted.
+	LastLoginEpoch      int64
+	SessionExpiresEpoch int64
+	IPAddress           string
+	UserAgent           string
+	LogoutURL           string
+	DiscoveryURL        string
+	ReqPath             string
+}
+
+// Initial is the first letter of the display name, for the identity avatar.
+// Empty when there is no name to take it from.
+func (d HomeData) Initial() string {
+	for _, r := range d.Username {
+		return strings.ToUpper(string(r))
+	}
+	for _, r := range d.Email {
+		return strings.ToUpper(string(r))
+	}
+	return ""
 }
 
 // HasHome reports whether the home template was loaded.

--- a/server/templates/templates.go
+++ b/server/templates/templates.go
@@ -384,18 +384,18 @@ type HomeData struct {
 	EmailVerified bool
 	Groups        []string
 	ConnectorName string
-	// SignedInEpoch and SessionExpiresEpoch are Unix seconds, restated in the
-	// visitor's timezone by the page's script. Zero means the row is omitted.
-	// The matching Text fields hold the UTC rendering the page shows until (or
-	// unless) that script runs.
+	// Each timestamp reaches the page twice: ISO for the <time> element's
+	// datetime attribute, which the page's script reads and restates in the
+	// visitor's timezone, and Text as the UTC rendering shown until (or unless)
+	// that script runs. Empty means the row is omitted.
 	//
-	// SignedInEpoch is when this session began, not the identity's last login:
-	// the page describes one session, and the identity's last login moves when
-	// the same user signs in from somewhere else entirely.
-	SignedInEpoch       int64
-	SignedInText        string
-	SessionExpiresEpoch int64
-	SessionExpiresText  string
+	// SignedIn is when this session began, not the identity's last login: the
+	// page describes one session, and the identity's last login moves when the
+	// same user signs in from somewhere else entirely.
+	SignedInISO        string
+	SignedInText       string
+	SessionExpiresISO  string
+	SessionExpiresText string
 	// SessionExpiryIsIdle says SessionExpiresEpoch is the idle timeout rather
 	// than the absolute one, so the page can say the deadline slides.
 	SessionExpiryIsIdle bool

--- a/server/templates/templates.go
+++ b/server/templates/templates.go
@@ -384,10 +384,14 @@ type HomeData struct {
 	EmailVerified bool
 	Groups        []string
 	ConnectorName string
-	// LastLoginEpoch and SessionExpiresEpoch are Unix seconds, rendered as local
-	// time by the page's script. Zero means the row is omitted.
+	// LastLoginEpoch and SessionExpiresEpoch are Unix seconds, restated in the
+	// visitor's timezone by the page's script. Zero means the row is omitted.
+	// The matching Text fields hold the UTC rendering the page shows until (or
+	// unless) that script runs.
 	LastLoginEpoch      int64
+	LastLoginText       string
 	SessionExpiresEpoch int64
+	SessionExpiresText  string
 	// SessionExpiryIsIdle says SessionExpiresEpoch is the idle timeout rather
 	// than the absolute one, so the page can say the deadline slides.
 	SessionExpiryIsIdle bool

--- a/server/templates/templates.go
+++ b/server/templates/templates.go
@@ -384,12 +384,16 @@ type HomeData struct {
 	EmailVerified bool
 	Groups        []string
 	ConnectorName string
-	// LastLoginEpoch and SessionExpiresEpoch are Unix seconds, restated in the
+	// SignedInEpoch and SessionExpiresEpoch are Unix seconds, restated in the
 	// visitor's timezone by the page's script. Zero means the row is omitted.
 	// The matching Text fields hold the UTC rendering the page shows until (or
 	// unless) that script runs.
-	LastLoginEpoch      int64
-	LastLoginText       string
+	//
+	// SignedInEpoch is when this session began, not the identity's last login:
+	// the page describes one session, and the identity's last login moves when
+	// the same user signs in from somewhere else entirely.
+	SignedInEpoch       int64
+	SignedInText        string
 	SessionExpiresEpoch int64
 	SessionExpiresText  string
 	// SessionExpiryIsIdle says SessionExpiresEpoch is the idle timeout rather

--- a/server/templates/templates.go
+++ b/server/templates/templates.go
@@ -395,18 +395,6 @@ type HomeData struct {
 	ReqPath             string
 }
 
-// Initial is the first letter of the display name, for the identity avatar.
-// Empty when there is no name to take it from.
-func (d HomeData) Initial() string {
-	for _, r := range d.Username {
-		return strings.ToUpper(string(r))
-	}
-	for _, r := range d.Email {
-		return strings.ToUpper(string(r))
-	}
-	return ""
-}
-
 // HasHome reports whether the home template was loaded.
 func (t *Templates) HasHome() bool {
 	return t.homeTmpl != nil

--- a/server/templates/templates.go
+++ b/server/templates/templates.go
@@ -388,6 +388,9 @@ type HomeData struct {
 	// time by the page's script. Zero means the row is omitted.
 	LastLoginEpoch      int64
 	SessionExpiresEpoch int64
+	// SessionExpiryIsIdle says SessionExpiresEpoch is the idle timeout rather
+	// than the absolute one, so the page can say the deadline slides.
+	SessionExpiryIsIdle bool
 	IPAddress           string
 	UserAgent           string
 	LogoutURL           string

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -190,11 +190,23 @@ body {
 
 .dex-identity__email {
   color: var(--dex-home-muted);
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
   font-size: 13px;
   line-height: 1.5;
   margin-top: 3px;
   overflow-wrap: anywhere;
+}
+
+/* Whether the connector vouched for the address belongs next to the address,
+ * not in a row of its own further down. It stays in the body face while the
+ * address is monospace: it is a remark about the value, not part of it. */
+.dex-identity__state {
+  white-space: nowrap;
+}
+
+/* An address nobody verified is the case worth noticing, so it is the one that
+ * gets full contrast. */
+.dex-identity__state--warn {
+  color: var(--dex-home-fg);
 }
 
 .dex-fact__count {
@@ -337,15 +349,18 @@ body {
   padding-top: 16px;
 }
 
+/* Underlined and in the accent colour from the start: as grey unadorned text it
+ * did not read as something you could click, which is the only thing this line
+ * is there for. */
 .dex-home__link {
-  color: var(--dex-home-muted);
-  font-size: 12px;
-  text-decoration: none;
+  color: var(--dex-home-accent);
+  font-size: 13px;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .dex-home__link:hover {
-  color: var(--dex-home-accent);
-  text-decoration: underline;
+  text-decoration-thickness: 2px;
 }
 
 @media (max-width: 420px) {

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -257,11 +257,12 @@ body {
 }
 
 /* Overlay scrollbars stay invisible until touched, so a clipped list would read
- * as complete. The template adds this class only when the list actually
- * overflows, and the fade says the rest is below. */
+ * as complete. The template adds this class while there is more below, and the
+ * fade says so. It covers only the row the cap cuts through — a longer gradient
+ * would dim the readable rows above it too. */
 .dex-groups--clipped {
-  -webkit-mask-image: linear-gradient(to bottom, #000 86px, transparent);
-  mask-image: linear-gradient(to bottom, #000 86px, transparent);
+  -webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - 22px), transparent);
+  mask-image: linear-gradient(to bottom, #000 calc(100% - 22px), transparent);
 }
 
 .dex-groups:focus-visible {

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -167,7 +167,8 @@ body {
   --dex-home-muted: var(--dex-fg-muted, #6b7280);
   --dex-home-border: var(--dex-border, #e8eaed);
   --dex-home-subtle: var(--dex-surface-subtle, #f4f5f7);
-  --dex-home-accent: var(--dex-accent, #4a90d9);
+  --dex-home-accent: var(--dex-accent, #2f6fb0);
+  --dex-home-accent-fg: var(--dex-accent-fg, #ffffff);
 
   color: var(--dex-home-fg);
   text-align: left;
@@ -239,13 +240,49 @@ body {
   text-transform: uppercase;
 }
 
+.dex-field__count {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: normal;
+  opacity: 0.75;
+}
+
+/* A directory can hand back dozens of groups, so the list is capped and scrolls
+ * instead of pushing the rest of the page out of view. The count in the label
+ * says how many there are; tabindex on the template keeps the overflow
+ * reachable by keyboard. */
 .dex-chips {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
   list-style: none;
   margin: 0;
-  padding: 0;
+  max-height: 114px;
+  overflow-y: auto;
+  padding: 0 2px 0 0;
+  scrollbar-color: var(--dex-home-border) transparent;
+  scrollbar-width: thin;
+}
+
+.dex-chips::-webkit-scrollbar {
+  width: 6px;
+}
+
+.dex-chips::-webkit-scrollbar-thumb {
+  background-color: var(--dex-home-border);
+  border-radius: 3px;
+}
+
+/* Overlay scrollbars stay invisible until touched, so a clipped list would read
+ * as complete. The template adds this class only when the list actually
+ * overflows, and the fade says the rest is below. */
+.dex-chips--clipped {
+  -webkit-mask-image: linear-gradient(to bottom, #000 72px, transparent);
+  mask-image: linear-gradient(to bottom, #000 72px, transparent);
+}
+
+.dex-chips:focus-visible {
+  outline: 2px solid var(--dex-home-accent);
+  outline-offset: 3px;
 }
 
 .dex-chip {
@@ -296,21 +333,25 @@ body {
   margin-top: 24px;
 }
 
-.dex-btn--outline {
-  background-color: transparent;
-  border: 1px solid var(--dex-home-border);
-  color: var(--dex-home-fg);
+/* The page's only action, so it gets the accent fill. The theme owns both the
+ * fill and the text on it: an accent light enough to need dark labels (the dark
+ * theme's) sets --dex-accent-fg accordingly. */
+.dex-btn--accent {
+  background-color: var(--dex-home-accent);
+  border: 0;
+  color: var(--dex-home-accent-fg);
   display: block;
   font-size: 14px;
-  font-weight: 500;
-  padding: 9px 16px;
+  font-weight: 600;
+  padding: 10px 16px;
   text-align: center;
   text-decoration: none;
+  transition: filter 0.15s ease;
   width: 100%;
 }
 
-.dex-btn--outline:hover {
-  background-color: var(--dex-home-subtle);
+.dex-btn--accent:hover {
+  filter: brightness(0.92);
 }
 
 .dex-home__empty {

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -168,7 +168,6 @@ body {
   --dex-home-border: var(--dex-border, #e8eaed);
   --dex-home-subtle: var(--dex-surface-subtle, #f4f5f7);
   --dex-home-accent: var(--dex-accent, #2f6fb0);
-  --dex-home-accent-fg: var(--dex-accent-fg, #ffffff);
 
   color: var(--dex-home-fg);
   text-align: left;
@@ -331,27 +330,18 @@ body {
 
 .dex-home__actions {
   margin-top: 24px;
+  text-align: center;
 }
 
-/* The page's only action, so it gets the accent fill. The theme owns both the
- * fill and the text on it: an accent light enough to need dark labels (the dark
- * theme's) sets --dex-accent-fg accordingly. */
-.dex-btn--accent {
-  background-color: var(--dex-home-accent);
-  border: 0;
-  color: var(--dex-home-accent-fg);
-  display: block;
+/* Logging out is a link here and a form button on /logout, so the anchor needs
+ * the few properties a <button> brings on its own. Everything else comes from
+ * theme-btn--primary, the same class the rest of the pages use. */
+.dex-home__actions .dex-btn {
+  display: inline-block;
   font-size: 14px;
   font-weight: 600;
-  padding: 10px 16px;
-  text-align: center;
+  line-height: 22px;
   text-decoration: none;
-  transition: filter 0.15s ease;
-  width: 100%;
-}
-
-.dex-btn--accent:hover {
-  filter: brightness(0.92);
 }
 
 .dex-home__empty {

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -312,6 +312,7 @@ body {
 
 .dex-home__actions {
   margin-top: 24px;
+  text-align: center;
 }
 
 /* Logging out is a link here and a form button on /logout, so the anchor needs

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -339,6 +339,14 @@ body {
   text-decoration-thickness: 2px;
 }
 
+/* Matches the focus ring the buttons and the group list use, rather than
+ * leaving this one link to the browser default. */
+.dex-home__link:focus-visible {
+  outline: 2px solid var(--dex-home-accent);
+  outline-offset: 3px;
+  text-decoration-thickness: 2px;
+}
+
 @media (max-width: 420px) {
   .dex-fact {
     grid-template-columns: minmax(0, 1fr);

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -146,85 +146,6 @@ body {
   text-align: left;
 }
 
-.dex-info-table {
-  margin: 12px auto;
-  text-align: left;
-  max-width: 300px;
-}
-
-.dex-info-row {
-  display: flex;
-  justify-content: space-between;
-  padding: 8px 0;
-  border-bottom: 1px solid #eee;
-  font-size: 13px;
-}
-
-.dex-info-row:last-child {
-  border-bottom: none;
-}
-
-.dex-info-label {
-  color: #888;
-  font-weight: 500;
-}
-
-.dex-info-value {
-  color: #333;
-  text-align: right;
-  word-break: break-word;
-  min-width: 0;
-  max-width: 200px;
-}
-
-.dex-info-details {
-  color: #333;
-  font-size: 13px;
-  min-width: 0;
-  max-width: 200px;
-  text-align: right;
-}
-
-.dex-info-details summary {
-  cursor: pointer;
-  list-style: none;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: #4A90D9;
-}
-
-.dex-info-details summary:hover {
-  text-decoration: underline;
-}
-
-.dex-info-details summary::-webkit-details-marker {
-  display: none;
-}
-
-.dex-info-details summary::after {
-  content: " \25B8";
-  color: #aaa;
-}
-
-.dex-info-details[open] summary::after {
-  content: " \25BE";
-}
-
-.dex-info-details[open] > :not(summary) {
-  text-align: left;
-}
-
-.dex-info-details[open] summary {
-  margin-bottom: 4px;
-}
-
-.dex-info-details .dex-info-details__list {
-  margin: 0;
-  padding-left: 16px;
-  line-height: 1.8;
-}
-
 .dex-error-box {
   background-color: #e5383b;
   border-radius: 6px;
@@ -234,4 +155,207 @@ body {
   margin: 20px auto;
   max-width: 320px;
   padding: 8px 12px;
+}
+
+/* Home page.
+ *
+ * Colours come from custom properties so a theme can restyle the page by
+ * setting a handful of values. The fallbacks are the light-theme values, so a
+ * custom theme that defines none of them still renders exactly as before. */
+.dex-home {
+  --dex-home-fg: var(--dex-fg, #1a1a1a);
+  --dex-home-muted: var(--dex-fg-muted, #6b7280);
+  --dex-home-border: var(--dex-border, #e8eaed);
+  --dex-home-subtle: var(--dex-surface-subtle, #f4f5f7);
+  --dex-home-accent: var(--dex-accent, #4a90d9);
+
+  color: var(--dex-home-fg);
+  text-align: left;
+}
+
+.dex-identity {
+  align-items: center;
+  display: flex;
+  gap: 14px;
+  min-width: 0;
+}
+
+.dex-identity__avatar {
+  align-items: center;
+  background-color: var(--dex-home-subtle);
+  border: 1px solid var(--dex-home-border);
+  border-radius: 50%;
+  color: var(--dex-home-muted);
+  display: flex;
+  flex: 0 0 auto;
+  font-size: 18px;
+  font-weight: 600;
+  height: 44px;
+  justify-content: center;
+  width: 44px;
+}
+
+.dex-identity__text {
+  min-width: 0;
+}
+
+.dex-identity__name {
+  font-size: 17px;
+  font-weight: 600;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.dex-identity__email {
+  color: var(--dex-home-muted);
+  font-size: 13px;
+  line-height: 1.5;
+  margin-top: 2px;
+  overflow-wrap: anywhere;
+}
+
+.dex-badge {
+  border: 1px solid var(--dex-home-border);
+  border-radius: 999px;
+  color: var(--dex-home-muted);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  margin-left: 6px;
+  padding: 1px 7px;
+  white-space: nowrap;
+}
+
+.dex-field {
+  margin-top: 20px;
+}
+
+.dex-field__label {
+  color: var(--dex-home-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+}
+
+.dex-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.dex-chip {
+  background-color: var(--dex-home-subtle);
+  border: 1px solid var(--dex-home-border);
+  border-radius: 6px;
+  font-size: 12px;
+  overflow-wrap: anywhere;
+  padding: 3px 9px;
+}
+
+.dex-useragent {
+  color: var(--dex-home-muted);
+  font-size: 12px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+/* Facts are label/value pairs. They stack on narrow viewports so a long value
+ * never has to share a line with its label. */
+.dex-facts {
+  border-top: 1px solid var(--dex-home-border);
+  margin: 20px 0 0;
+  padding: 0;
+}
+
+.dex-fact {
+  border-bottom: 1px solid var(--dex-home-border);
+  display: flex;
+  font-size: 13px;
+  gap: 16px;
+  justify-content: space-between;
+  padding: 9px 0;
+}
+
+.dex-fact dt {
+  color: var(--dex-home-muted);
+  flex: 0 0 auto;
+}
+
+.dex-fact dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+  text-align: right;
+}
+
+.dex-home__actions {
+  margin-top: 24px;
+}
+
+.dex-btn--outline {
+  background-color: transparent;
+  border: 1px solid var(--dex-home-border);
+  color: var(--dex-home-fg);
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 9px 16px;
+  text-align: center;
+  text-decoration: none;
+  width: 100%;
+}
+
+.dex-btn--outline:hover {
+  background-color: var(--dex-home-subtle);
+}
+
+.dex-home__empty {
+  padding: 8px 0 4px;
+  text-align: center;
+}
+
+.dex-home__empty-title {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.dex-home__empty-text {
+  color: var(--dex-home-muted);
+  font-size: 13px;
+  line-height: 1.6;
+  margin: 6px auto 0;
+  max-width: 34ch;
+}
+
+.dex-home__footer {
+  border-top: 1px solid var(--dex-home-border);
+  margin-top: 24px;
+  padding-top: 16px;
+  text-align: center;
+}
+
+.dex-home__link {
+  color: var(--dex-home-muted);
+  font-size: 12px;
+  text-decoration: none;
+}
+
+.dex-home__link:hover {
+  color: var(--dex-home-accent);
+  text-decoration: underline;
+}
+
+@media (max-width: 420px) {
+  .dex-fact {
+    display: block;
+  }
+
+  .dex-fact dd {
+    margin-top: 2px;
+    text-align: left;
+  }
 }

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -184,6 +184,7 @@ body {
   font-size: 17px;
   font-weight: 600;
   line-height: 1.3;
+  margin: 0;
   overflow-wrap: anywhere;
 }
 
@@ -196,35 +197,34 @@ body {
   overflow-wrap: anywhere;
 }
 
-.dex-field {
-  margin-top: 20px;
-}
-
-.dex-field__label {
-  color: var(--dex-home-muted);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  margin-bottom: 8px;
-  text-transform: uppercase;
-}
-
-.dex-field__count {
+.dex-fact__count {
   font-variant-numeric: tabular-nums;
-  letter-spacing: normal;
   opacity: 0.75;
 }
 
-/* A directory can hand back dozens of groups, so the list is capped and scrolls
+/* Groups sit below the table rather than in it: a group is often a full DN, and
+ * the table's value column would wrap one across three lines. The label matches
+ * the table's, so a wider row does not read as a different system.
+ *
+ * A directory can hand back dozens of groups, so the list is capped and scrolls
  * instead of pushing the rest of the page out of view. The count in the label
  * says how many there are; tabindex on the template keeps the overflow
  * reachable by keyboard. */
+.dex-groups-block {
+  margin-top: 14px;
+}
+
+.dex-groups-block__label {
+  color: var(--dex-home-muted);
+  font-size: 13px;
+  margin-bottom: 6px;
+}
 .dex-groups {
   font-size: 12.5px;
-  line-height: 1.7;
+  line-height: 1.6;
   list-style: none;
   margin: 0;
-  max-height: 128px;
+  max-height: 120px;
   overflow-y: auto;
   padding: 0 2px 0 0;
   scrollbar-color: var(--dex-home-border) transparent;
@@ -257,15 +257,11 @@ body {
   outline-offset: 3px;
 }
 
-.dex-useragent {
-  color: var(--dex-home-muted);
-  font-size: 12px;
-  line-height: 1.5;
-  overflow-wrap: anywhere;
-}
-
-/* Facts are label/value pairs. They stack on narrow viewports so a long value
- * never has to share a line with its label. */
+/* Facts are label/value pairs on a fixed label column. Pushing values to the
+ * right edge instead would leave a hand's width of empty panel between a label
+ * and the value it belongs to, and would be the third alignment on a card that
+ * only needs one. They stack on narrow viewports, where the column costs more
+ * room than it buys. */
 .dex-facts {
   border-top: 1px solid var(--dex-home-border);
   margin: 20px 0 0;
@@ -274,22 +270,20 @@ body {
 
 .dex-fact {
   border-bottom: 1px solid var(--dex-home-border);
-  display: flex;
+  display: grid;
   font-size: 13px;
-  gap: 16px;
-  justify-content: space-between;
+  gap: 4px 16px;
+  grid-template-columns: 116px minmax(0, 1fr);
   padding: 9px 0;
 }
 
 .dex-fact dt {
   color: var(--dex-home-muted);
-  flex: 0 0 auto;
 }
 
 .dex-fact dd {
   margin: 0;
   overflow-wrap: anywhere;
-  text-align: right;
 }
 
 /* Monospace runs large at a shared size; nudge it back to match its neighbours. */
@@ -297,9 +291,15 @@ body {
   font-size: 12.5px;
 }
 
+/* The User-Agent is the longest and least urgent value on the page. */
+.dex-fact dd.dex-fact__long {
+  color: var(--dex-home-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
 .dex-home__actions {
   margin-top: 24px;
-  text-align: center;
 }
 
 /* Logging out is a link here and a form button on /logout, so the anchor needs
@@ -335,7 +335,6 @@ body {
   border-top: 1px solid var(--dex-home-border);
   margin-top: 24px;
   padding-top: 16px;
-  text-align: center;
 }
 
 .dex-home__link {
@@ -351,11 +350,6 @@ body {
 
 @media (max-width: 420px) {
   .dex-fact {
-    display: block;
-  }
-
-  .dex-fact dd {
-    margin-top: 2px;
-    text-align: left;
+    grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -173,30 +173,11 @@ body {
   text-align: left;
 }
 
-.dex-identity {
-  align-items: center;
-  display: flex;
-  gap: 14px;
-  min-width: 0;
-}
-
-.dex-identity__avatar {
-  align-items: center;
-  background-color: var(--dex-home-subtle);
-  border: 1px solid var(--dex-home-border);
-  border-radius: 50%;
-  color: var(--dex-home-muted);
-  display: flex;
-  flex: 0 0 auto;
-  font-size: 18px;
-  font-weight: 600;
-  height: 44px;
-  justify-content: center;
-  width: 44px;
-}
-
-.dex-identity__text {
-  min-width: 0;
+/* Claim values are machine strings — an address, a group name, an IP. They read
+ * as data rather than prose in a monospace face, and it keeps the page from
+ * looking like a social profile, which is not what dex knows about anyone. */
+.dex-mono {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
 }
 
 .dex-identity__name {
@@ -208,22 +189,11 @@ body {
 
 .dex-identity__email {
   color: var(--dex-home-muted);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
   font-size: 13px;
   line-height: 1.5;
-  margin-top: 2px;
+  margin-top: 3px;
   overflow-wrap: anywhere;
-}
-
-.dex-badge {
-  border: 1px solid var(--dex-home-border);
-  border-radius: 999px;
-  color: var(--dex-home-muted);
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.02em;
-  margin-left: 6px;
-  padding: 1px 7px;
-  white-space: nowrap;
 }
 
 .dex-field {
@@ -249,24 +219,27 @@ body {
  * instead of pushing the rest of the page out of view. The count in the label
  * says how many there are; tabindex on the template keeps the overflow
  * reachable by keyboard. */
-.dex-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+.dex-groups {
+  font-size: 12.5px;
+  line-height: 1.7;
   list-style: none;
   margin: 0;
-  max-height: 114px;
+  max-height: 128px;
   overflow-y: auto;
   padding: 0 2px 0 0;
   scrollbar-color: var(--dex-home-border) transparent;
   scrollbar-width: thin;
 }
 
-.dex-chips::-webkit-scrollbar {
+.dex-groups li {
+  overflow-wrap: anywhere;
+}
+
+.dex-groups::-webkit-scrollbar {
   width: 6px;
 }
 
-.dex-chips::-webkit-scrollbar-thumb {
+.dex-groups::-webkit-scrollbar-thumb {
   background-color: var(--dex-home-border);
   border-radius: 3px;
 }
@@ -274,23 +247,14 @@ body {
 /* Overlay scrollbars stay invisible until touched, so a clipped list would read
  * as complete. The template adds this class only when the list actually
  * overflows, and the fade says the rest is below. */
-.dex-chips--clipped {
-  -webkit-mask-image: linear-gradient(to bottom, #000 72px, transparent);
-  mask-image: linear-gradient(to bottom, #000 72px, transparent);
+.dex-groups--clipped {
+  -webkit-mask-image: linear-gradient(to bottom, #000 86px, transparent);
+  mask-image: linear-gradient(to bottom, #000 86px, transparent);
 }
 
-.dex-chips:focus-visible {
+.dex-groups:focus-visible {
   outline: 2px solid var(--dex-home-accent);
   outline-offset: 3px;
-}
-
-.dex-chip {
-  background-color: var(--dex-home-subtle);
-  border: 1px solid var(--dex-home-border);
-  border-radius: 6px;
-  font-size: 12px;
-  overflow-wrap: anywhere;
-  padding: 3px 9px;
 }
 
 .dex-useragent {
@@ -326,6 +290,11 @@ body {
   margin: 0;
   overflow-wrap: anywhere;
   text-align: right;
+}
+
+/* Monospace runs large at a shared size; nudge it back to match its neighbours. */
+.dex-fact dd.dex-mono {
+  font-size: 12.5px;
 }
 
 .dex-home__actions {

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -173,13 +173,6 @@ body {
   text-align: left;
 }
 
-/* Claim values are machine strings — an address, a group name, an IP. They read
- * as data rather than prose in a monospace face, and it keeps the page from
- * looking like a social profile, which is not what dex knows about anyone. */
-.dex-mono {
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-}
-
 .dex-identity__name {
   font-size: 17px;
   font-weight: 600;
@@ -197,8 +190,7 @@ body {
 }
 
 /* Whether the connector vouched for the address belongs next to the address,
- * not in a row of its own further down. It stays in the body face while the
- * address is monospace: it is a remark about the value, not part of it. */
+ * not in a row of its own further down. */
 .dex-identity__state {
   white-space: nowrap;
 }
@@ -232,6 +224,10 @@ body {
   margin-bottom: 6px;
 }
 .dex-groups {
+  /* The one place the page changes face. A group is an identifier you compare
+   * against something else, and a column of them lines up character for
+   * character in monospace. Single values elsewhere gain nothing from it. */
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
   font-size: 12.5px;
   line-height: 1.6;
   list-style: none;
@@ -297,11 +293,6 @@ body {
 .dex-fact dd {
   margin: 0;
   overflow-wrap: anywhere;
-}
-
-/* Monospace runs large at a shared size; nudge it back to match its neighbours. */
-.dex-fact dd.dex-mono {
-  font-size: 12.5px;
 }
 
 /* The User-Agent is the longest and least urgent value on the page. */

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -205,24 +205,11 @@ body {
   opacity: 0.75;
 }
 
-/* Groups sit below the table rather than in it: a group is often a full DN, and
- * the table's value column would wrap one across three lines. The label matches
- * the table's, so a wider row does not read as a different system.
- *
- * A directory can hand back dozens of groups, so the list is capped and scrolls
- * instead of pushing the rest of the page out of view. The count in the label
- * says how many there are; tabindex on the template keeps the overflow
- * reachable by keyboard. */
-.dex-groups-block {
-  margin-top: 14px;
-}
-
-.dex-groups-block__label {
-  color: var(--dex-home-muted);
-  font-size: 13px;
-  margin-bottom: 6px;
-}
-
+/* Groups are a row like the others, so their values start where every other
+ * value on the page starts. A directory can hand back dozens of them, so the
+ * list is capped and scrolls instead of pushing the rest of the page out of
+ * view. The count in the label says how many there are; tabindex on the
+ * template keeps the overflow reachable by keyboard. */
 .dex-groups {
   font-size: 13px;
   line-height: 1.6;

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -166,7 +166,6 @@ body {
   --dex-home-fg: var(--dex-fg, #1a1a1a);
   --dex-home-muted: var(--dex-fg-muted, #6b7280);
   --dex-home-border: var(--dex-border, #e8eaed);
-  --dex-home-subtle: var(--dex-surface-subtle, #f4f5f7);
   --dex-home-accent: var(--dex-accent, #2f6fb0);
 
   color: var(--dex-home-fg);
@@ -201,7 +200,7 @@ body {
   color: var(--dex-home-fg);
 }
 
-.dex-fact__count {
+.dex-count {
   font-variant-numeric: tabular-nums;
   opacity: 0.75;
 }
@@ -223,12 +222,9 @@ body {
   font-size: 13px;
   margin-bottom: 6px;
 }
+
 .dex-groups {
-  /* The one place the page changes face. A group is an identifier you compare
-   * against something else, and a column of them lines up character for
-   * character in monospace. Single values elsewhere gain nothing from it. */
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 12.5px;
+  font-size: 13px;
   line-height: 1.6;
   list-style: none;
   margin: 0;

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -6,9 +6,9 @@
     {{ if .Username }}<h2 class="dex-identity__name">{{ .Username }}</h2>{{ end }}
     {{ if .Email }}
     <div class="dex-identity__email">
-      <span class="dex-mono">{{ .Email }}</span>
-      {{ if .EmailVerified }}<span class="dex-identity__state">· verified</span>
-      {{ else }}<span class="dex-identity__state dex-identity__state--warn">· not verified</span>{{ end }}
+      {{ .Email }}
+      {{ if .EmailVerified }}<span class="dex-identity__state">(verified)</span>
+      {{ else }}<span class="dex-identity__state dex-identity__state--warn">(not verified)</span>{{ end }}
     </div>
     {{ end }}
   </div>
@@ -35,7 +35,7 @@
     {{ if .IPAddress }}
     <div class="dex-fact">
       <dt>IP address</dt>
-      <dd class="dex-mono">{{ .IPAddress }}</dd>
+      <dd>{{ .IPAddress }}</dd>
     </div>
     {{ end }}
     {{ if .UserAgent }}
@@ -49,7 +49,7 @@
   {{ if .Groups }}
   <div class="dex-groups-block">
     <div class="dex-groups-block__label">Groups <span class="dex-fact__count">{{ len .Groups }}</span></div>
-    <ul class="dex-groups dex-mono" tabindex="0">
+    <ul class="dex-groups" tabindex="0">
       {{ range .Groups }}<li>{{ . }}</li>{{ end }}
     </ul>
   </div>

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -20,10 +20,10 @@
       <dd>{{ .ConnectorName }}</dd>
     </div>
     {{ end }}
-    {{ if .LastLoginEpoch }}
+    {{ if .SignedInEpoch }}
     <div class="dex-fact">
-      <dt>Last sign-in</dt>
-      <dd><time datetime="{{ .LastLoginEpoch }}">{{ .LastLoginText }}</time></dd>
+      <dt>Signed in</dt>
+      <dd><time datetime="{{ .SignedInEpoch }}">{{ .SignedInText }}</time></dd>
     </div>
     {{ end }}
     {{ if .SessionExpiresEpoch }}
@@ -34,7 +34,7 @@
     {{ end }}
     {{ if .IPAddress }}
     <div class="dex-fact">
-      <dt>IP address</dt>
+      <dt>Signed in from</dt>
       <dd>{{ .IPAddress }}</dd>
     </div>
     {{ end }}

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -38,6 +38,16 @@
       <dd>{{ .IPAddress }}</dd>
     </div>
     {{ end }}
+    {{ if .Groups }}
+    <div class="dex-fact">
+      <dt id="groups-label">Groups <span class="dex-count">{{ len .Groups }}</span></dt>
+      <dd>
+        <ul class="dex-groups" tabindex="0" aria-labelledby="groups-label">
+          {{ range .Groups }}<li>{{ . }}</li>{{ end }}
+        </ul>
+      </dd>
+    </div>
+    {{ end }}
     {{ if .UserAgent }}
     <div class="dex-fact">
       <dt>Browser</dt>
@@ -45,15 +55,6 @@
     </div>
     {{ end }}
   </dl>
-
-  {{ if .Groups }}
-  <div class="dex-groups-block">
-    <div class="dex-groups-block__label" id="groups-label">Groups <span class="dex-count">{{ len .Groups }}</span></div>
-    <ul class="dex-groups" tabindex="0" aria-labelledby="groups-label">
-      {{ range .Groups }}<li>{{ . }}</li>{{ end }}
-    </ul>
-  </div>
-  {{ end }}
 
   <div class="dex-home__actions">
     <a href="{{ .LogoutURL }}" class="dex-btn theme-btn--primary">Log out</a>

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -4,7 +4,13 @@
   {{ if .LoggedIn }}
   <div class="dex-identity">
     {{ if .Username }}<h2 class="dex-identity__name">{{ .Username }}</h2>{{ end }}
-    {{ if .Email }}<div class="dex-identity__email">{{ .Email }}</div>{{ end }}
+    {{ if .Email }}
+    <div class="dex-identity__email">
+      <span class="dex-mono">{{ .Email }}</span>
+      {{ if .EmailVerified }}<span class="dex-identity__state">· verified</span>
+      {{ else }}<span class="dex-identity__state dex-identity__state--warn">· not verified</span>{{ end }}
+    </div>
+    {{ end }}
   </div>
 
   <dl class="dex-facts">
@@ -12,12 +18,6 @@
     <div class="dex-fact">
       <dt>Signed in with</dt>
       <dd>{{ .ConnectorName }}</dd>
-    </div>
-    {{ end }}
-    {{ if .Email }}
-    <div class="dex-fact">
-      <dt>Email verified</dt>
-      <dd>{{ if .EmailVerified }}yes{{ else }}no{{ end }}</dd>
     </div>
     {{ end }}
     {{ if .LastLoginEpoch }}

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -3,32 +3,21 @@
 <div class="theme-panel dex-home">
   {{ if .LoggedIn }}
   <div class="dex-identity">
-    {{ with .Initial }}<div class="dex-identity__avatar" aria-hidden="true">{{ . }}</div>{{ end }}
-    <div class="dex-identity__text">
-      {{ if .Username }}<div class="dex-identity__name">{{ .Username }}</div>{{ end }}
-      {{ if .Email }}
-      <div class="dex-identity__email">
-        {{ .Email }}
-        {{ if .EmailVerified }}<span class="dex-badge" title="Email address verified by the connector">Verified</span>{{ end }}
-      </div>
-      {{ end }}
-    </div>
+    {{ if .Username }}<div class="dex-identity__name">{{ .Username }}</div>{{ end }}
+    {{ if .Email }}<div class="dex-identity__email">{{ .Email }}</div>{{ end }}
   </div>
-
-  {{ if .Groups }}
-  <div class="dex-field">
-    <div class="dex-field__label">Groups <span class="dex-field__count">{{ len .Groups }}</span></div>
-    <ul class="dex-chips" tabindex="0">
-      {{ range .Groups }}<li class="dex-chip">{{ . }}</li>{{ end }}
-    </ul>
-  </div>
-  {{ end }}
 
   <dl class="dex-facts">
     {{ if .ConnectorName }}
     <div class="dex-fact">
       <dt>Connector</dt>
       <dd>{{ .ConnectorName }}</dd>
+    </div>
+    {{ end }}
+    {{ if .Email }}
+    <div class="dex-fact">
+      <dt>Email verified</dt>
+      <dd>{{ if .EmailVerified }}yes{{ else }}no{{ end }}</dd>
     </div>
     {{ end }}
     {{ if .LastLoginEpoch }}
@@ -46,13 +35,22 @@
     {{ if .IPAddress }}
     <div class="dex-fact">
       <dt>IP address</dt>
-      <dd>{{ .IPAddress }}</dd>
+      <dd class="dex-mono">{{ .IPAddress }}</dd>
     </div>
     {{ end }}
   </dl>
 
+  {{ if .Groups }}
+  <div class="dex-field">
+    <div class="dex-field__label">Groups <span class="dex-field__count">{{ len .Groups }}</span></div>
+    <ul class="dex-groups dex-mono" tabindex="0">
+      {{ range .Groups }}<li>{{ . }}</li>{{ end }}
+    </ul>
+  </div>
+  {{ end }}
+
   {{ if .UserAgent }}
-  <div class="dex-field dex-field--wrap">
+  <div class="dex-field">
     <div class="dex-field__label">Browser</div>
     <div class="dex-useragent">{{ .UserAgent }}</div>
   </div>
@@ -80,9 +78,9 @@
   (function () {
     // A long group list is capped by CSS; fade its bottom edge so the cut is
     // visible on platforms whose scrollbars only appear while scrolling.
-    var groups = document.querySelector('.dex-chips');
+    var groups = document.querySelector('.dex-groups');
     if (groups && groups.scrollHeight > groups.clientHeight) {
-      groups.classList.add('dex-chips--clipped');
+      groups.classList.add('dex-groups--clipped');
     }
 
     // The server sends Unix seconds; render them in the visitor's own timezone.

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -23,13 +23,13 @@
     {{ if .LastLoginEpoch }}
     <div class="dex-fact">
       <dt>Last sign-in</dt>
-      <dd><time id="last-login" datetime="{{ .LastLoginEpoch }}">&mdash;</time></dd>
+      <dd><time datetime="{{ .LastLoginEpoch }}">{{ .LastLoginText }}</time></dd>
     </div>
     {{ end }}
     {{ if .SessionExpiresEpoch }}
     <div class="dex-fact">
       <dt>{{ if .SessionExpiryIsIdle }}Expires if idle{{ else }}Session ends{{ end }}</dt>
-      <dd><time id="session-expires" datetime="{{ .SessionExpiresEpoch }}">&mdash;</time></dd>
+      <dd><time datetime="{{ .SessionExpiresEpoch }}">{{ .SessionExpiresText }}</time></dd>
     </div>
     {{ end }}
     {{ if .IPAddress }}
@@ -48,8 +48,8 @@
 
   {{ if .Groups }}
   <div class="dex-groups-block">
-    <div class="dex-groups-block__label">Groups <span class="dex-fact__count">{{ len .Groups }}</span></div>
-    <ul class="dex-groups" tabindex="0">
+    <div class="dex-groups-block__label" id="groups-label">Groups <span class="dex-count">{{ len .Groups }}</span></div>
+    <ul class="dex-groups" tabindex="0" aria-labelledby="groups-label">
       {{ range .Groups }}<li>{{ . }}</li>{{ end }}
     </ul>
   </div>
@@ -60,7 +60,7 @@
   </div>
   {{ else }}
   <div class="dex-home__empty">
-    <div class="dex-home__empty-title">Not signed in</div>
+    <h2 class="dex-home__empty-title">Not signed in</h2>
     <p class="dex-home__empty-text">
       This is the dex identity provider. Sign in from the application you want to use.
     </p>
@@ -87,6 +87,9 @@
       };
       syncFade();
       groups.addEventListener('scroll', syncFade, {passive: true});
+      // A narrower window wraps long group names onto more lines, so whether
+      // the list overflows is not settled once at load.
+      window.addEventListener('resize', syncFade, {passive: true});
     }
 
     // The server sends Unix seconds; render them in the visitor's own timezone.

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -76,10 +76,17 @@
 <script>
   (function () {
     // A long group list is capped by CSS; fade its bottom edge so the cut is
-    // visible on platforms whose scrollbars only appear while scrolling.
+    // visible on platforms whose scrollbars only appear while scrolling. The
+    // fade tracks the scroll position — left up permanently it would dim the
+    // last group even once you had scrolled down to read it.
     var groups = document.querySelector('.dex-groups');
-    if (groups && groups.scrollHeight > groups.clientHeight) {
-      groups.classList.add('dex-groups--clipped');
+    if (groups) {
+      var syncFade = function () {
+        var more = groups.scrollTop + groups.clientHeight < groups.scrollHeight - 1;
+        groups.classList.toggle('dex-groups--clipped', more);
+      };
+      syncFade();
+      groups.addEventListener('scroll', syncFade, {passive: true});
     }
 
     // The server sends Unix seconds; render them in the visitor's own timezone.

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -17,8 +17,8 @@
 
   {{ if .Groups }}
   <div class="dex-field">
-    <div class="dex-field__label">Groups</div>
-    <ul class="dex-chips">
+    <div class="dex-field__label">Groups <span class="dex-field__count">{{ len .Groups }}</span></div>
+    <ul class="dex-chips" tabindex="0">
       {{ range .Groups }}<li class="dex-chip">{{ . }}</li>{{ end }}
     </ul>
   </div>
@@ -59,7 +59,7 @@
   {{ end }}
 
   <div class="dex-home__actions">
-    <a href="{{ .LogoutURL }}" class="dex-btn dex-btn--outline">Log out</a>
+    <a href="{{ .LogoutURL }}" class="dex-btn dex-btn--accent">Log out</a>
   </div>
   {{ else }}
   <div class="dex-home__empty">
@@ -78,6 +78,13 @@
 {{ if .LoggedIn }}
 <script>
   (function () {
+    // A long group list is capped by CSS; fade its bottom edge so the cut is
+    // visible on platforms whose scrollbars only appear while scrolling.
+    var groups = document.querySelector('.dex-chips');
+    if (groups && groups.scrollHeight > groups.clientHeight) {
+      groups.classList.add('dex-chips--clipped');
+    }
+
     // The server sends Unix seconds; render them in the visitor's own timezone.
     document.querySelectorAll('time[datetime]').forEach(function (el) {
       var epoch = parseInt(el.getAttribute('datetime'), 10);

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -59,7 +59,7 @@
   {{ end }}
 
   <div class="dex-home__actions">
-    <a href="{{ .LogoutURL }}" class="dex-btn dex-btn--accent">Log out</a>
+    <a href="{{ .LogoutURL }}" class="dex-btn theme-btn--primary">Log out</a>
   </div>
   {{ else }}
   <div class="dex-home__empty">

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -3,14 +3,14 @@
 <div class="theme-panel dex-home">
   {{ if .LoggedIn }}
   <div class="dex-identity">
-    {{ if .Username }}<div class="dex-identity__name">{{ .Username }}</div>{{ end }}
+    {{ if .Username }}<h2 class="dex-identity__name">{{ .Username }}</h2>{{ end }}
     {{ if .Email }}<div class="dex-identity__email">{{ .Email }}</div>{{ end }}
   </div>
 
   <dl class="dex-facts">
     {{ if .ConnectorName }}
     <div class="dex-fact">
-      <dt>Connector</dt>
+      <dt>Signed in with</dt>
       <dd>{{ .ConnectorName }}</dd>
     </div>
     {{ end }}
@@ -22,13 +22,13 @@
     {{ end }}
     {{ if .LastLoginEpoch }}
     <div class="dex-fact">
-      <dt>Signed in</dt>
+      <dt>Last sign-in</dt>
       <dd><time id="last-login" datetime="{{ .LastLoginEpoch }}">&mdash;</time></dd>
     </div>
     {{ end }}
     {{ if .SessionExpiresEpoch }}
     <div class="dex-fact">
-      <dt>Session ends</dt>
+      <dt>{{ if .SessionExpiryIsIdle }}Expires if idle{{ else }}Session ends{{ end }}</dt>
       <dd><time id="session-expires" datetime="{{ .SessionExpiresEpoch }}">&mdash;</time></dd>
     </div>
     {{ end }}
@@ -38,21 +38,20 @@
       <dd class="dex-mono">{{ .IPAddress }}</dd>
     </div>
     {{ end }}
+    {{ if .UserAgent }}
+    <div class="dex-fact">
+      <dt>Browser</dt>
+      <dd class="dex-fact__long">{{ .UserAgent }}</dd>
+    </div>
+    {{ end }}
   </dl>
 
   {{ if .Groups }}
-  <div class="dex-field">
-    <div class="dex-field__label">Groups <span class="dex-field__count">{{ len .Groups }}</span></div>
+  <div class="dex-groups-block">
+    <div class="dex-groups-block__label">Groups <span class="dex-fact__count">{{ len .Groups }}</span></div>
     <ul class="dex-groups dex-mono" tabindex="0">
       {{ range .Groups }}<li>{{ . }}</li>{{ end }}
     </ul>
-  </div>
-  {{ end }}
-
-  {{ if .UserAgent }}
-  <div class="dex-field">
-    <div class="dex-field__label">Browser</div>
-    <div class="dex-useragent">{{ .UserAgent }}</div>
   </div>
   {{ end }}
 
@@ -88,7 +87,7 @@
       var epoch = parseInt(el.getAttribute('datetime'), 10);
       if (!epoch) return;
       var date = new Date(epoch * 1000);
-      el.textContent = date.toLocaleString();
+      el.textContent = date.toLocaleString([], {dateStyle: 'medium', timeStyle: 'short'});
       el.setAttribute('datetime', date.toISOString());
     });
   })();

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -20,16 +20,16 @@
       <dd>{{ .ConnectorName }}</dd>
     </div>
     {{ end }}
-    {{ if .SignedInEpoch }}
+    {{ if .SignedInISO }}
     <div class="dex-fact">
       <dt>Signed in</dt>
-      <dd><time datetime="{{ .SignedInEpoch }}">{{ .SignedInText }}</time></dd>
+      <dd><time datetime="{{ .SignedInISO }}">{{ .SignedInText }}</time></dd>
     </div>
     {{ end }}
-    {{ if .SessionExpiresEpoch }}
+    {{ if .SessionExpiresISO }}
     <div class="dex-fact">
       <dt>{{ if .SessionExpiryIsIdle }}Expires if idle{{ else }}Session ends{{ end }}</dt>
-      <dd><time datetime="{{ .SessionExpiresEpoch }}">{{ .SessionExpiresText }}</time></dd>
+      <dd><time datetime="{{ .SessionExpiresISO }}">{{ .SessionExpiresText }}</time></dd>
     </div>
     {{ end }}
     {{ if .IPAddress }}
@@ -93,13 +93,11 @@
       window.addEventListener('resize', syncFade, {passive: true});
     }
 
-    // The server sends Unix seconds; render them in the visitor's own timezone.
+    // The server states these in UTC; restate them in the visitor's own zone.
     document.querySelectorAll('time[datetime]').forEach(function (el) {
-      var epoch = parseInt(el.getAttribute('datetime'), 10);
-      if (!epoch) return;
-      var date = new Date(epoch * 1000);
+      var date = new Date(el.getAttribute('datetime'));
+      if (isNaN(date.getTime())) return;
       el.textContent = date.toLocaleString([], {dateStyle: 'medium', timeStyle: 'short'});
-      el.setAttribute('datetime', date.toISOString());
     });
   })();
 </script>

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -1,96 +1,91 @@
-{{ define "info-value" }}
-  {{ if gt (len .) 24 }}
-  <details class="dex-info-details">
-    <summary>{{ . }}</summary>
-    <div>{{ . }}</div>
-  </details>
-  {{ else }}
-  <span class="dex-info-value">{{ . }}</span>
-  {{ end }}
-{{ end }}
-
 {{ template "header.html" . }}
 
-<div class="theme-panel">
-  <div style="text-align: center; margin-bottom: 16px;">
-    <img src="{{ url .ReqPath logo }}" alt="{{ issuer }}" style="max-height: 36px;">
+<div class="theme-panel dex-home">
+  {{ if .LoggedIn }}
+  <div class="dex-identity">
+    {{ with .Initial }}<div class="dex-identity__avatar" aria-hidden="true">{{ . }}</div>{{ end }}
+    <div class="dex-identity__text">
+      {{ if .Username }}<div class="dex-identity__name">{{ .Username }}</div>{{ end }}
+      {{ if .Email }}
+      <div class="dex-identity__email">
+        {{ .Email }}
+        {{ if .EmailVerified }}<span class="dex-badge" title="Email address verified by the connector">Verified</span>{{ end }}
+      </div>
+      {{ end }}
+    </div>
   </div>
 
-  {{ if .LoggedIn }}
-  <hr class="dex-separator">
-  <div class="dex-info-table">
-    {{ if .Username }}
-    <div class="dex-info-row">
-      <span class="dex-info-label">Username</span>
-      {{ template "info-value" .Username }}
-    </div>
-    {{ end }}
-    {{ if .Email }}
-    <div class="dex-info-row">
-      <span class="dex-info-label">Email</span>
-      <span class="dex-info-value">{{ .Email }}{{ if .EmailVerified }} &#10003;{{ end }}</span>
-    </div>
-    {{ end }}
-    {{ if .Groups }}
-    <div class="dex-info-row">
-      <span class="dex-info-label">Groups</span>
-      <details class="dex-info-details">
-        <summary>{{ len .Groups }} group{{ if gt (len .Groups) 1 }}s{{ end }}</summary>
-        <ul class="dex-info-details__list">
-          {{ range .Groups }}<li>{{ . }}</li>{{ end }}
-        </ul>
-      </details>
-    </div>
-    {{ end }}
+  {{ if .Groups }}
+  <div class="dex-field">
+    <div class="dex-field__label">Groups</div>
+    <ul class="dex-chips">
+      {{ range .Groups }}<li class="dex-chip">{{ . }}</li>{{ end }}
+    </ul>
+  </div>
+  {{ end }}
+
+  <dl class="dex-facts">
     {{ if .ConnectorName }}
-    <div class="dex-info-row">
-      <span class="dex-info-label">Connector</span>
-      {{ template "info-value" .ConnectorName }}
-    </div>
-    {{ end }}
-    {{ if .IPAddress }}
-    <div class="dex-info-row">
-      <span class="dex-info-label">IP address</span>
-      {{ template "info-value" .IPAddress }}
-    </div>
-    {{ end }}
-    {{ if .UserAgent }}
-    <div class="dex-info-row">
-      <span class="dex-info-label">Browser</span>
-      {{ template "info-value" .UserAgent }}
+    <div class="dex-fact">
+      <dt>Connector</dt>
+      <dd>{{ .ConnectorName }}</dd>
     </div>
     {{ end }}
     {{ if .LastLoginEpoch }}
-    <div class="dex-info-row">
-      <span class="dex-info-label">Last login</span>
-      <span class="dex-info-value" id="last-login"></span>
+    <div class="dex-fact">
+      <dt>Signed in</dt>
+      <dd><time id="last-login" datetime="{{ .LastLoginEpoch }}">&mdash;</time></dd>
     </div>
     {{ end }}
-  </div>
-  <hr class="dex-separator">
+    {{ if .SessionExpiresEpoch }}
+    <div class="dex-fact">
+      <dt>Session ends</dt>
+      <dd><time id="session-expires" datetime="{{ .SessionExpiresEpoch }}">&mdash;</time></dd>
+    </div>
+    {{ end }}
+    {{ if .IPAddress }}
+    <div class="dex-fact">
+      <dt>IP address</dt>
+      <dd>{{ .IPAddress }}</dd>
+    </div>
+    {{ end }}
+  </dl>
 
-  <div class="theme-form-row">
-    <a href="{{ .LogoutURL }}" class="dex-btn theme-btn--primary" style="display: inline-block; text-decoration: none; padding: 8px 16px;">Logout</a>
-  </div>
-  {{ else }}
-  <div>
-    <div class="dex-subtle-text">Not logged in</div>
+  {{ if .UserAgent }}
+  <div class="dex-field dex-field--wrap">
+    <div class="dex-field__label">Browser</div>
+    <div class="dex-useragent">{{ .UserAgent }}</div>
   </div>
   {{ end }}
 
-  <div class="theme-form-row">
-    <a href="{{ .DiscoveryURL }}" class="dex-subtle-text">Discovery</a>
+  <div class="dex-home__actions">
+    <a href="{{ .LogoutURL }}" class="dex-btn dex-btn--outline">Log out</a>
+  </div>
+  {{ else }}
+  <div class="dex-home__empty">
+    <div class="dex-home__empty-title">Not signed in</div>
+    <p class="dex-home__empty-text">
+      This is the dex identity provider. Sign in from the application you want to use.
+    </p>
+  </div>
+  {{ end }}
+
+  <div class="dex-home__footer">
+    <a href="{{ .DiscoveryURL }}" class="dex-home__link">OpenID configuration</a>
   </div>
 </div>
 
-{{ if .LastLoginEpoch }}
+{{ if .LoggedIn }}
 <script>
-  (function() {
-    var epoch = {{ .LastLoginEpoch }};
-    var el = document.getElementById('last-login');
-    if (el && epoch) {
-      el.textContent = new Date(epoch * 1000).toLocaleString();
-    }
+  (function () {
+    // The server sends Unix seconds; render them in the visitor's own timezone.
+    document.querySelectorAll('time[datetime]').forEach(function (el) {
+      var epoch = parseInt(el.getAttribute('datetime'), 10);
+      if (!epoch) return;
+      var date = new Date(epoch * 1000);
+      el.textContent = date.toLocaleString();
+      el.setAttribute('datetime', date.toISOString());
+    });
   })();
 </script>
 {{ end }}

--- a/web/themes/dark/styles.css
+++ b/web/themes/dark/styles.css
@@ -145,5 +145,4 @@
   --dex-border: #2a2d35;
   --dex-surface-subtle: #22252c;
   --dex-accent: #5a9bb5;
-  --dex-accent-fg: #12141a;
 }

--- a/web/themes/dark/styles.css
+++ b/web/themes/dark/styles.css
@@ -143,6 +143,5 @@
   --dex-fg: #dcdfe5;
   --dex-fg-muted: #8b909b;
   --dex-border: #2a2d35;
-  --dex-surface-subtle: #22252c;
   --dex-accent: #5a9bb5;
 }

--- a/web/themes/dark/styles.css
+++ b/web/themes/dark/styles.css
@@ -135,3 +135,14 @@
 .dex-container {
   color: #b8bcc4;
 }
+
+/* Palette the shared stylesheet reads for the home page. Without these the
+ * page would fall back to the light values and render dark text on the dark
+ * panel. */
+.theme-body {
+  --dex-fg: #dcdfe5;
+  --dex-fg-muted: #8b909b;
+  --dex-border: #2a2d35;
+  --dex-surface-subtle: #22252c;
+  --dex-accent: #5a9bb5;
+}

--- a/web/themes/dark/styles.css
+++ b/web/themes/dark/styles.css
@@ -145,4 +145,5 @@
   --dex-border: #2a2d35;
   --dex-surface-subtle: #22252c;
   --dex-accent: #5a9bb5;
+  --dex-accent-fg: #12141a;
 }

--- a/web/themes/light/styles.css
+++ b/web/themes/light/styles.css
@@ -127,3 +127,12 @@
   width: 260px;
   margin: 4px auto;
 }
+
+/* Palette the shared stylesheet reads for the home page. */
+.theme-body {
+  --dex-fg: #1a1a1a;
+  --dex-fg-muted: #6b7280;
+  --dex-border: #e8eaed;
+  --dex-surface-subtle: #f4f5f7;
+  --dex-accent: #4a90d9;
+}

--- a/web/themes/light/styles.css
+++ b/web/themes/light/styles.css
@@ -135,5 +135,4 @@
   --dex-border: #e8eaed;
   --dex-surface-subtle: #f4f5f7;
   --dex-accent: #2f6fb0;
-  --dex-accent-fg: #ffffff;
 }

--- a/web/themes/light/styles.css
+++ b/web/themes/light/styles.css
@@ -134,5 +134,6 @@
   --dex-fg-muted: #6b7280;
   --dex-border: #e8eaed;
   --dex-surface-subtle: #f4f5f7;
-  --dex-accent: #4a90d9;
+  --dex-accent: #2f6fb0;
+  --dex-accent-fg: #ffffff;
 }

--- a/web/themes/light/styles.css
+++ b/web/themes/light/styles.css
@@ -133,6 +133,5 @@
   --dex-fg: #1a1a1a;
   --dex-fg-muted: #6b7280;
   --dex-border: #e8eaed;
-  --dex-surface-subtle: #f4f5f7;
   --dex-accent: #2f6fb0;
 }


### PR DESCRIPTION
#### Overview

The home page rendered a signed-in account as a seven-row label/value table
under a logo the navbar already shows. This rebuilds it around the identity,
fixes two things it reported wrongly, and makes it legible on the dark theme.

#### What this PR does / why we need it

**Layout.** Everything on the page carried the same weight: the user's name sat
between their IP address and a truncated User-Agent. The page now reads as what
it is — the claims dex issued for this session. The identity leads with the name
and the email below it, and everything after it is a labelled claim on a single
label column. Machine strings (email, groups, IP) are set in monospace so they
read as values rather than prose. Groups are listed outright instead of hidden
behind a `<details>` disclosure, in a full-width block because a group is often
a whole DN. The discovery document gets a real link instead of grey fine print,
logging out uses `theme-btn--primary` like every other button in the product,
and the logo no longer repeats inside the panel.

On narrow viewports the label/value rows stack, so a long value never has to
share a line with its label. Values that used to be truncated to 200px with a
disclosure widget — the User-Agent in particular — now simply wrap.

Group lists are capped and scroll, with the total in the label and a faded
bottom edge when there is more below. A directory account can easily carry fifty
groups, and an uncapped list pushed the session facts and the logout button off
the screen.

Nothing on the page is decorative: no avatar (dex has no picture to put in one)
and no badges, and colour is left to the theme.

**Two parameters were wrong or missing:**

- The client IP was recorded with the ephemeral source port: a deployment with
  no trusted proxies stored `127.0.0.1:64181` as the address the session was
  created from. Only the header-based resolver stripped the port; the
  `RemoteAddr` fallback did not.
- The page never showed when the session ends, which is the one question it was
  in a position to answer. The data was already on the session — it now reports
  the earlier of the absolute lifetime and the idle timeout, and says which of
  the two it is. The idle deadline slides forward on every use, so labelling it
  "session ends" would name a time the user is likely to still be signed in
  past.

**The dark theme never styled this page.** Values were `#333` on a `#1a1d23`
panel and the row rules were `#eee`, so the separators were considerably more
legible than the content they separated. The palette now comes from five custom
properties that each theme sets. The shared stylesheet declares the light values
as fallbacks, so a custom theme that defines none of them renders exactly as it
does today.

`main.css` loses the 79 lines of `.dex-info-*` rules, which nothing else used.

#### Special notes for your reviewer

Verified in a browser against a running dex — signed in and signed out, light
and dark, desktop and 390px — rather than from the template alone. That is how
the dark-theme contrast and the IP port turned up.

No new assets or fonts: dex is deployed air-gapped often enough that the page
should not start depending on a CDN, so this stays within the existing font
stack and ships no images.
