### PR TITLE
fix(server): introspect session-bound refresh tokens against their session

### DIFF
--- a/server/grants/refresh.go
+++ b/server/grants/refresh.go
@@ -180,18 +180,20 @@ func (g *refresh) sessionID(ctx context.Context, refreshToken *storage.RefreshTo
 		return "", nil
 	}
 
-	ref, ok := offlineSessions.Refresh[refreshToken.ClientID]
-	if !ok || ref.SessionID == "" {
+	// Shared with introspection so the two cannot disagree about which session a
+	// token names (see tokens.RefreshReferenceSessionID).
+	sid := tokens.RefreshReferenceSessionID(offlineSessions, refreshToken.ClientID)
+	if sid == "" {
 		// Issued outside a browser flow — the password grant, or before sessions were
 		// turned on. There is no session to be bound to, so there is none to end.
 		return "", nil
 	}
 
 	if !bound {
-		return ref.SessionID, nil
+		return sid, nil
 	}
 
-	if !g.sessions.Alive(ctx, ref.SessionID) {
+	if !g.sessions.Alive(ctx, sid) {
 		// Through the store, not storage.DeleteRefresh: the token and the offline
 		// session's reference to it have to go together, or the admin API lists a
 		// token that no longer exists and fails trying to revoke it.
@@ -202,7 +204,7 @@ func (g *refresh) sessionID(ctx context.Context, refreshToken *storage.RefreshTo
 			"client_id", refreshToken.ClientID, "user_id", refreshToken.Claims.UserID)
 		return "", sessionEndedError()
 	}
-	return ref.SessionID, nil
+	return sid, nil
 }
 
 // sessionEndedError reports a refused refresh as invalid_grant, the one code RFC

--- a/server/introspection/introspection.go
+++ b/server/introspection/introspection.go
@@ -94,8 +94,9 @@ type IntrospectionExtra struct {
 	// token at all when sessions are disabled.
 	//
 	// Note what this does not mean: introspection reports on the token, not on the
-	// session. A token from a session that has since ended still introspects as
-	// active until it expires, because nothing here consults session storage.
+	// session. For a standalone client a token from a session that has since ended
+	// still introspects as active until it expires. For a session-bound client the
+	// ended session takes the token with it, and introspection reports inactive.
 	SessionID string `json:"sid,omitempty"`
 
 	Email         string `json:"email,omitempty"`
@@ -258,6 +259,34 @@ func (h *Handler) introspectRefreshToken(ctx context.Context, token string) (*In
 	if sErr != nil {
 		h.Logger.ErrorContext(ctx, "failed to marshal offline session ID", "err", sErr)
 		return nil, newIntrospectInternalServerError()
+	}
+
+	client, err := h.Storage.GetClient(ctx, refresh.ClientID)
+	if err != nil {
+		h.Logger.ErrorContext(ctx, "error while fetching client from storage", "err", err.Error())
+		return nil, newIntrospectInternalServerError()
+	}
+
+	// A refresh token's sid lives on its offline-session reference, read the same
+	// way the refresh grant reads it: the two must agree on whether the session
+	// the token is bound to still stands.
+	var sessionID string
+	offlineSessions, err := h.Storage.GetOfflineSessions(ctx, refresh.Claims.UserID, refresh.ConnectorID)
+	if err != nil {
+		if !errors.Is(err, storage.ErrNotFound) {
+			h.Logger.ErrorContext(ctx, "failed to read offline session for sid", "err", err)
+		}
+		if client.RefreshBoundToSession() {
+			// The grant refuses a bound token whose session cannot be read;
+			// introspection reports it inactive.
+			return nil, newIntrospectInactiveTokenError()
+		}
+	} else if ref, ok := offlineSessions.Refresh[refresh.ClientID]; ok {
+		sessionID = ref.SessionID
+	}
+
+	if !h.sessionAlive(ctx, client, subjectString, sessionID) {
+		return nil, newIntrospectInactiveTokenError()
 	}
 
 	return &Introspection{

--- a/server/introspection/introspection.go
+++ b/server/introspection/introspection.go
@@ -263,30 +263,36 @@ func (h *Handler) introspectRefreshToken(ctx context.Context, token string) (*In
 
 	client, err := h.Storage.GetClient(ctx, refresh.ClientID)
 	if err != nil {
+		// A deleted client cannot redeem the token; report inactive rather than 500.
+		// The endpoint takes no client authentication, so this is also the safer
+		// answer for an unauthenticated probe of a dangling token.
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, newIntrospectInactiveTokenError()
+		}
 		h.Logger.ErrorContext(ctx, "error while fetching client from storage", "err", err.Error())
 		return nil, newIntrospectInternalServerError()
 	}
 
-	// A refresh token's sid lives on its offline-session reference, read the same
-	// way the refresh grant reads it: the two must agree on whether the session
-	// the token is bound to still stands.
-	var sessionID string
-	offlineSessions, err := h.Storage.GetOfflineSessions(ctx, refresh.Claims.UserID, refresh.ConnectorID)
-	if err != nil {
-		if !errors.Is(err, storage.ErrNotFound) {
-			h.Logger.ErrorContext(ctx, "failed to read offline session for sid", "err", err)
-		}
-		if client.RefreshBoundToSession() {
+	// Standalone clients are not judged by their session. Skip the offline-session
+	// read: the endpoint is unauthenticated, and on Kubernetes that is one avoidable
+	// API call per request whose result would be discarded.
+	if client.RefreshBoundToSession() {
+		// A refresh token's sid lives on its offline-session reference, read the
+		// same way the refresh grant reads it (tokens.RefreshReferenceSessionID):
+		// the two must agree on whether the session the token is bound to still stands.
+		offlineSessions, err := h.Storage.GetOfflineSessions(ctx, refresh.Claims.UserID, refresh.ConnectorID)
+		if err != nil {
+			if !errors.Is(err, storage.ErrNotFound) {
+				h.Logger.ErrorContext(ctx, "failed to read offline session for sid", "err", err)
+			}
 			// The grant refuses a bound token whose session cannot be read;
 			// introspection reports it inactive.
 			return nil, newIntrospectInactiveTokenError()
 		}
-	} else if ref, ok := offlineSessions.Refresh[refresh.ClientID]; ok {
-		sessionID = ref.SessionID
-	}
-
-	if !h.sessionAlive(ctx, client, subjectString, sessionID) {
-		return nil, newIntrospectInactiveTokenError()
+		sessionID := tokens.RefreshReferenceSessionID(offlineSessions, refresh.ClientID)
+		if !h.sessionAlive(ctx, client, sessionID) {
+			return nil, newIntrospectInactiveTokenError()
+		}
 	}
 
 	return &Introspection{
@@ -322,11 +328,15 @@ func (h *Handler) introspectRefreshToken(ctx context.Context, token string) (*In
 // RefreshTokenLifetime, the same declaration the refresh grant reads — the two must
 // agree, or a standalone client refreshes into a token that is inactive from birth.
 //
+// When sessions are disabled the grant skips its check entirely (sessionsEnabled),
+// so introspection must too: Manager.Alive returns false when Config is nil, which
+// would otherwise flip every bound token inactive the moment sessions are turned off.
+//
 // The comparison is against the sid, not merely the existence of a session: signing
 // out and back in makes a new session under the same subject, and the old token must
 // not be revived by it.
-func (h *Handler) sessionAlive(ctx context.Context, client storage.Client, subject, sessionID string) bool {
-	if sessionID == "" || !client.RefreshBoundToSession() {
+func (h *Handler) sessionAlive(ctx context.Context, client storage.Client, sessionID string) bool {
+	if sessionID == "" || !client.RefreshBoundToSession() || h.Sessions == nil || !h.Sessions.Enabled() {
 		return true
 	}
 
@@ -354,11 +364,14 @@ func (h *Handler) introspectAccessToken(ctx context.Context, token string) (*Int
 
 	client, err := h.Storage.GetClient(ctx, clientID)
 	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, newIntrospectInactiveTokenError()
+		}
 		h.Logger.ErrorContext(ctx, "error while fetching client from storage", "err", err.Error())
 		return nil, newIntrospectInternalServerError()
 	}
 
-	if !h.sessionAlive(ctx, client, idToken.Subject, claims.SessionID) {
+	if !h.sessionAlive(ctx, client, claims.SessionID) {
 		return nil, newIntrospectInactiveTokenError()
 	}
 

--- a/server/introspection/introspection.go
+++ b/server/introspection/introspection.go
@@ -276,7 +276,11 @@ func (h *Handler) introspectRefreshToken(ctx context.Context, token string) (*In
 	// Standalone clients are not judged by their session. Skip the offline-session
 	// read: the endpoint is unauthenticated, and on Kubernetes that is one avoidable
 	// API call per request whose result would be discarded.
-	if client.RefreshBoundToSession() {
+	//
+	// When sessions are disabled the refresh grant skips its session check
+	// (sessionsEnabled). Gate here before GetOfflineSessions so a storage error
+	// cannot report inactive while the grant would still redeem the token.
+	if client.RefreshBoundToSession() && h.Sessions != nil && h.Sessions.Enabled() {
 		// A refresh token's sid lives on its offline-session reference, read the
 		// same way the refresh grant reads it (tokens.RefreshReferenceSessionID):
 		// the two must agree on whether the session the token is bound to still stands.

--- a/server/server_introspection_test.go
+++ b/server/server_introspection_test.go
@@ -257,3 +257,67 @@ func TestHandleIntrospect(t *testing.T) {
 		})
 	}
 }
+
+// A session-bound client's refresh token must introspect as inactive once the
+// session it was issued under has ended, the same judgment the refresh grant
+// makes. A standalone client's token outlives the session by design.
+func TestHandleIntrospectRefreshTokenSessionBinding(t *testing.T) {
+	ctx := t.Context()
+
+	httpServer, s := newTestServerWithSessions(t, nil)
+	defer httpServer.Close()
+
+	mockTestStorage(t, s.storage)
+
+	// The refresh token was issued under a browser session.
+	require.NoError(t, s.storage.UpdateOfflineSessions(ctx, "1", "test",
+		func(old storage.OfflineSessions) (storage.OfflineSessions, error) {
+			old.Refresh["test"].SessionID = "sid"
+			return old, nil
+		}))
+
+	// That session has since ended by timeout: the row is still stored, but both
+	// expiries are in the past.
+	past := time.Now().Add(-time.Hour)
+	require.NoError(t, s.storage.CreateAuthSession(ctx, storage.AuthSession{
+		ID: "sid", Secret: testSessionSecret("sid"),
+		UserID: "1", ConnectorID: "test",
+		CreatedAt: past, LastActivity: past,
+		AbsoluteExpiry: past, IdleExpiry: past,
+	}))
+
+	refreshToken, err := internal.Marshal(&internal.RefreshToken{RefreshId: "test", Token: "bar"})
+	require.NoError(t, err)
+
+	introspect := func() string {
+		data := url.Values{}
+		data.Set("token", refreshToken)
+
+		u, err := url.Parse(s.issuerURL.String())
+		require.NoError(t, err)
+		u.Path = path.Join(u.Path, "token", "introspect")
+
+		req, _ := http.NewRequest("POST", u.String(), bytes.NewBufferString(data.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		rr := httptest.NewRecorder()
+		s.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+
+		result, err := io.ReadAll(rr.Body)
+		require.NoError(t, err)
+		return string(result)
+	}
+
+	// Standalone client: the ended session changes nothing.
+	require.Contains(t, introspect(), `"active":true`)
+
+	require.NoError(t, s.storage.UpdateClient(ctx, "test",
+		func(old storage.Client) (storage.Client, error) {
+			old.RefreshTokenLifetime = storage.RefreshTokenLifetimeSession
+			return old, nil
+		}))
+
+	// Session-bound client: the token ended with the session.
+	require.Equal(t, "{\"active\":false}\n", introspect())
+}

--- a/server/server_introspection_test.go
+++ b/server/server_introspection_test.go
@@ -320,4 +320,20 @@ func TestHandleIntrospectRefreshTokenSessionBinding(t *testing.T) {
 
 	// Session-bound client: the token ended with the session.
 	require.Equal(t, "{\"active\":false}\n", introspect())
+
+	// Bound client whose offline-session row is gone: grant refuses; introspection
+	// must report inactive (not 500).
+	require.NoError(t, s.storage.DeleteOfflineSessions(ctx, "1", "test"))
+	require.Equal(t, "{\"active\":false}\n", introspect())
+
+	// Bound client with a reference that carries no sid (minted outside a browser
+	// flow): there is no session to judge, so the token stays active.
+	require.NoError(t, s.storage.CreateOfflineSessions(ctx, storage.OfflineSessions{
+		UserID: "1",
+		ConnID: "test",
+		Refresh: map[string]*storage.RefreshTokenRef{
+			"test": {ID: "test", ClientID: "test"},
+		},
+	}))
+	require.Contains(t, introspect(), `"active":true`)
 }

--- a/server/tokens/refresh_session.go
+++ b/server/tokens/refresh_session.go
@@ -1,0 +1,16 @@
+package tokens
+
+import "github.com/dexidp/dex/storage"
+
+// RefreshReferenceSessionID returns the browser session ID recorded on an
+// offline session's refresh reference for clientID. The empty string means
+// there is no reference, or the reference carries no sid (token minted outside
+// a browser flow). The refresh grant and token introspection both read the sid
+// through this helper so they cannot disagree about which session a token names.
+func RefreshReferenceSessionID(offline storage.OfflineSessions, clientID string) string {
+	ref, ok := offline.Refresh[clientID]
+	if !ok || ref == nil {
+		return ""
+	}
+	return ref.SessionID
+}

--- a/server/tokens/refresh_session_test.go
+++ b/server/tokens/refresh_session_test.go
@@ -1,0 +1,24 @@
+package tokens
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dexidp/dex/storage"
+)
+
+func TestRefreshReferenceSessionID(t *testing.T) {
+	offline := storage.OfflineSessions{
+		Refresh: map[string]*storage.RefreshTokenRef{
+			"bound":   {ID: "r1", ClientID: "bound", SessionID: "sid"},
+			"empty":   {ID: "r2", ClientID: "empty", SessionID: ""},
+			"nil-ref": nil,
+		},
+	}
+
+	require.Equal(t, "sid", RefreshReferenceSessionID(offline, "bound"))
+	require.Equal(t, "", RefreshReferenceSessionID(offline, "empty"))
+	require.Equal(t, "", RefreshReferenceSessionID(offline, "nil-ref"))
+	require.Equal(t, "", RefreshReferenceSessionID(offline, "missing"))
+}


### PR DESCRIPTION
## Problem

533d177 added `Handler.sessionAlive` to token introspection and deliberately excluded refresh tokens, on the grounds that they outlive the session that issued them. 155557b then introduced per-client session binding: a client configured with `refreshTokenLifetime: session` (`storage.Client.RefreshBoundToSession`) has refresh tokens that explicitly do NOT outlive the session, and `sessionAlive` was rewritten to gate on exactly that flag.

The access-token path got the check; the refresh-token path never did. `introspectAccessToken` consults `sessionAlive`, while `introspectRefreshToken` returns `active: true` for any token that passes `LookupRefreshToken`, without consulting the session.

## Reachability

Explicit logout is already covered: logout eagerly deletes bound clients' refresh tokens, so the lookup itself fails. But a session that ends by idle or absolute timeout revokes nothing eagerly. Between session end and the token's own expiry, a session-bound refresh token still introspects `active: true`, even though the refresh grant would refuse to redeem it (`grants/refresh.go` `sessionID()` reads the same flag and the same session, and refuses a dead one). Introspection and the grant disagree about the token's state, and RFC 7662 section 4 requires a revoked token to be reported inactive.

## Fix

In `introspectRefreshToken`, after the lookup succeeds:

1. Load the client.
2. Read the token's sid from its offline-session reference, the same source the refresh grant reads.
3. Apply the same `sessionAlive` check the access-token path uses. A dead session means `active: false`.

A bound token whose offline session cannot be read is reported inactive, matching the grant's refusal in the same situation. For standalone clients the response is unchanged; the path now additionally reads the client and the offline-session reference. Also updates the `IntrospectionExtra.SessionID` doc comment, which still claimed nothing here consults session storage.

## Tests

New `TestHandleIntrospectRefreshTokenSessionBinding` (server/server_introspection_test.go): a session-bound client whose session ended by timeout (row still stored, both expiries in the past) introspects its refresh token as `active: false`; a standalone client with the same dead session stays `active: true`. Verified the test fails without the fix.

- `go build ./...`
- `go test ./server/ -run 'Introspect|Session' -count=1`
- `go test ./server/... -count=1`

All pass.

Made with [Cursor](https://cursor.com)