### PR TITLE
fix(server): give refresh token reuse a default grace window

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -91,7 +91,7 @@ web:
 #   idTokens: "24h"
 #   refreshTokens:
 #     disableRotation: false
-#     reuseInterval: "3s"
+#     reuseInterval: "3s" # default, "0s" disables the reuse grace window
 #     validIfNotUsedFor: "2160h" # 90 days
 #     absoluteLifetime: "3960h" # 165 days
 #

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -93,7 +93,7 @@ grpc:
 #   signingKeys: "6h" # deprecated, use signer.config.keysRotationPeriod
 #   idTokens: "24h"
 #   refreshTokens:
-#     reuseInterval: "3s"
+#     reuseInterval: "3s" # default, "0s" disables the reuse grace window
 #     validIfNotUsedFor: "2160h" # 90 days
 #     absoluteLifetime: "3960h" # 165 days
 

--- a/server/tokens/refresh_strategy.go
+++ b/server/tokens/refresh_strategy.go
@@ -33,11 +33,26 @@ func NewRefreshStrategy(rotate bool, absoluteLifetime, validIfNotUsedFor, reuseI
 	}
 }
 
+// defaultReuseInterval is the reuse window applied when the configuration leaves
+// reuseInterval unset.
+//
+// Rotation is on by default, and with no window at all a refresh token is claimable
+// exactly once: a client that never saw the response to its refresh — a timeout, a
+// dropped connection, a second replica refreshing the same stored token — retries,
+// is told invalid_grant, and has to send its user back through login. Within the
+// window Rotate hands the retry the same token the first call minted, which makes
+// the request idempotent. Three seconds is what the sample configuration has always
+// suggested: long enough for concurrent requests to converge, short enough that a
+// stolen token is not a durable credential. Set "0s" to keep the old behavior.
+const defaultReuseInterval = 3 * time.Second
+
 // NewRefreshTokenPolicy parses the refresh-token configuration into a rotation
 // strategy — the config-reading adapter over NewRefreshStrategy.
 func NewRefreshTokenPolicy(logger *slog.Logger, rotation bool, validIfNotUsedFor, absoluteLifetime, reuseInterval string) (*RefreshStrategy, error) {
-	var validDur, absoluteDur, reuseDur time.Duration
+	var validDur, absoluteDur time.Duration
 	var err error
+
+	reuseDur := defaultReuseInterval
 
 	if validIfNotUsedFor != "" {
 		validDur, err = time.ParseDuration(validIfNotUsedFor)
@@ -60,8 +75,8 @@ func NewRefreshTokenPolicy(logger *slog.Logger, rotation bool, validIfNotUsedFor
 		if err != nil {
 			return nil, fmt.Errorf("invalid config value %q for refresh tokens reuse interval: %v", reuseInterval, err)
 		}
-		logger.Info("config refresh tokens", "reuse_interval", reuseInterval)
 	}
+	logger.Info("config refresh tokens", "reuse_interval", reuseDur)
 
 	rotate := !rotation
 	logger.Info("config refresh tokens rotation", "enabled", rotate)

--- a/server/tokens/refresh_strategy_test.go
+++ b/server/tokens/refresh_strategy_test.go
@@ -1,6 +1,7 @@
 package tokens
 
 import (
+	"log/slog"
 	"testing"
 	"time"
 
@@ -22,6 +23,18 @@ func TestStrategy(t *testing.T) {
 		require.False(t, s.AllowedToReuse(lastTime))
 		require.True(t, s.ExpiredBecauseUnused(lastTime))
 		require.True(t, s.CompletelyExpired(lastTime))
+	})
+
+	t.Run("reuse defaults to a grace window", func(t *testing.T) {
+		logger := slog.New(slog.DiscardHandler)
+
+		s, err := NewRefreshTokenPolicy(logger, false, "", "", "")
+		require.NoError(t, err)
+		require.True(t, s.AllowedToReuse(time.Now()))
+
+		s, err = NewRefreshTokenPolicy(logger, false, "", "", "0s")
+		require.NoError(t, err)
+		require.False(t, s.AllowedToReuse(time.Now()))
 	})
 
 	t.Run("disabled intervals never expire", func(t *testing.T) {


### PR DESCRIPTION
#### Overview

Default `expiry.refreshTokens.reuseInterval` to `3s` instead of `0`.

#### What this PR does / why we need it

Rotation is enabled by default, and with `reuseInterval` unset the reuse window is zero, so a refresh token is claimable exactly once. Any client that does not see the response to its refresh — a request timeout, a dropped connection, or a second replica of an HA relying party refreshing the same stored token — retries with a token dex has already rotated, gets `invalid_grant`, and has to send the user back through login.

`Rotate` already handles this properly: inside the reuse window it returns the token the first call minted, so the retry is idempotent. Only the default was missing, and `3s` is the value the sample configuration has suggested all along.

`reuseInterval: "0s"` keeps the previous behavior for anyone who wants a token claimable exactly once.

#### Special notes for your reviewer

The trade-off is a 3 second window in which an already-rotated token still works. Dex does not revoke the token family on reuse detection today, so the practical difference is that a retry succeeds rather than logging the user out.