### PR TITLE
fix(server): clarify the error when a login request is double-submitted

### DIFF
--- a/server/authflow/callback.go
+++ b/server/authflow/callback.go
@@ -99,6 +99,13 @@ func (h *Handler) handleConnectorCallback(w http.ResponseWriter, r *http.Request
 	authReq, err = h.finalizeLogin(ctx, identity, authReq, conn.Connector)
 	if err != nil {
 		h.Logger.ErrorContext(r.Context(), "failed to finalize login", "err", err)
+		if errors.Is(err, storage.ErrNotFound) {
+			// The auth request is gone from storage, most likely because an earlier,
+			// still-in-flight submission already finalized it (e.g. a
+			// double-submitted callback).
+			h.renderError(r, w, http.StatusBadRequest, ErrMsgRequestAlreadyCompleted)
+			return
+		}
 		h.renderError(r, w, http.StatusInternalServerError, "Login error.")
 		return
 	}

--- a/server/authflow/errors.go
+++ b/server/authflow/errors.go
@@ -27,4 +27,11 @@ const (
 	// ErrMsgNotInRequiredGroups is shown when a user authenticates successfully
 	// but is not a member of any of the groups required by the connector.
 	ErrMsgNotInRequiredGroups = "You are not a member of any of the required groups to authenticate."
+
+	// ErrMsgRequestAlreadyCompleted is shown when a login request is resubmitted
+	// after its AuthRequest is no longer in storage: most commonly because it was
+	// already finalized by an earlier, still-in-flight submission (e.g. a
+	// double-submitted login form, or a stale page resubmitted via the browser
+	// back button), but also possible if the request expired in the meantime.
+	ErrMsgRequestAlreadyCompleted = "This login request is no longer valid. It may have already been completed, or it may have expired. Please close this tab, or go back and start over if you need to sign in again."
 )

--- a/server/authflow/finalize.go
+++ b/server/authflow/finalize.go
@@ -52,7 +52,7 @@ func (h *Handler) finalizeLogin(ctx context.Context, identity connector.Identity
 		return a, nil
 	}
 	if err := h.Storage.UpdateAuthRequest(ctx, authReq.ID, updater); err != nil {
-		return storage.AuthRequest{}, fmt.Errorf("failed to update auth request: %v", err)
+		return storage.AuthRequest{}, fmt.Errorf("failed to update auth request: %w", err)
 	}
 	// Keep the in-memory copy in sync with what was persisted so later reads
 	// (the next-step decision below) see the identity we just stored.

--- a/server/authflow/finalize_test.go
+++ b/server/authflow/finalize_test.go
@@ -1,6 +1,7 @@
 package authflow
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -57,4 +58,30 @@ func TestFinalizeLoginBlockedAccount(t *testing.T) {
 	}))
 	_, err = server.finalizeLogin(ctx, ident, authReq, nil)
 	require.NoError(t, err)
+}
+
+// TestFinalizeLoginAlreadyFinalized reproduces a double-submitted login (e.g. the
+// user double-clicks the submit button, or resubmits a stale page reached via the
+// browser back button): by the time the duplicate request reaches finalizeLogin,
+// the first submission has already completed and the AuthRequest is gone. The
+// caller needs to distinguish this from a generic storage failure, so the
+// returned error must still satisfy errors.Is(err, storage.ErrNotFound).
+func TestFinalizeLoginAlreadyFinalized(t *testing.T) {
+	httpServer, server := newTestHandler(t, nil)
+	defer httpServer.Close()
+
+	ctx := t.Context()
+
+	ident := connector.Identity{UserID: "user-1", Email: "user@example.com"}
+	authReq := storage.AuthRequest{
+		ID:          "login-req",
+		ClientID:    "example-app",
+		Expiry:      time.Now().Add(time.Hour),
+		ConnectorID: "mock",
+	}
+	// Do not create the AuthRequest, simulating that an earlier, still-in-flight
+	// submission already finalized and deleted it.
+	_, err := server.finalizeLogin(ctx, ident, authReq, nil)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, storage.ErrNotFound), "expected error to wrap storage.ErrNotFound, got: %v", err)
 }

--- a/server/authflow/password.go
+++ b/server/authflow/password.go
@@ -4,6 +4,7 @@ package authflow
 // form and the credential check for password connectors.
 
 import (
+	"errors"
 	"net/http"
 	"net/url"
 
@@ -80,6 +81,10 @@ func (h *Handler) handlePasswordLogin(w http.ResponseWriter, r *http.Request) {
 					authReq, err = h.finalizeLogin(ctx, *ident, authReq, conn.Connector)
 					if err != nil {
 						h.Logger.ErrorContext(ctx, "failed to finalize login", "err", err)
+						if errors.Is(err, storage.ErrNotFound) {
+							h.renderError(r, w, http.StatusBadRequest, ErrMsgRequestAlreadyCompleted)
+							return
+						}
 						h.renderError(r, w, http.StatusInternalServerError, "Login error.")
 						return
 					}
@@ -116,6 +121,13 @@ func (h *Handler) handlePasswordLogin(w http.ResponseWriter, r *http.Request) {
 		authReq, err = h.finalizeLogin(r.Context(), identity, authReq, conn.Connector)
 		if err != nil {
 			h.Logger.ErrorContext(r.Context(), "failed to finalize login", "err", err)
+			if errors.Is(err, storage.ErrNotFound) {
+				// The auth request is gone from storage, most likely because an
+				// earlier submission already finalized it, e.g. the user
+				// double-clicked the login button.
+				h.renderError(r, w, http.StatusBadRequest, ErrMsgRequestAlreadyCompleted)
+				return
+			}
 			h.renderError(r, w, http.StatusInternalServerError, "Login error.")
 			return
 		}


### PR DESCRIPTION
#### Overview

Clarifies the error returned when a login or consent request is double-submitted (e.g. via double-click or a stale back-button resubmit), so the user sees a 400 with an explanatory message instead of an opaque 500 "Login error."

#### What this PR does / why we need it

Double-clicking the login/consent submit button, or resubmitting a stale page reached via the browser back button, sends a duplicate request for the same `AuthRequest`. The first submission completes normally and consumes the `AuthRequest`; by the time the duplicate reaches `finalizeLogin`, `storage.UpdateAuthRequest` fails with `storage.ErrNotFound` because the row is already gone. Previously, that error was wrapped with `fmt.Errorf("...: %v", err)`, which discarded the error's identity, so every caller rendered the same generic 500 "Login error." regardless of cause.

Changes:
- `server/authflow/finalize.go`: wrap the `UpdateAuthRequest` error with `%w` instead of `%v` so `errors.Is(err, storage.ErrNotFound)` works on the error `finalizeLogin` returns.
- `server/authflow/errors.go`: add `ErrMsgRequestAlreadyCompleted`, a user-facing message explaining the request is no longer valid (already completed, or expired) rather than a generic failure.
- `server/authflow/callback.go` and `server/authflow/password.go` (both call sites, including the SPNEGO branch): when `finalizeLogin` fails with `errors.Is(err, storage.ErrNotFound)`, render 400 with the new message instead of 500 "Login error." This matches the existing convention in this package, where a missing `AuthRequest` is already treated as a 400 client-side condition elsewhere (e.g. `callback.go`'s and `password.go`'s `GetAuthRequest` checks, and `consent.go`'s approval handler).
- `server/authflow/sessionlogin.go` was deliberately left untouched: its `UpdateAuthRequest` failure path silently falls back rather than rendering a terminal error to the user, so it isn't affected by this failure mode.

User-visible behavior is otherwise unchanged: a double-submitted login still fails, and no session or auth request is recovered. The narrower, concrete improvement is that the response is now a 400 with an explanation the user can act on, instead of an opaque 500 that looks like a server-side database bug.

Closes #4451

#### Special notes for your reviewer

- A maintainer confirmed this exact failure mode on the issue and noted that, short of the larger session-based rework tracked separately, clarifying the error would be worthwhile.
- Reproduced the failure locally with a new unit test, `TestFinalizeLoginAlreadyFinalized` in `server/authflow/finalize_test.go`, which calls `finalizeLogin` against an `AuthRequest` that was never created in storage (simulating a duplicate submission after the first one already consumed it) and asserts the returned error still satisfies `errors.Is(err, storage.ErrNotFound)`. Confirmed this test fails without the `%v` -> `%w` change and passes with it.
- Ran `go build ./...`, `go test ./server/... -race`, and `golangci-lint run ./server/authflow/...`. All passed, including the full existing `server/authflow` suite (no regressions) and `go vet`.

---
AI assistance: this change was drafted with Claude Code.