### PR TITLE
fix(build): use netgo DNS resolver for release binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,12 @@ update-gomplate: ## Check and update gomplate version in Dockerfile.
 .PHONY: release-binary
 release-binary: LD_FLAGS = "-w -X main.version=$(VERSION) -extldflags \"-static\""
 release-binary: ## Build release binaries (used to build a final container image).
-	@go build -o /go/bin/dex -v -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/dex
-	@go build -o /go/bin/docker-entrypoint -v -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/docker-entrypoint
+	# Use the pure Go DNS resolver (netgo) so that the binary does not depend on
+	# libc's getaddrinfo. This is required for distroless base images, which do
+	# not ship the dynamic libraries needed for CGO-based name resolution.
+	# See https://github.com/dexidp/dex/issues/2469
+	@go build -tags netgo -o /go/bin/dex -v -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/dex
+	@go build -tags netgo -o /go/bin/docker-entrypoint -v -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/docker-entrypoint
 
 bin/dex:
 	@mkdir -p bin/


### PR DESCRIPTION
#### Overview

Build the Dex release binaries with the `netgo` build tag so the pure Go DNS resolver is used instead of libc-based `getaddrinfo`.

#### What this PR does / why we need it

Distroless base images do not ship the dynamic libraries required by libc's `getaddrinfo` (which calls `dlopen`). When CGO is enabled, the Go standard library uses the CGO resolver for `*.local` hostnames, so distroless-based Dex builds fail with:

```
LDAP Result Code 200 "Network Error": dial tcp: lookup ldap.openldap.svc.cluster.local: device or resource busy
```

Building the release binaries with `-tags netgo` forces the pure Go DNS resolver, which has no dependency on dynamic libraries and works on distroless images. CGO remains enabled for SQLite storage support.

Closes #2469

#### Special notes for your reviewer

- Verified that `CGO_ENABLED=1 go build -tags netgo ./...` compiles for the main module, `examples/` and `api/v2`.
- Verified with `GODEBUG=netdns=2` that the resulting binary reports it was "compiled without support for the cgo resolver".
- Verified SQLite/cgo symbols (e.g. `sqlite3_open`) are still present in the binary.