### PR TITLE
feat(google): implement TokenIdentity for RFC 8693 token exchange

### DIFF
--- a/connector/google/google.go
+++ b/connector/google/google.go
@@ -131,6 +131,7 @@ func (c *Config) Open(id string, logger *slog.Logger) (conn connector.Connector,
 		verifier: provider.Verifier(
 			&oidc.Config{ClientID: clientID},
 		),
+		provider:                       provider,
 		logger:                         logger,
 		cancel:                         cancel,
 		hostedDomains:                  c.HostedDomains,
@@ -144,14 +145,16 @@ func (c *Config) Open(id string, logger *slog.Logger) (conn connector.Connector,
 }
 
 var (
-	_ connector.CallbackConnector = (*googleConnector)(nil)
-	_ connector.RefreshConnector  = (*googleConnector)(nil)
+	_ connector.CallbackConnector      = (*googleConnector)(nil)
+	_ connector.RefreshConnector       = (*googleConnector)(nil)
+	_ connector.TokenIdentityConnector = (*googleConnector)(nil)
 )
 
 type googleConnector struct {
 	redirectURI                    string
 	oauth2Config                   *oauth2.Config
 	verifier                       *oidc.IDTokenVerifier
+	provider                       *oidc.Provider
 	cancel                         context.CancelFunc
 	logger                         *slog.Logger
 	hostedDomains                  []string
@@ -227,6 +230,15 @@ func (c *googleConnector) Refresh(ctx context.Context, s connector.Scopes, ident
 	return c.createIdentity(ctx, identity, s, token)
 }
 
+// googleClaims holds the claims read from either a verified Google ID Token
+// or the Google userinfo endpoint.
+type googleClaims struct {
+	Username      string `json:"name"`
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"email_verified"`
+	HostedDomain  string `json:"hd"`
+}
+
 func (c *googleConnector) createIdentity(ctx context.Context, identity connector.Identity, s connector.Scopes, token *oauth2.Token) (connector.Identity, error) {
 	rawIDToken, ok := token.Extra("id_token").(string)
 	if !ok {
@@ -237,12 +249,7 @@ func (c *googleConnector) createIdentity(ctx context.Context, identity connector
 		return identity, fmt.Errorf("google: failed to verify ID Token: %v", err)
 	}
 
-	var claims struct {
-		Username      string `json:"name"`
-		Email         string `json:"email"`
-		EmailVerified bool   `json:"email_verified"`
-		HostedDomain  string `json:"hd"`
-	}
+	var claims googleClaims
 	if err := idToken.Claims(&claims); err != nil {
 		return identity, fmt.Errorf("oidc: failed to decode claims: %v", err)
 	}
@@ -255,6 +262,54 @@ func (c *googleConnector) createIdentity(ctx context.Context, identity connector
 	if claims.Username == "" {
 		claims.Username = identity.Username
 	}
+
+	return c.identityFromClaims(s, idToken.Subject, claims, token.RefreshToken)
+}
+
+// TokenIdentity implements token exchange (RFC 8693): it verifies a Google ID
+// Token or access token supplied by the client and returns the associated
+// identity, mirroring the behavior of the OIDC connector.
+func (c *googleConnector) TokenIdentity(ctx context.Context, subjectTokenType, subjectToken string) (connector.Identity, error) {
+	var (
+		identity connector.Identity
+		claims   googleClaims
+		subject  string
+	)
+
+	switch subjectTokenType {
+	case "urn:ietf:params:oauth:token-type:id_token":
+		idToken, err := c.provider.Verifier(&oidc.Config{SkipClientIDCheck: true}).Verify(ctx, subjectToken)
+		if err != nil {
+			return identity, fmt.Errorf("google: failed to verify ID Token: %v", err)
+		}
+		if err := idToken.Claims(&claims); err != nil {
+			return identity, fmt.Errorf("google: failed to decode claims: %v", err)
+		}
+		subject = idToken.Subject
+	case "urn:ietf:params:oauth:token-type:access_token":
+		userInfo, err := c.provider.UserInfo(ctx, oauth2.StaticTokenSource(&oauth2.Token{
+			AccessToken: subjectToken,
+			TokenType:   "Bearer", // The UserInfo endpoint requires a bearer token as per RFC6750
+		}))
+		if err != nil {
+			return identity, fmt.Errorf("google: error loading userinfo: %v", err)
+		}
+		if err := userInfo.Claims(&claims); err != nil {
+			return identity, fmt.Errorf("google: failed to decode userinfo claims: %v", err)
+		}
+		subject = userInfo.Subject
+	default:
+		return identity, fmt.Errorf("google: unknown token type for token exchange: %s", subjectTokenType)
+	}
+
+	// Groups are configured per connector rather than requested via scopes, so
+	// always attempt to fetch them here and let configuration gate it, same as
+	// the other token exchange enabled connectors.
+	return c.identityFromClaims(connector.Scopes{Groups: true}, subject, claims, "")
+}
+
+func (c *googleConnector) identityFromClaims(s connector.Scopes, subject string, claims googleClaims, refreshToken string) (connector.Identity, error) {
+	var identity connector.Identity
 
 	if len(c.hostedDomains) > 0 {
 		found := false
@@ -273,6 +328,7 @@ func (c *googleConnector) createIdentity(ctx context.Context, identity connector
 	var groups []string
 	if s.Groups && len(c.adminSrv) > 0 {
 		checkedGroups := make(map[string]struct{})
+		var err error
 		groups, err = c.getGroups(claims.Email, c.fetchTransitiveGroupMembership, checkedGroups)
 		if err != nil {
 			return identity, fmt.Errorf("google: could not retrieve groups: %v", err)
@@ -287,11 +343,11 @@ func (c *googleConnector) createIdentity(ctx context.Context, identity connector
 	}
 
 	identity = connector.Identity{
-		UserID:        idToken.Subject,
+		UserID:        subject,
 		Username:      claims.Username,
 		Email:         claims.Email,
 		EmailVerified: claims.EmailVerified,
-		ConnectorData: []byte(token.RefreshToken),
+		ConnectorData: []byte(refreshToken),
 		Groups:        groups,
 	}
 	return identity, nil

--- a/connector/google/google_test.go
+++ b/connector/google/google_test.go
@@ -449,3 +449,112 @@ func TestPromptTypeConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestIdentityFromClaims(t *testing.T) {
+	ts := testSetup()
+	defer ts.Close()
+
+	serviceAccountFilePath, err := tempServiceAccountKey()
+	assert.Nil(t, err)
+
+	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", serviceAccountFilePath)
+	conn, err := newConnector(&Config{
+		ClientID:           "testClient",
+		ClientSecret:       "testSecret",
+		RedirectURI:        ts.URL + "/callback",
+		Scopes:             []string{"openid", "groups"},
+		DomainToAdminEmail: map[string]string{"*": "admin@dexidp.com"},
+		Groups:             []string{"groups_1@dexidp.com"},
+	})
+	assert.Nil(t, err)
+
+	conn.adminSrv[wildcardDomainToAdminEmail], err = admin.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(ts.URL))
+	assert.Nil(t, err)
+
+	type testCase struct {
+		scopes      connector.Scopes
+		claims      googleClaims
+		subject     string
+		expectedErr string
+		expectID    connector.Identity
+	}
+
+	for name, tc := range map[string]testCase{
+		"groups_fetched_and_filtered": {
+			scopes:  connector.Scopes{Groups: true},
+			claims:  googleClaims{Username: "User One", Email: "user_1@dexidp.com", EmailVerified: true},
+			subject: "user-1-id",
+			expectID: connector.Identity{
+				UserID:        "user-1-id",
+				Username:      "User One",
+				Email:         "user_1@dexidp.com",
+				EmailVerified: true,
+				Groups:        []string{"groups_1@dexidp.com"},
+				ConnectorData: []byte(""),
+			},
+		},
+		"groups_not_requested": {
+			scopes:  connector.Scopes{Groups: false},
+			claims:  googleClaims{Username: "User One", Email: "user_1@dexidp.com", EmailVerified: true},
+			subject: "user-1-id",
+			expectID: connector.Identity{
+				UserID:        "user-1-id",
+				Username:      "User One",
+				Email:         "user_1@dexidp.com",
+				EmailVerified: true,
+				ConnectorData: []byte(""),
+			},
+		},
+		"user_not_in_allowed_group": {
+			scopes:      connector.Scopes{Groups: true},
+			claims:      googleClaims{Username: "Groups Zero", Email: "groups_0@dexidp.com", EmailVerified: true},
+			subject:     "groups-0-id",
+			expectedErr: "is not in any of the required groups",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			identity, err := conn.identityFromClaims(tc.scopes, tc.subject, tc.claims, "")
+			if tc.expectedErr != "" {
+				assert.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expectID, identity)
+		})
+	}
+}
+
+func TestIdentityFromClaimsHostedDomain(t *testing.T) {
+	ts := testSetup()
+	defer ts.Close()
+
+	conn, err := newConnector(&Config{
+		ClientID:      "testClient",
+		ClientSecret:  "testSecret",
+		RedirectURI:   ts.URL + "/callback",
+		HostedDomains: []string{"dexidp.com"},
+	})
+	assert.Nil(t, err)
+
+	_, err = conn.identityFromClaims(connector.Scopes{}, "user-1-id", googleClaims{Email: "user@other.com", HostedDomain: "other.com"}, "")
+	assert.ErrorContains(t, err, "unexpected hd claim")
+
+	identity, err := conn.identityFromClaims(connector.Scopes{}, "user-1-id", googleClaims{Email: "user@dexidp.com", HostedDomain: "dexidp.com"}, "refresh-token")
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("refresh-token"), identity.ConnectorData)
+}
+
+func TestTokenIdentityUnknownTokenType(t *testing.T) {
+	ts := testSetup()
+	defer ts.Close()
+
+	conn, err := newConnector(&Config{
+		ClientID:     "testClient",
+		ClientSecret: "testSecret",
+		RedirectURI:  ts.URL + "/callback",
+	})
+	assert.Nil(t, err)
+
+	_, err = conn.TokenIdentity(context.Background(), "urn:ietf:params:oauth:token-type:saml2", "some-token")
+	assert.ErrorContains(t, err, "unknown token type for token exchange")
+}


### PR DESCRIPTION
#### Overview

Adds RFC 8693 token-exchange support to the Google connector by implementing `TokenIdentity`.

#### What this PR does / why we need it

The Google connector only implemented `CallbackConnector` and `RefreshConnector`, so it couldn't be used with the token-exchange grant. Users needing machine authentication with group claims (e.g. exchanging a Google access token from an impersonated service account for a dex-issued JWT) had to fall back to the OIDC connector configured against Google, which does not return group claims since the Google connector handles group membership as a special case via the Admin Directory API.

This PR adds a `TokenIdentity` method to the Google connector, mirroring the existing OIDC connector implementation. It verifies a Google ID Token (subjectTokenType `urn:ietf:params:oauth:token-type:id_token`) or loads the identity from Google's userinfo endpoint for an access token (`urn:ietf:params:oauth:token-type:access_token`), then reuses the connector's existing hosted-domain check and group-fetching logic, which was extracted from `createIdentity` into a shared `identityFromClaims` helper. Since `TokenIdentity` has no `Scopes` parameter, groups are always attempted and gated by connector configuration, matching the approach already used by the GitLab connector's `TokenIdentity` (see https://github.com/dexidp/dex/pull/4606).

Closes #3768

#### Special notes for your reviewer

- Validation: `go build ./...` passes; `go vet ./connector/google/... ./server/...` passes with no findings; `gofmt -l` on both changed files is clean; `go test ./connector/google/...` and `go test -race ./connector/google/... ./server/grants/...` pass, including new tests `TestIdentityFromClaims`, `TestIdentityFromClaimsHostedDomain`, and `TestTokenIdentityUnknownTokenType` covering the hosted-domain check, group fetch/filter, and unknown-token-type error paths.
- `golangci-lint` could not be run in this sandbox (the pinned v2.4.0 panics against the sandbox's Go 1.26 toolchain, unrelated to this change).
- Not validated: an end-to-end exchange against real Google OAuth tokens, since no live Google credentials are available in this environment. The `id_token` and `access_token` branches delegate to the now shared, unit-tested `identityFromClaims` helper but are not exercised by a test that performs a real network call to Google.

---
AI assistance: this change was drafted with Claude Code.