### PR TITLE
fix(web): keep the connector buttons intact when a connector name is long

### DIFF
--- a/server/templates/templates.go
+++ b/server/templates/templates.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"cmp"
 	"fmt"
 	"html/template"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"slices"
 	"sort"
 	"strings"
 
@@ -279,11 +281,15 @@ type ConnectorInfo struct {
 	Type string
 }
 
-type byName []ConnectorInfo
-
-func (n byName) Len() int           { return len(n) }
-func (n byName) Less(i, j int) bool { return n[i].Name < n[j].Name }
-func (n byName) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+// sortConnectors orders the login screen the way a reader scans it, which is
+// not the way bytes compare: "okta" sorting after "Zendesk" is an artifact of
+// capital letters coming first in ASCII, and connector names are whatever the
+// operator typed. Names that differ only in case keep a stable order.
+func sortConnectors(connectors []ConnectorInfo) {
+	slices.SortStableFunc(connectors, func(a, b ConnectorInfo) int {
+		return cmp.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
+	})
+}
 
 func (t *Templates) Device(r *http.Request, w http.ResponseWriter, postURL string, userCode string, lastWasInvalid bool) error {
 	if lastWasInvalid {
@@ -307,7 +313,7 @@ func (t *Templates) DeviceSuccess(r *http.Request, w http.ResponseWriter, client
 }
 
 func (t *Templates) Login(r *http.Request, w http.ResponseWriter, connectors []ConnectorInfo) error {
-	sort.Sort(byName(connectors))
+	sortConnectors(connectors)
 	data := struct {
 		Connectors []ConnectorInfo
 		ReqPath    string

--- a/server/templates/templates_test.go
+++ b/server/templates/templates_test.go
@@ -70,3 +70,37 @@ func TestRelativeURL(t *testing.T) {
 		})
 	}
 }
+
+func TestSortConnectors(t *testing.T) {
+	connectors := []ConnectorInfo{
+		{ID: "keycloak", Name: "keycloak"},
+		{ID: "okta", Name: "Okta"},
+		{ID: "azure", Name: "azure ad"},
+		{ID: "google", Name: "Google"},
+	}
+
+	sortConnectors(connectors)
+
+	// Byte order would have put both lowercase names below both capitalised
+	// ones, which is a property of ASCII rather than of anything the operator
+	// meant by naming a connector.
+	expected := []string{"azure ad", "Google", "keycloak", "Okta"}
+	for i, name := range expected {
+		if connectors[i].Name != name {
+			t.Fatalf("position %d: got %q, expected %q", i, connectors[i].Name, name)
+		}
+	}
+}
+
+func TestSortConnectorsKeepsCaseVariantsStable(t *testing.T) {
+	connectors := []ConnectorInfo{
+		{ID: "second", Name: "SSO"},
+		{ID: "first", Name: "sso"},
+	}
+
+	sortConnectors(connectors)
+
+	if connectors[0].ID != "second" || connectors[1].ID != "first" {
+		t.Fatalf("names differing only in case were reordered: %q, %q", connectors[0].ID, connectors[1].ID)
+	}
+}

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -57,14 +57,17 @@ body {
   max-width: 100%;
 }
 
+/* The icon keeps its own size instead of stretching down the side of a button
+ * a long name has made two or three lines tall. */
 .dex-btn-icon {
+  align-self: center;
   background-position: center;
   background-repeat: no-repeat;
-  background-size: 20px;
-  border-radius: 8px 0 0 8px;
-  flex: 0 0 40px;
-  margin-right: 4px;
-  min-height: 40px;
+  background-size: 18px;
+  border-radius: 6px;
+  flex: 0 0 36px;
+  height: 36px;
+  margin: 0 4px 0 3px;
 }
 
 .dex-btn-icon--google {
@@ -151,7 +154,7 @@ body {
   line-height: 1.35;
   min-height: 40px;
   overflow-wrap: anywhere;
-  padding: 6px 14px;
+  padding: 6px 12px;
   text-align: center;
 }
 

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -38,15 +38,33 @@ body {
   opacity: 0.5;
 }
 
+/* A connector button is an icon and a label. The label used to sit next to a
+ * floated icon on a single 40px line, which held together only while the name
+ * was short: a longer one stretched its button past the others, and once it
+ * wrapped, the second line cleared the float while the icon stayed a 40px
+ * square at the top of a taller button.
+ *
+ * The button is a row instead, at a width that does not depend on the name, so
+ * a label that does not fit wraps inside it and the icon spans the full height
+ * however many lines that turns out to be. */
+.dex-btn-provider {
+  align-items: stretch;
+  /* inline-flex, not flex: the button sits inside the connector's link, and an
+   * atomic inline-level box is where the link's underline stops. A block-level
+   * flex container would take that underline across the label, and no rule on
+   * the label can turn off a decoration its ancestor is drawing. */
+  display: inline-flex;
+  max-width: 100%;
+}
+
 .dex-btn-icon {
   background-position: center;
   background-repeat: no-repeat;
   background-size: 20px;
   border-radius: 8px 0 0 8px;
-  float: left;
-  height: 40px;
+  flex: 0 0 40px;
   margin-right: 4px;
-  width: 40px;
+  min-height: 40px;
 }
 
 .dex-btn-icon--google {
@@ -122,9 +140,17 @@ body {
   background-image: url(../static/img/mock-icon.svg);
 }
 
+/* Also the label of the approval buttons, which have no icon: the min-height
+ * keeps those the size they were when a 40px line box set it. */
 .dex-btn-text {
+  align-items: center;
+  display: flex;
+  flex: 1;
   font-weight: 600;
-  line-height: 40px;
+  justify-content: center;
+  line-height: 1.35;
+  min-height: 40px;
+  overflow-wrap: anywhere;
   padding: 6px 14px;
   text-align: center;
 }

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -19,6 +19,10 @@ body {
   border-radius: 8px;
   border: 0;
   cursor: pointer;
+  /* Buttons do not inherit the page's typeface on their own, so without this
+   * every button label on every screen came out in the browser's default —
+   * Arial next to the system font the rest of the page is set in. */
+  font-family: inherit;
   font-size: 15px;
   padding: 0;
   transition: background-color 0.15s ease, box-shadow 0.15s ease, transform 0.1s ease;
@@ -55,12 +59,19 @@ body {
    * the label can turn off a decoration its ancestor is drawing. */
   display: inline-flex;
   max-width: 100%;
+  /* It is a link: it navigates to the connector, and it is the only thing on
+   * the row that should take focus. */
+  text-decoration: none;
 }
 
 /* The icon keeps its own size instead of stretching down the side of a button
  * a long name has made two or three lines tall. */
 .dex-btn-icon {
   align-self: center;
+  /* Not every connector type has a rule below — oauth, authproxy and openshift
+   * are shipped without one. They used to render as a transparent hole with the
+   * label pushed off to the side of it; a plain tile is at least a tile. */
+  background-color: #84B6EF;
   background-position: center;
   background-repeat: no-repeat;
   background-size: 18px;

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -5,11 +5,9 @@
   <div>
     {{ range $c := .Connectors }}
       <div class="theme-form-row">
-        <a href="{{ $c.URL }}" target="_self">
-          <button class="dex-btn dex-btn-provider theme-btn-provider">
-            <span class="dex-btn-icon dex-btn-icon--{{ $c.Type }}"></span>
-            <span class="dex-btn-text">Log in with {{ $c.Name }}</span>
-          </button>
+        <a href="{{ $c.URL }}" class="dex-btn dex-btn-provider theme-btn-provider">
+          <span class="dex-btn-icon dex-btn-icon--{{ $c.Type }}"></span>
+          <span class="dex-btn-text">Log in with {{ $c.Name }}</span>
         </a>
       </div>
     {{ end }}

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -6,7 +6,7 @@
     {{ range $c := .Connectors }}
       <div class="theme-form-row">
         <a href="{{ $c.URL }}" target="_self">
-          <button class="dex-btn theme-btn-provider">
+          <button class="dex-btn dex-btn-provider theme-btn-provider">
             <span class="dex-btn-icon dex-btn-icon--{{ $c.Type }}"></span>
             <span class="dex-btn-text">Log in with {{ $c.Name }}</span>
           </button>

--- a/web/themes/dark/styles.css
+++ b/web/themes/dark/styles.css
@@ -44,11 +44,15 @@
   padding: 32px;
 }
 
+/* A width rather than a minimum: the button has to be the same size whatever
+ * the connector is called, and it has to give way on a screen too narrow to
+ * hold it rather than push out of the panel. */
 .theme-btn-provider {
   background-color: #22252c;
   border: 1px solid #33363e;
   color: #b8bcc4;
-  min-width: 260px;
+  max-width: 100%;
+  width: 260px;
 }
 
 .theme-btn-provider:hover {

--- a/web/themes/light/styles.css
+++ b/web/themes/light/styles.css
@@ -43,11 +43,15 @@
   padding: 32px;
 }
 
+/* A width rather than a minimum: the button has to be the same size whatever
+ * the connector is called, and it has to give way on a screen too narrow to
+ * hold it rather than push out of the panel. */
 .theme-btn-provider {
   background-color: #fff;
   border: 1px solid #d0d5dd;
   color: #1a1a1a;
-  min-width: 260px;
+  max-width: 100%;
+  width: 260px;
 }
 
 .theme-btn-provider:hover {


### PR DESCRIPTION
#### Overview

The connector buttons on the login screen only held their shape while the
connector name was short. This makes them survive whatever an operator called
their IdP.

#### What this PR does / why we need it

A connector name is free text from the config, and something like
`Example Corporation Single Sign-On (Production, EU region)` is an ordinary
thing to call one. Today that breaks the screen in three ways at once:

- The button has a minimum width and no maximum, so a long name stretches its
  button past its neighbours and the column comes out ragged.
- The label is a single 40px line beside a floated icon. When it wraps, the
  second line clears the float and sits centred under a first line that started
  44px in, while the icon stays a 40px square at the top of a now-80px button,
  leaving a blank corner under it.
- A name with no spaces — `keycloak-production-eu-central-1-authentication-service`,
  which is what these usually look like — does not wrap at all and pushes the
  button out of the panel.

The button is a flex row now. The icon is a fixed-width item that spans the full
height however many lines the label takes, and the label wraps and stays centred
within its own column. The built-in themes give the button a width rather than a
minimum, so every button matches regardless of the names, and the width gives way
on a screen too narrow to hold it: at 320px the buttons used to hang out of the
panel whatever the connector was called.

#### Special notes for your reviewer

`inline-flex` rather than `flex` is deliberate. The button sits inside the
connector's link, and an atomic inline-level box is where the link's underline
stops — a block-level flex container takes that underline across the label, and
no rule on the label can turn off a decoration its ancestor is drawing.

Themes are the only place a width is set, which is where the sizing already
lived. A custom theme that still sets `min-width` keeps working and picks up the
wrapping and the icon fix; it just does not get the uniform width.

`.dex-btn-text` is shared with the approval screen's buttons, which have no
icon. Its `min-height` keeps those exactly the size the 40px line box gave them;
checked against that screen in both themes.

Verified in a browser against a running dex configured with short, long, and
unbreakable connector names — light and dark, desktop and 320px.
