### PR TITLE
feat(oidc): add allowRedirectMismatch option to skip callback URL check

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -47,6 +47,13 @@ type Config struct {
 	ClientSecret string `json:"clientSecret"`
 	RedirectURI  string `json:"redirectURI"`
 
+	// AllowRedirectMismatch skips the check that requires the OIDC callback URL
+	// received at runtime to match RedirectURI in the configuration. This is
+	// useful when a reverse proxy terminates TLS and forwards the request, so
+	// the callback URL seen by dex differs from the one configured with the
+	// upstream identity provider.
+	AllowRedirectMismatch bool `json:"allowRedirectMismatch"`
+
 	// The section to override options discovered automatically from
 	// the providers' discovery URL (.well-known/openid-configuration).
 	ProviderDiscoveryOverrides ProviderDiscoveryOverrides `json:"providerDiscoveryOverrides"`
@@ -374,8 +381,9 @@ func (c *Config) Open(id string, logger *slog.Logger) (conn connector.Connector,
 
 	clientID := c.ClientID
 	return &oidcConnector{
-		provider:    provider,
-		redirectURI: c.RedirectURI,
+		provider:              provider,
+		redirectURI:           c.RedirectURI,
+		allowRedirectMismatch: c.AllowRedirectMismatch,
 		oauth2Config: &oauth2.Config{
 			ClientID:     clientID,
 			ClientSecret: c.ClientSecret,
@@ -421,6 +429,7 @@ var (
 type oidcConnector struct {
 	provider                  *oidc.Provider
 	redirectURI               string
+	allowRedirectMismatch     bool
 	oauth2Config              *oauth2.Config
 	verifier                  *oidc.IDTokenVerifier
 	cancel                    context.CancelFunc
@@ -452,8 +461,8 @@ func (c *oidcConnector) Close() error {
 }
 
 func (c *oidcConnector) LoginURL(s connector.Scopes, callbackURL, state string) (string, []byte, error) {
-	if c.redirectURI != callbackURL {
-		return "", nil, fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
+	if !c.allowRedirectMismatch && c.redirectURI != callbackURL {
+		return "", nil, fmt.Errorf("allowRedirectMismatch is false and expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}
 
 	var opts []oauth2.AuthCodeOption

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -871,6 +871,51 @@ func TestProviderOverride(t *testing.T) {
 	})
 }
 
+func TestAllowRedirectMismatch(t *testing.T) {
+
+	testServer, err := setupServer(map[string]any{
+		"sub":  "subvalue",
+		"name": "namevalue",
+	}, true)
+	if err != nil {
+		t.Fatal("failed to setup test server", err)
+	}
+	redirectURI := "https://auth.example.com/callback"
+	scopes := []string{"openid", "groups", "offline_access"}
+	connectorScopes := connector.Scopes{OfflineAccess: true, Groups: true}
+	state := "foo"
+
+	t.Run("No allowRedirectMismatch", func(t *testing.T) {
+		conn, err := newConnector(Config{
+			Issuer:      testServer.URL,
+			Scopes:      scopes,
+			RedirectURI: redirectURI,
+		})
+		if err != nil {
+			t.Fatal("failed to create new connector", err)
+		}
+
+		_, _, err = conn.LoginURL(connectorScopes, testServer.URL+"/callback", state)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "did not match the URL in the config")
+	})
+	t.Run("allowRedirectMismatch", func(t *testing.T) {
+		conn, err := newConnector(Config{
+			Issuer:                testServer.URL,
+			Scopes:                scopes,
+			RedirectURI:           redirectURI,
+			AllowRedirectMismatch: true,
+		})
+		if err != nil {
+			t.Fatal("failed to create new connector", err)
+		}
+
+		_, _, err = conn.LoginURL(connectorScopes, testServer.URL+"/callback", state)
+		require.NoError(t, err)
+	})
+
+}
+
 func setupServer(tok map[string]interface{}, idTokenDesired bool) (*httptest.Server, error) {
 	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->

Introduce a new AllowRedirectMismatch boolean on the OIDC connector Config.
When enabled, the connector skips the strict equality check between the
runtime callback URL and the RedirectURI configured for the connector.

#### What this PR does / why we need it

This is useful when dex sits behind a reverse proxy that terminates TLS
and rewrites the request: the callback URL observed by dex differs from
the RedirectURI registered with the upstream identity provider, so the
existing check rejects otherwise-legitimate flows.

The check is preserved by default; users opt in explicitly per connector
by setting allowRedirectMismatch: true in the connector config.

#### Special notes for your reviewer
