### PR TITLE
fix(examples): reject backslash redirect targets in the admin pages

### DIFF
--- a/examples/example-app/server/admindetail.go
+++ b/examples/example-app/server/admindetail.go
@@ -229,15 +229,33 @@ func (s *Server) handleAdminDeleteWebAuthn(w http.ResponseWriter, r *http.Reques
 	}
 }
 
+// localPath reports whether a redirect target stays inside this app.
+//
+// A leading slash is not enough: a browser reads "//host" as another host, and
+// so does it read "/\host", because it turns backslashes into slashes before
+// resolving. Normalising first and then insisting the parsed URL carries
+// neither scheme nor host covers both spellings.
+func localPath(target string) bool {
+	if !strings.HasPrefix(target, "/") {
+		return false
+	}
+
+	u, err := url.Parse(strings.ReplaceAll(target, `\`, "/"))
+	if err != nil {
+		return false
+	}
+
+	return u.Scheme == "" && u.Host == "" && strings.HasPrefix(u.Path, "/") && !strings.HasPrefix(u.Path, "//")
+}
+
 // detailRedirect returns to the detail page an action was started from.
 //
 // The target comes from the form, so it is only honoured when it points back
-// into this app: a path, and not a protocol-relative one, which a browser reads
-// as another host. Anything else would make these endpoints a way to bounce
+// into this app. Anything else would make these endpoints a way to bounce
 // someone off to a site of the sender's choosing.
 func (s *Server) detailRedirect(w http.ResponseWriter, r *http.Request, notice, errMsg string) {
 	back := r.FormValue("back")
-	if !strings.HasPrefix(back, "/") || strings.HasPrefix(back, "//") {
+	if !localPath(back) {
 		back = "/admin"
 	}
 

--- a/examples/example-app/server/admindetail_test.go
+++ b/examples/example-app/server/admindetail_test.go
@@ -16,13 +16,16 @@ func TestDetailRedirectStaysLocal(t *testing.T) {
 		back string
 		want string
 	}{
-		{"/admin/client/example-app", "/admin/client/example-app"},
+		{"/admin/client/example-app", "/admin/client/example-app?notice=done"},
 		{"/admin?section=clients", "/admin?section=clients&notice=done"},
-		{"", "/admin"},
-		{"https://example.com/phish", "/admin"},
-		{"//example.com/phish", "/admin"},
-		{"http://127.0.0.1:5599/", "/admin"},
-		{"javascript:alert(1)", "/admin"},
+		{"", "/admin?notice=done"},
+		{"https://example.com/phish", "/admin?notice=done"},
+		{"//example.com/phish", "/admin?notice=done"},
+		// A browser turns the backslash into a slash, so these read as a host too.
+		{`/\example.com/phish`, "/admin?notice=done"},
+		{`/\/example.com/phish`, "/admin?notice=done"},
+		{"http://127.0.0.1:5599/", "/admin?notice=done"},
+		{"javascript:alert(1)", "/admin?notice=done"},
 	}
 
 	s := &Server{}
@@ -34,14 +37,8 @@ func TestDetailRedirectStaysLocal(t *testing.T) {
 
 		s.detailRedirect(w, r, "done", "")
 
-		got := w.Header().Get("Location")
-		if !strings.HasPrefix(got, "/") || strings.HasPrefix(got, "//") {
-			t.Fatalf("back=%q redirected off the app: %q", tc.back, got)
-		}
-		if tc.back == "" || !strings.HasPrefix(tc.back, "/") || strings.HasPrefix(tc.back, "//") {
-			if !strings.HasPrefix(got, "/admin") {
-				t.Errorf("back=%q: got %q, expected the admin page", tc.back, got)
-			}
+		if got := w.Header().Get("Location"); got != tc.want {
+			t.Errorf("back=%q: redirected to %q, want %q", tc.back, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
#### Overview

Fixes the open redirect CodeQL found in the example app's admin pages
(`go/bad-redirect-check` #891, `go/unvalidated-url-redirection` #892).

#### What this PR does / why we need it

The admin actions return to the page they were started from, and the target
comes from a form field. The check rejected a target starting with `//`, but not
one starting with `/\`. Browsers turn a backslash into a slash before resolving
a URL, so `/\evil.com` reads as an absolute URL on another host, and any admin
action could be used to bounce a browser there.

The target is now parsed with backslashes normalised, and it is only honoured
when the result carries neither a scheme nor a host. The existing test grew the
two backslash spellings and now compares the whole redirect target rather than
just its prefix.

#### Special notes for your reviewer

Example app only — the same pattern is not used in the server.
