### PR TITLE
feat(saml): support IdP metadata discovery for certificate rotation

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -135,3 +135,14 @@ type LogoutCallbackConnector interface {
 	// return nil.
 	HandleLogoutCallback(ctx context.Context, r *http.Request) error
 }
+
+// LifecycleConnector is an optional interface for connectors that run
+// background work (for example polling). The server starts and stops these
+// connectors with the server's lifetime.
+type LifecycleConnector interface {
+	// Start begins any background work. A returned error means the connector
+	// should be considered failed to open.
+	Start(ctx context.Context) error
+	// Close stops any background work started by Start.
+	Close()
+}

--- a/connector/saml/metadata.go
+++ b/connector/saml/metadata.go
@@ -1,0 +1,115 @@
+package saml
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
+
+// IdPMetadata is the subset of SAML IdP metadata dex consumes.
+type IdPMetadata struct {
+	EntityID     string
+	SSOEndpoints []SSOEndpoint
+	SigningCerts []*x509.Certificate
+}
+
+// SSOEndpoint is a SingleSignOnService entry from the IdP metadata.
+type SSOEndpoint struct {
+	Binding  string
+	Location string
+}
+
+// ssoEndpoint returns the Location of the first endpoint using the given
+// binding, if any.
+func (m *IdPMetadata) ssoEndpoint(binding string) (string, bool) {
+	for _, e := range m.SSOEndpoints {
+		if e.Binding == binding {
+			return e.Location, true
+		}
+	}
+	return "", false
+}
+
+type entityDescriptor struct {
+	XMLName          xml.Name          `xml:"urn:oasis:names:tc:SAML:2.0:metadata EntityDescriptor"`
+	EntityID         string            `xml:"entityID,attr"`
+	IDPSSODescriptor *idpSSODescriptor `xml:"IDPSSODescriptor"`
+}
+
+type idpSSODescriptor struct {
+	XMLName             xml.Name              `xml:"urn:oasis:names:tc:SAML:2.0:metadata IDPSSODescriptor"`
+	KeyDescriptors      []keyDescriptor       `xml:"KeyDescriptor"`
+	SingleSignOnService []singleSignOnService `xml:"SingleSignOnService"`
+}
+
+type keyDescriptor struct {
+	Use     string   `xml:"use,attr"`
+	KeyInfo *keyInfo `xml:"http://www.w3.org/2000/09/xmldsig# KeyInfo"`
+}
+
+type keyInfo struct {
+	X509Data *x509Data `xml:"http://www.w3.org/2000/09/xmldsig# X509Data"`
+}
+
+type x509Data struct {
+	X509Certificate []x509Certificate `xml:"http://www.w3.org/2000/09/xmldsig# X509Certificate"`
+}
+
+type x509Certificate struct {
+	Data string `xml:",chardata"`
+}
+
+type singleSignOnService struct {
+	Binding  string `xml:"Binding,attr"`
+	Location string `xml:"Location,attr"`
+}
+
+// parseMetadata parses a SAML IdP metadata document and extracts the entity ID,
+// signing certificates, and SingleSignOnService endpoints.
+func parseMetadata(data []byte) (*IdPMetadata, error) {
+	var ed entityDescriptor
+	if err := xml.Unmarshal(data, &ed); err != nil {
+		return nil, fmt.Errorf("parse metadata: %v", err)
+	}
+	if ed.EntityID == "" {
+		return nil, fmt.Errorf("parse metadata: missing entityID attribute")
+	}
+	if ed.IDPSSODescriptor == nil {
+		return nil, fmt.Errorf("parse metadata: no IDPSSODescriptor found")
+	}
+
+	meta := &IdPMetadata{EntityID: ed.EntityID}
+	idp := ed.IDPSSODescriptor
+
+	for _, kd := range idp.KeyDescriptors {
+		// Encryption-only keys are irrelevant for signature verification.
+		if kd.Use == "encryption" || kd.KeyInfo == nil || kd.KeyInfo.X509Data == nil {
+			continue
+		}
+		for _, cert := range kd.KeyInfo.X509Data.X509Certificate {
+			der, err := base64.StdEncoding.DecodeString(strings.TrimSpace(cert.Data))
+			if err != nil {
+				return nil, fmt.Errorf("parse metadata: decode certificate: %v", err)
+			}
+			c, err := x509.ParseCertificate(der)
+			if err != nil {
+				return nil, fmt.Errorf("parse metadata: parse certificate: %v", err)
+			}
+			meta.SigningCerts = append(meta.SigningCerts, c)
+		}
+	}
+
+	for _, sso := range idp.SingleSignOnService {
+		meta.SSOEndpoints = append(meta.SSOEndpoints, SSOEndpoint{
+			Binding:  sso.Binding,
+			Location: sso.Location,
+		})
+	}
+
+	if len(meta.SigningCerts) == 0 && len(meta.SSOEndpoints) == 0 {
+		return nil, fmt.Errorf("parse metadata: no signing certificates or SSO endpoints found")
+	}
+	return meta, nil
+}

--- a/connector/saml/metadata.go
+++ b/connector/saml/metadata.go
@@ -89,7 +89,9 @@ func parseMetadata(data []byte) (*IdPMetadata, error) {
 			continue
 		}
 		for _, cert := range kd.KeyInfo.X509Data.X509Certificate {
-			der, err := base64.StdEncoding.DecodeString(strings.TrimSpace(cert.Data))
+			// Real-world metadata often wraps the base64 across lines with
+			// embedded whitespace; strip all of it before decoding.
+			der, err := base64.StdEncoding.DecodeString(strings.Join(strings.Fields(cert.Data), ""))
 			if err != nil {
 				return nil, fmt.Errorf("parse metadata: decode certificate: %v", err)
 			}

--- a/connector/saml/metadata_test.go
+++ b/connector/saml/metadata_test.go
@@ -20,8 +20,16 @@ func certPEMBlock(t *testing.T, pemBytes []byte) string {
 
 func metadataXML(t *testing.T, keyDescriptors, ssoServices string) string {
 	t.Helper()
+	return metadataXMLWithEntity(t, "https://idp.example.com", keyDescriptors, ssoServices)
+}
+
+// metadataXMLWithEntity builds an IdP metadata document with the given entityID,
+// key descriptors, and SSO services. The entityID matters for tests that drive
+// HandlePOST, which checks the response issuer against the discovered issuer.
+func metadataXMLWithEntity(t *testing.T, entityID, keyDescriptors, ssoServices string) string {
+	t.Helper()
 	return `<?xml version="1.0" encoding="UTF-8"?>
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://idp.example.com">
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="` + entityID + `">
   <md:IDPSSODescriptor>` + keyDescriptors + ssoServices + `
   </md:IDPSSODescriptor>
 </md:EntityDescriptor>`
@@ -105,6 +113,25 @@ func TestParseMetadataErrors(t *testing.T) {
 				t.Error("expected an error")
 			}
 		})
+	}
+}
+
+func TestParseMetadataWrappedBase64Cert(t *testing.T) {
+	// Real-world metadata wraps the base64 certificate across lines with
+	// embedded newlines and indentation. All whitespace must be stripped
+	// before decoding.
+	cert := certPEMBlock(t, mustReadFile(t, "testdata/ca.crt"))
+	wrapped := cert[:20] + "\n  " + cert[20:50] + "\n  " + cert[50:]
+	xml := metadataXML(t,
+		`<md:KeyDescriptor use="signing"><ds:KeyInfo><ds:X509Data><ds:X509Certificate>`+wrapped+`</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>`,
+		`<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.example.com/sso"/>`)
+
+	meta, err := parseMetadata([]byte(xml))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(meta.SigningCerts) != 1 {
+		t.Fatalf("expected 1 signing cert, got %d", len(meta.SigningCerts))
 	}
 }
 

--- a/connector/saml/metadata_test.go
+++ b/connector/saml/metadata_test.go
@@ -1,0 +1,118 @@
+package saml
+
+import (
+	"encoding/base64"
+	"encoding/pem"
+	"os"
+	"testing"
+)
+
+// certPEMBlock returns the base64-DER form of the first PEM block in pemBytes,
+// as it appears inside a SAML metadata <ds:X509Certificate> element.
+func certPEMBlock(t *testing.T, pemBytes []byte) string {
+	t.Helper()
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		t.Fatal("no PEM block found")
+	}
+	return base64.StdEncoding.EncodeToString(block.Bytes)
+}
+
+func metadataXML(t *testing.T, keyDescriptors, ssoServices string) string {
+	t.Helper()
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://idp.example.com">
+  <md:IDPSSODescriptor>` + keyDescriptors + ssoServices + `
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>`
+}
+
+func TestParseMetadata(t *testing.T) {
+	cert := certPEMBlock(t, mustReadFile(t, "testdata/ca.crt"))
+	xml := metadataXML(t,
+		`<md:KeyDescriptor use="signing"><ds:KeyInfo><ds:X509Data><ds:X509Certificate>`+cert+`</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>`+
+			`<md:KeyDescriptor use="encryption"><ds:KeyInfo><ds:X509Data><ds:X509Certificate>`+cert+`</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>`,
+		`<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.example.com/sso/redirect"/>`+
+			`<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.example.com/sso/post"/>`)
+
+	meta, err := parseMetadata([]byte(xml))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.EntityID != "https://idp.example.com" {
+		t.Errorf("expected entityID, got %q", meta.EntityID)
+	}
+	if len(meta.SigningCerts) != 1 {
+		t.Fatalf("expected 1 signing cert (encryption key excluded), got %d", len(meta.SigningCerts))
+	}
+	if len(meta.SSOEndpoints) != 2 {
+		t.Fatalf("expected 2 SSO endpoints, got %d", len(meta.SSOEndpoints))
+	}
+	if meta.SSOEndpoints[0].Binding != "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" {
+		t.Errorf("expected first endpoint to be HTTP-Redirect, got %q", meta.SSOEndpoints[0].Binding)
+	}
+	if url, ok := meta.ssoEndpoint(bindingPOST); !ok || url != "https://idp.example.com/sso/post" {
+		t.Errorf("expected ssoEndpoint(POST) to find the POST location, got %q ok=%v", url, ok)
+	}
+	if url, ok := meta.ssoEndpoint(bindingRedirect); !ok || url != "https://idp.example.com/sso/redirect" {
+		t.Errorf("expected ssoEndpoint(Redirect) to find the redirect location, got %q ok=%v", url, ok)
+	}
+}
+
+func TestParseMetadataKeyDescriptorWithoutUse(t *testing.T) {
+	cert := certPEMBlock(t, mustReadFile(t, "testdata/ca.crt"))
+	xml := metadataXML(t,
+		`<md:KeyDescriptor><ds:KeyInfo><ds:X509Data><ds:X509Certificate>`+cert+`</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>`,
+		`<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.example.com/sso"/>`)
+
+	meta, err := parseMetadata([]byte(xml))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A KeyDescriptor without a use attribute counts as signing per the spec.
+	if len(meta.SigningCerts) != 1 {
+		t.Fatalf("expected 1 signing cert, got %d", len(meta.SigningCerts))
+	}
+}
+
+func TestParseMetadataErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		xml  string
+	}{
+		{
+			name: "malformed XML",
+			xml:  `<md:EntityDescriptor`,
+		},
+		{
+			name: "no IDPSSODescriptor",
+			xml:  `<?xml version="1.0"?><md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="x"/>`,
+		},
+		{
+			name: "no signing certs or SSO endpoints",
+			xml:  metadataXML(t, "", ""),
+		},
+		{
+			name: "bad base64 cert",
+			xml: metadataXML(t,
+				`<md:KeyDescriptor use="signing"><ds:KeyInfo><ds:X509Data><ds:X509Certificate>not!base64</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>`,
+				`<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.example.com/sso"/>`),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseMetadata([]byte(tc.xml)); err == nil {
+				t.Error("expected an error")
+			}
+		})
+	}
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}

--- a/connector/saml/saml.go
+++ b/connector/saml/saml.go
@@ -878,7 +878,7 @@ func (p *provider) refresh() error {
 
 // Start implements connector.LifecycleConnector. It performs an immediate
 // metadata fetch and then polls on MetadataRefreshInterval until Close is
-// called or ctx is cancelled. The first fetch is critical: when it fails and
+// called or ctx is canceled. The first fetch is critical: when it fails and
 // no manual certificates are configured, Start returns an error.
 func (p *provider) Start(ctx context.Context) error {
 	if p.metadataURL == "" {

--- a/connector/saml/saml.go
+++ b/connector/saml/saml.go
@@ -807,37 +807,41 @@ func after(now, notOnOrAfter time.Time) bool {
 
 // applyMetadata merges discovered IdP metadata into the provider state. Manually
 // configured values always win; discovered values only fill unset fields. The
-// validator uses the union of manual and discovered signing certs.
+// validator uses the union of manual and discovered signing certs. The new state
+// is only written once all checks pass, so a failed merge leaves the last known
+// state fully intact.
 func (p *provider) applyMetadata(meta *IdPMetadata) error {
 	certs := append([]*x509.Certificate(nil), p.manualCerts...)
 	certs = append(certs, meta.SigningCerts...)
 
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	newState := providerState{}
 
 	if !p.insecureSkipSigValidation {
 		if len(certs) == 0 {
 			return fmt.Errorf("saml: no signing certificates available from metadata")
 		}
-		p.state.validator = dsig.NewDefaultValidationContext(certStore{certs})
+		newState.validator = dsig.NewDefaultValidationContext(certStore{certs})
 	}
 
 	if p.manualSSOURL != "" {
-		p.state.ssoURL = p.manualSSOURL
+		newState.ssoURL = p.manualSSOURL
 	} else if url, ok := meta.ssoEndpoint(bindingPOST); ok && url != "" {
-		p.state.ssoURL = url
+		newState.ssoURL = url
 	} else if url, ok := meta.ssoEndpoint(bindingRedirect); ok && url != "" {
-		p.state.ssoURL = url
+		newState.ssoURL = url
 	} else {
 		return fmt.Errorf("saml: no SSO endpoint in metadata and ssoURL is not set")
 	}
 
 	if p.manualSSOIssuer != "" {
-		p.state.ssoIssuer = p.manualSSOIssuer
+		newState.ssoIssuer = p.manualSSOIssuer
 	} else if meta.EntityID != "" {
-		p.state.ssoIssuer = meta.EntityID
+		newState.ssoIssuer = meta.EntityID
 	}
 
+	p.mu.Lock()
+	p.state = newState
+	p.mu.Unlock()
 	return nil
 }
 

--- a/connector/saml/saml.go
+++ b/connector/saml/saml.go
@@ -11,6 +11,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -166,10 +167,12 @@ func (c *Config) openConnector(logger *slog.Logger) (*provider, error) {
 	requiredFields := []struct {
 		name, val string
 	}{
-		{"ssoURL", c.SSOURL},
 		{"usernameAttr", c.UsernameAttr},
 		{"emailAttr", c.EmailAttr},
 		{"redirectURI", c.RedirectURI},
+	}
+	if c.MetadataURL == "" {
+		requiredFields = append(requiredFields, struct{ name, val string }{"ssoURL", c.SSOURL})
 	}
 	var missing []string
 	for _, f := range requiredFields {
@@ -186,20 +189,32 @@ func (c *Config) openConnector(logger *slog.Logger) (*provider, error) {
 	}
 
 	p := &provider{
-		entityIssuer:  c.EntityIssuer,
-		ssoIssuer:     c.SSOIssuer,
-		ssoURL:        c.SSOURL,
-		now:           time.Now,
-		usernameAttr:  c.UsernameAttr,
-		emailAttr:     c.EmailAttr,
-		groupsAttr:    c.GroupsAttr,
-		groupsDelim:   c.GroupsDelim,
-		allowedGroups: c.AllowedGroups,
-		filterGroups:  c.FilterGroups,
-		redirectURI:   c.RedirectURI,
-		logger:        logger,
+		manualSSOURL:              c.SSOURL,
+		manualSSOIssuer:           c.SSOIssuer,
+		insecureSkipSigValidation: c.InsecureSkipSignatureValidation,
+		entityIssuer:              c.EntityIssuer,
+		now:                       time.Now,
+		usernameAttr:              c.UsernameAttr,
+		emailAttr:                 c.EmailAttr,
+		groupsAttr:                c.GroupsAttr,
+		groupsDelim:               c.GroupsDelim,
+		allowedGroups:             c.AllowedGroups,
+		filterGroups:              c.FilterGroups,
+		redirectURI:               c.RedirectURI,
+		logger:                    logger,
 
 		nameIDPolicyFormat: c.NameIDPolicyFormat,
+	}
+	p.state.ssoURL = c.SSOURL
+	p.state.ssoIssuer = c.SSOIssuer
+
+	if c.MetadataURL != "" {
+		p.metadataURL = c.MetadataURL
+		p.refreshInterval = value(time.Duration(c.MetadataRefreshInterval), time.Hour)
+		if p.refreshInterval < time.Minute {
+			return nil, fmt.Errorf("metadataRefreshInterval must be at least 1 minute")
+		}
+		p.httpClient = &http.Client{Timeout: 10 * time.Second}
 	}
 
 	if p.nameIDPolicyFormat == "" {
@@ -226,10 +241,6 @@ func (c *Config) openConnector(logger *slog.Logger) (*provider, error) {
 	}
 
 	if !c.InsecureSkipSignatureValidation {
-		if (c.CA == "") == (c.CAData == nil) {
-			return nil, errors.New("must provide either 'ca' or 'caData'")
-		}
-
 		var caData []byte
 		if c.CA != "" {
 			data, err := os.ReadFile(c.CA)
@@ -237,35 +248,52 @@ func (c *Config) openConnector(logger *slog.Logger) (*provider, error) {
 				return nil, fmt.Errorf("read ca file: %v", err)
 			}
 			caData = data
-		} else {
+		} else if c.CAData != nil {
 			caData = c.CAData
 		}
 
-		var (
-			certs []*x509.Certificate
-			block *pem.Block
-		)
-		for {
-			block, caData = pem.Decode(caData)
-			if block == nil {
-				caData = bytes.TrimSpace(caData)
-				if len(caData) > 0 { // if there's some left, we've been given bad caData
-					return nil, fmt.Errorf("parse cert: trailing data: %q", string(caData))
-				}
-				break
-			}
-			cert, err := x509.ParseCertificate(block.Bytes)
-			if err != nil {
-				return nil, fmt.Errorf("parse cert: %v", err)
-			}
-			certs = append(certs, cert)
+		certs, err := parsePEMCerts(caData)
+		if err != nil {
+			return nil, err
 		}
-		if len(certs) == 0 {
-			return nil, errors.New("no certificates found in ca data")
+		if c.MetadataURL == "" && len(certs) == 0 {
+			return nil, errors.New("must provide either 'ca' or 'caData'")
 		}
-		p.validator = dsig.NewDefaultValidationContext(certStore{certs})
+		p.manualCerts = certs
+		if len(certs) > 0 {
+			p.state.validator = dsig.NewDefaultValidationContext(certStore{certs})
+		}
 	}
 	return p, nil
+}
+
+// parsePEMCerts decodes every PEM certificate in data.
+func parsePEMCerts(data []byte) ([]*x509.Certificate, error) {
+	var certs []*x509.Certificate
+	var block *pem.Block
+	for {
+		block, data = pem.Decode(data)
+		if block == nil {
+			data = bytes.TrimSpace(data)
+			if len(data) > 0 { // if there's some left, we've been given bad data
+				return nil, fmt.Errorf("parse cert: trailing data: %q", string(data))
+			}
+			break
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse cert: %v", err)
+		}
+		certs = append(certs, cert)
+	}
+	return certs, nil
+}
+
+func value(val, defaultValue time.Duration) time.Duration {
+	if val == 0 {
+		return defaultValue
+	}
+	return val
 }
 
 var (
@@ -275,13 +303,15 @@ var (
 
 type provider struct {
 	entityIssuer string
-	ssoIssuer    string
-	ssoURL       string
+
+	// Manually configured values. These always win over discovered metadata
+	// values. ssoURL/issuer may be empty when metadata discovery is enabled.
+	manualSSOURL              string
+	manualSSOIssuer           string
+	manualCerts               []*x509.Certificate
+	insecureSkipSigValidation bool
 
 	now func() time.Time
-
-	// If nil, don't do signature validation.
-	validator *dsig.ValidationContext
 
 	// Attribute mappings
 	usernameAttr  string
@@ -295,7 +325,30 @@ type provider struct {
 
 	nameIDPolicyFormat string
 
+	// Metadata discovery configuration.
+	metadataURL     string
+	refreshInterval time.Duration
+	httpClient      *http.Client
+
+	// mu guards state.
+	mu    sync.RWMutex
+	state providerState
+
 	logger *slog.Logger
+}
+
+// providerState is the set of values the SAML request/response paths read. It is
+// swapped atomically when metadata is refreshed.
+type providerState struct {
+	validator *dsig.ValidationContext
+	ssoURL    string
+	ssoIssuer string
+}
+
+func (p *provider) stateSnapshot() providerState {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.state
 }
 
 // cachedIdentity stores the identity from SAML assertion for refresh token support.
@@ -329,11 +382,12 @@ func marshalCachedIdentity(ident connector.Identity) (connector.Identity, error)
 }
 
 func (p *provider) POSTData(s connector.Scopes, id string) (action, value string, err error) {
+	st := p.stateSnapshot()
 	r := &authnRequest{
 		ProtocolBinding: bindingPOST,
 		ID:              id,
 		IssueInstant:    xmlTime(p.now()),
-		Destination:     p.ssoURL,
+		Destination:     st.ssoURL,
 		NameIDPolicy: &nameIDPolicy{
 			AllowCreate: true,
 			Format:      p.nameIDPolicyFormat,
@@ -353,7 +407,7 @@ func (p *provider) POSTData(s connector.Scopes, id string) (action, value string
 
 	// See: https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf
 	// "3.5.4 Message Encoding"
-	return p.ssoURL, base64.StdEncoding.EncodeToString(data), nil
+	return st.ssoURL, base64.StdEncoding.EncodeToString(data), nil
 }
 
 // HandlePOST interprets a request from a SAML provider attempting to verify a
@@ -366,6 +420,7 @@ func (p *provider) POSTData(s connector.Scopes, id string) (action, value string
 // * Verify various parts of the Assertion element. Conditions, audience, etc.
 // * Map the Assertion's attribute elements to user info.
 func (p *provider) HandlePOST(s connector.Scopes, samlResponse, inResponseTo string) (ident connector.Identity, err error) {
+	st := p.stateSnapshot()
 	rawResp, err := base64.StdEncoding.DecodeString(samlResponse)
 	if err != nil {
 		return ident, fmt.Errorf("decode response: %v", err)
@@ -378,8 +433,8 @@ func (p *provider) HandlePOST(s connector.Scopes, samlResponse, inResponseTo str
 
 	// Root element is allowed to not be signed if the Assertion element is.
 	rootElementSigned := true
-	if p.validator != nil {
-		rawResp, rootElementSigned, err = verifyResponseSig(p.validator, rawResp)
+	if st.validator != nil {
+		rawResp, rootElementSigned, err = verifyResponseSig(st.validator, rawResp)
 		if err != nil {
 			return ident, fmt.Errorf("verify signature: %v", err)
 		}
@@ -393,8 +448,8 @@ func (p *provider) HandlePOST(s connector.Scopes, samlResponse, inResponseTo str
 	// If the root element isn't signed, there's no reason to inspect these
 	// elements. They're not verified.
 	if rootElementSigned {
-		if p.ssoIssuer != "" && resp.Issuer != nil && resp.Issuer.Issuer != p.ssoIssuer {
-			return ident, fmt.Errorf("expected Issuer value %s, got %s", p.ssoIssuer, resp.Issuer.Issuer)
+		if st.ssoIssuer != "" && resp.Issuer != nil && resp.Issuer.Issuer != st.ssoIssuer {
+			return ident, fmt.Errorf("expected Issuer value %s, got %s", st.ssoIssuer, resp.Issuer.Issuer)
 		}
 
 		// Verify InResponseTo value matches the expected ID associated with
@@ -746,4 +801,40 @@ func before(now, notBefore time.Time) bool {
 // allowed clock drift.
 func after(now, notOnOrAfter time.Time) bool {
 	return now.After(notOnOrAfter.Add(allowedClockDrift))
+}
+
+// applyMetadata merges discovered IdP metadata into the provider state. Manually
+// configured values always win; discovered values only fill unset fields. The
+// validator uses the union of manual and discovered signing certs.
+func (p *provider) applyMetadata(meta *IdPMetadata) error {
+	certs := append([]*x509.Certificate(nil), p.manualCerts...)
+	certs = append(certs, meta.SigningCerts...)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.insecureSkipSigValidation {
+		if len(certs) == 0 {
+			return fmt.Errorf("saml: no signing certificates available from metadata")
+		}
+		p.state.validator = dsig.NewDefaultValidationContext(certStore{certs})
+	}
+
+	if p.manualSSOURL != "" {
+		p.state.ssoURL = p.manualSSOURL
+	} else if url, ok := meta.ssoEndpoint(bindingPOST); ok && url != "" {
+		p.state.ssoURL = url
+	} else if url, ok := meta.ssoEndpoint(bindingRedirect); ok && url != "" {
+		p.state.ssoURL = url
+	} else {
+		return fmt.Errorf("saml: no SSO endpoint in metadata and ssoURL is not set")
+	}
+
+	if p.manualSSOIssuer != "" {
+		p.state.ssoIssuer = p.manualSSOIssuer
+	} else if meta.EntityID != "" {
+		p.state.ssoIssuer = meta.EntityID
+	}
+
+	return nil
 }

--- a/connector/saml/saml.go
+++ b/connector/saml/saml.go
@@ -10,6 +10,7 @@ import (
 	"encoding/pem"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -329,6 +330,7 @@ type provider struct {
 	metadataURL     string
 	refreshInterval time.Duration
 	httpClient      *http.Client
+	cancel          context.CancelFunc
 
 	// mu guards state.
 	mu    sync.RWMutex
@@ -837,4 +839,86 @@ func (p *provider) applyMetadata(meta *IdPMetadata) error {
 	}
 
 	return nil
+}
+
+// fetchMetadata retrieves the IdP metadata document from the metadata URL.
+func (p *provider) fetchMetadata() ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, p.metadataURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("saml: build metadata request: %v", err)
+	}
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("saml: fetch metadata: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("saml: fetch metadata: unexpected status %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("saml: read metadata: %v", err)
+	}
+	return data, nil
+}
+
+// refresh fetches and applies the latest IdP metadata.
+func (p *provider) refresh() error {
+	data, err := p.fetchMetadata()
+	if err != nil {
+		return err
+	}
+	meta, err := parseMetadata(data)
+	if err != nil {
+		return err
+	}
+	return p.applyMetadata(meta)
+}
+
+// Start implements connector.LifecycleConnector. It performs an immediate
+// metadata fetch and then polls on MetadataRefreshInterval until Close is
+// called or ctx is cancelled. The first fetch is critical: when it fails and
+// no manual certificates are configured, Start returns an error.
+func (p *provider) Start(ctx context.Context) error {
+	if p.metadataURL == "" {
+		return nil
+	}
+
+	if err := p.refresh(); err != nil {
+		if len(p.manualCerts) > 0 || p.insecureSkipSigValidation {
+			p.logger.Warn("failed to fetch SAML metadata; using manual configuration", "err", err)
+		} else {
+			return fmt.Errorf("saml: failed to fetch metadata: %v", err)
+		}
+	}
+
+	pollCtx, cancel := context.WithCancel(ctx)
+	p.cancel = cancel
+	go func() {
+		defer cancel()
+		ticker := time.NewTicker(p.refreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-pollCtx.Done():
+				return
+			case <-ticker.C:
+				if err := p.refresh(); err != nil {
+					p.logger.Warn("failed to refresh SAML metadata; keeping last known configuration", "err", err)
+					continue
+				}
+				p.logger.Info("refreshed SAML metadata")
+			}
+		}
+	}()
+	return nil
+}
+
+// Close stops the metadata polling goroutine, if any.
+func (p *provider) Close() {
+	if p.cancel != nil {
+		p.cancel()
+		p.cancel = nil
+	}
 }

--- a/connector/saml/saml.go
+++ b/connector/saml/saml.go
@@ -67,6 +67,31 @@ var (
 	lookupOnce sync.Once
 )
 
+// duration is a JSON duration string (e.g. "1h", "30m"). It exists so
+// connector configs can express refresh intervals the same way the server
+// config does.
+type duration time.Duration
+
+// UnmarshalJSON accepts a Go duration string.
+func (d *duration) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return fmt.Errorf("parse duration: %v", err)
+	}
+	v, err := time.ParseDuration(s)
+	if err != nil {
+		return fmt.Errorf("parse duration %q: %v", s, err)
+	}
+	*d = duration(v)
+	return nil
+}
+
+// MarshalJSON serializes the duration as a string so config round-trips
+// (yaml -> json -> storage -> json) keep a stable representation.
+func (d duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).String())
+}
+
 // Config represents configuration options for the SAML provider.
 type Config struct {
 	// TODO(ericchiang): A bunch of these fields could be auto-filled if
@@ -95,6 +120,17 @@ type Config struct {
 	AllowedGroups []string `json:"allowedGroups"`
 	FilterGroups  bool     `json:"filterGroups"`
 	RedirectURI   string   `json:"redirectURI"`
+
+	// MetadataURL is the URL of the IdP's SAML metadata. When set, dex fetches
+	// and polls this URL to auto-discover the IdP's SSO endpoint(s), issuer,
+	// and signing certificates. Fields explicitly set in the config (ssoURL,
+	// ssoIssuer, entityIssuer, ca/caData) take precedence over discovered
+	// values. Discovered values only fill in what is not explicitly set.
+	MetadataURL string `json:"metadataURL"`
+
+	// MetadataRefreshInterval is how often dex re-fetches MetadataURL.
+	// Defaults to 1 hour. Must be >= 1 minute if set.
+	MetadataRefreshInterval duration `json:"metadataRefreshInterval"`
 
 	// Requested format of the NameID. The NameID value is is mapped to the ID Token
 	// 'sub' claim.

--- a/connector/saml/saml_test.go
+++ b/connector/saml/saml_test.go
@@ -952,3 +952,150 @@ func TestSAMLRefresh(t *testing.T) {
 		}
 	})
 }
+
+func TestApplyMetadataFillsUnsetFields(t *testing.T) {
+	p := &provider{
+		manualSSOURL:    "https://manual.example.com/sso",
+		manualSSOIssuer: "",
+		manualCerts:     nil,
+		logger:          slog.New(slog.DiscardHandler),
+	}
+	ca, err := os.ReadFile("testdata/ca.crt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, _ := pem.Decode(ca)
+	if block == nil {
+		t.Fatal("no PEM block")
+	}
+	discCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	meta := &IdPMetadata{
+		EntityID: "https://idp.example.com",
+		SSOEndpoints: []SSOEndpoint{
+			{Binding: bindingRedirect, Location: "https://idp.example.com/sso/redirect"},
+			{Binding: bindingPOST, Location: "https://idp.example.com/sso/post"},
+		},
+		SigningCerts: []*x509.Certificate{discCert},
+	}
+
+	if err := p.applyMetadata(meta); err != nil {
+		t.Fatal(err)
+	}
+
+	st := p.stateSnapshot()
+	// Explicitly set ssoURL wins over discovered endpoint.
+	if st.ssoURL != "https://manual.example.com/sso" {
+		t.Errorf("expected manual ssoURL to win, got %q", st.ssoURL)
+	}
+	// Unset ssoIssuer is filled from the discovered entityID.
+	if st.ssoIssuer != "https://idp.example.com" {
+		t.Errorf("expected discovered entityID as ssoIssuer, got %q", st.ssoIssuer)
+	}
+	// Discovered certs are used for validation.
+	if st.validator == nil {
+		t.Fatal("expected a validation context")
+	}
+	if got, _ := st.validator.CertificateStore.Certificates(); len(got) != 1 {
+		t.Errorf("expected 1 cert in validator, got %d", len(got))
+	}
+}
+
+func TestApplyMetadataDiscoverSSOURL(t *testing.T) {
+	p := &provider{logger: slog.New(slog.DiscardHandler), insecureSkipSigValidation: true}
+	meta := &IdPMetadata{
+		EntityID: "https://idp.example.com",
+		SSOEndpoints: []SSOEndpoint{
+			{Binding: bindingRedirect, Location: "https://idp.example.com/sso/redirect"},
+			{Binding: bindingPOST, Location: "https://idp.example.com/sso/post"},
+		},
+		SigningCerts: []*x509.Certificate{},
+	}
+	if err := p.applyMetadata(meta); err != nil {
+		t.Fatal(err)
+	}
+	// With no manual ssoURL, the POST endpoint is preferred.
+	if got := p.stateSnapshot().ssoURL; got != "https://idp.example.com/sso/post" {
+		t.Errorf("expected discovered POST ssoURL, got %q", got)
+	}
+}
+
+func TestApplyMetadataNoSSOEndpoint(t *testing.T) {
+	p := &provider{logger: slog.New(slog.DiscardHandler), insecureSkipSigValidation: true}
+	meta := &IdPMetadata{EntityID: "https://idp.example.com", SigningCerts: []*x509.Certificate{}}
+	if err := p.applyMetadata(meta); err == nil {
+		t.Error("expected an error when no SSO endpoint exists and ssoURL is not set")
+	}
+}
+
+func TestConfigValidationWithMetadataURL(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	t.Run("metadataURL makes ssoURL optional", func(t *testing.T) {
+		// No ssoURL and no ca/caData: allowed because metadata supplies both.
+		c := Config{
+			UsernameAttr: "Name",
+			EmailAttr:    "email",
+			RedirectURI:  "http://127.0.0.1:5556/dex/callback",
+			MetadataURL:  "https://idp.example.com/metadata",
+		}
+		if _, err := c.openConnector(logger); err != nil {
+			t.Fatalf("expected connector to open without ssoURL when metadataURL is set: %v", err)
+		}
+	})
+
+	t.Run("no metadataURL keeps old requirements", func(t *testing.T) {
+		c := Config{
+			UsernameAttr: "Name",
+			EmailAttr:    "email",
+			RedirectURI:  "http://127.0.0.1:5556/dex/callback",
+		}
+		if _, err := c.openConnector(logger); err == nil {
+			t.Fatal("expected error for missing ssoURL when metadataURL is unset")
+		}
+	})
+
+	t.Run("no metadataURL requires ca", func(t *testing.T) {
+		c := Config{
+			UsernameAttr: "Name",
+			EmailAttr:    "email",
+			RedirectURI:  "http://127.0.0.1:5556/dex/callback",
+			SSOURL:       "http://foo.bar/",
+		}
+		if _, err := c.openConnector(logger); err == nil {
+			t.Fatal("expected error for missing ca/caData when metadataURL is unset")
+		}
+	})
+
+	t.Run("metadataURL with explicit ca still works", func(t *testing.T) {
+		c := Config{
+			CA:           "testdata/ca.crt",
+			UsernameAttr: "Name",
+			EmailAttr:    "email",
+			RedirectURI:  "http://127.0.0.1:5556/dex/callback",
+			SSOURL:       "http://foo.bar/",
+			MetadataURL:  "https://idp.example.com/metadata",
+		}
+		if _, err := c.openConnector(logger); err != nil {
+			t.Fatalf("expected connector to open: %v", err)
+		}
+	})
+
+	t.Run("sub-minute refresh interval rejected", func(t *testing.T) {
+		c := Config{
+			CA:                      "testdata/ca.crt",
+			UsernameAttr:            "Name",
+			EmailAttr:               "email",
+			RedirectURI:             "http://127.0.0.1:5556/dex/callback",
+			SSOURL:                  "http://foo.bar/",
+			MetadataURL:             "https://idp.example.com/metadata",
+			MetadataRefreshInterval: duration(30 * time.Second),
+		}
+		if _, err := c.openConnector(logger); err == nil {
+			t.Fatal("expected error for sub-minute refresh interval")
+		}
+	})
+}

--- a/connector/saml/saml_test.go
+++ b/connector/saml/saml_test.go
@@ -473,6 +473,42 @@ func (r responseTest) run(t *testing.T) {
 	}
 }
 
+func TestConfigMetadataFields(t *testing.T) {
+	cfg := Config{}
+	if err := json.Unmarshal([]byte(`{"metadataURL":"https://idp.example.com/metadata","metadataRefreshInterval":"30m"}`), &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.MetadataURL != "https://idp.example.com/metadata" {
+		t.Errorf("expected metadataURL to be parsed, got %q", cfg.MetadataURL)
+	}
+	if time.Duration(cfg.MetadataRefreshInterval) != 30*time.Minute {
+		t.Errorf("expected 30m refresh interval, got %v", time.Duration(cfg.MetadataRefreshInterval))
+	}
+}
+
+func TestMetadataRefreshIntervalRoundTrip(t *testing.T) {
+	cfg := Config{MetadataRefreshInterval: duration(90 * time.Minute)}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got Config
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if time.Duration(got.MetadataRefreshInterval) != 90*time.Minute {
+		t.Errorf("expected round-trip to preserve 90m, got %v", time.Duration(got.MetadataRefreshInterval))
+	}
+}
+
+func TestMetadataRefreshIntervalInvalid(t *testing.T) {
+	cfg := Config{}
+	err := json.Unmarshal([]byte(`{"metadataRefreshInterval":"nope"}`), &cfg)
+	if err == nil {
+		t.Error("expected an error for an invalid duration string")
+	}
+}
+
 func TestConfigCAData(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	validPEM, err := os.ReadFile("testdata/ca.crt")

--- a/connector/saml/saml_test.go
+++ b/connector/saml/saml_test.go
@@ -8,8 +8,11 @@ import (
 	"encoding/pem"
 	"errors"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"sort"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1098,4 +1101,191 @@ func TestConfigValidationWithMetadataURL(t *testing.T) {
 			t.Fatal("expected error for sub-minute refresh interval")
 		}
 	})
+}
+
+func TestMetadataPollerRefreshesCerts(t *testing.T) {
+	ca, err := os.ReadFile("testdata/ca.crt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	caBlock, _ := pem.Decode(ca)
+	if caBlock == nil {
+		t.Fatal("no PEM block")
+	}
+
+	keyDescriptor := func(certPEM []byte) string {
+		block, _ := pem.Decode(certPEM)
+		if block == nil {
+			t.Fatal("no PEM block")
+		}
+		return `<md:KeyDescriptor use="signing"><ds:KeyInfo><ds:X509Data><ds:X509Certificate>` +
+			base64.StdEncoding.EncodeToString(block.Bytes) +
+			`</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>`
+	}
+	ssoServices := `<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.example.com/sso"/>`
+
+	var current atomic.Value
+	current.Store([]byte(metadataXML(t, keyDescriptor(ca), ssoServices)))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(current.Load().([]byte))
+	}))
+	defer srv.Close()
+
+	c := Config{
+		UsernameAttr: "Name",
+		EmailAttr:    "email",
+		RedirectURI:  "http://127.0.0.1:5556/dex/callback",
+		MetadataURL:  srv.URL,
+	}
+	conn, err := c.openConnector(slog.New(slog.DiscardHandler))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := conn
+	// Override the validated interval so the test runs quickly. Production
+	// validation (>= 1 minute) is exercised by TestConfigValidationWithMetadataURL.
+	p.refreshInterval = 50 * time.Millisecond
+
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	signingCerts := func() int {
+		st := p.stateSnapshot()
+		if st.validator == nil {
+			return 0
+		}
+		certs, _ := st.validator.CertificateStore.Certificates()
+		return len(certs)
+	}
+
+	// Initial fetch populated the validator.
+	if n := signingCerts(); n != 1 {
+		t.Fatalf("expected 1 cert after initial fetch, got %d", n)
+	}
+
+	// Rotate: serve the second CA cert alongside the first.
+	okta, err := os.ReadFile("testdata/okta-ca.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.Store([]byte(metadataXML(t, keyDescriptor(ca)+keyDescriptor(okta), ssoServices)))
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if signingCerts() == 2 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("expected poller to pick up the second certificate within 5s")
+}
+
+func TestMetadataPollerKeepsLastStateOnFailure(t *testing.T) {
+	ca, err := os.ReadFile("testdata/ca.crt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	caBlock, _ := pem.Decode(ca)
+	if caBlock == nil {
+		t.Fatal("no PEM block")
+	}
+	metaXML := metadataXML(t,
+		`<md:KeyDescriptor use="signing"><ds:KeyInfo><ds:X509Data><ds:X509Certificate>`+
+			base64.StdEncoding.EncodeToString(caBlock.Bytes)+
+			`</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>`,
+		`<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.example.com/sso"/>`)
+
+	var fail atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fail.Load() {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(metaXML))
+	}))
+	defer srv.Close()
+
+	c := Config{
+		UsernameAttr: "Name",
+		EmailAttr:    "email",
+		RedirectURI:  "http://127.0.0.1:5556/dex/callback",
+		MetadataURL:  srv.URL,
+	}
+	conn, err := c.openConnector(slog.New(slog.DiscardHandler))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := conn
+	p.refreshInterval = 50 * time.Millisecond
+
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	storeCerts := func() int {
+		certs, _ := p.stateSnapshot().validator.CertificateStore.Certificates()
+		return len(certs)
+	}
+
+	if got := storeCerts(); got != 1 {
+		t.Fatalf("expected 1 cert, got %d", got)
+	}
+
+	// Subsequent polls fail; the last known validator must be kept.
+	fail.Store(true)
+	time.Sleep(200 * time.Millisecond)
+	if got := storeCerts(); got != 1 {
+		t.Fatalf("expected last known cert to be retained, got %d", got)
+	}
+}
+
+func TestMetadataPollerFirstFetchFailsWithoutFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := Config{
+		UsernameAttr: "Name",
+		EmailAttr:    "email",
+		RedirectURI:  "http://127.0.0.1:5556/dex/callback",
+		MetadataURL:  srv.URL,
+	}
+	conn, err := c.openConnector(slog.New(slog.DiscardHandler))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := conn
+	if err := p.Start(context.Background()); err == nil {
+		t.Fatal("expected Start to fail when the first fetch fails without manual certs")
+	}
+	p.Close()
+}
+
+func TestMetadataPollerFirstFetchFailsWithManualFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := Config{
+		CA:           "testdata/ca.crt",
+		UsernameAttr: "Name",
+		EmailAttr:    "email",
+		RedirectURI:  "http://127.0.0.1:5556/dex/callback",
+		SSOURL:       "http://foo.bar/",
+		MetadataURL:  srv.URL,
+	}
+	conn, err := c.openConnector(slog.New(slog.DiscardHandler))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := conn
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("expected Start to tolerate a failing first fetch when manual certs exist: %v", err)
+	}
+	p.Close()
 }

--- a/connector/saml/saml_test.go
+++ b/connector/saml/saml_test.go
@@ -1242,6 +1242,154 @@ func TestMetadataPollerKeepsLastStateOnFailure(t *testing.T) {
 	}
 }
 
+// TestMetadataPollerHandlesKeyRotation verifies the feature's core promise: a
+// login signed by the original IdP key keeps working, and after the IdP rotates
+// to a new key (published alongside the old one in its metadata), a login signed
+// by the new key is accepted too.
+func TestMetadataPollerHandlesKeyRotation(t *testing.T) {
+	ca, err := os.ReadFile("testdata/ca.crt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	okta, err := os.ReadFile("testdata/okta-ca.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keyDescriptor := func(certPEM []byte) string {
+		block, _ := pem.Decode(certPEM)
+		if block == nil {
+			t.Fatal("no PEM block")
+		}
+		return `<md:KeyDescriptor use="signing"><ds:KeyInfo><ds:X509Data><ds:X509Certificate>` +
+			base64.StdEncoding.EncodeToString(block.Bytes) +
+			`</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>`
+	}
+	ssoServices := `<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.example.com/sso"/>`
+	// Both test responses carry this issuer, so the discovered entityID must
+	// match it for the HandlePOST issuer check to pass.
+	entityID := "http://www.okta.com/exk91cb99lKkKSYoy0h7"
+
+	var current atomic.Value
+	current.Store([]byte(metadataXMLWithEntity(t, entityID, keyDescriptor(ca), ssoServices)))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(current.Load().([]byte))
+	}))
+	defer srv.Close()
+
+	c := Config{
+		UsernameAttr: "Name",
+		EmailAttr:    "email",
+		RedirectURI:  "http://127.0.0.1:5556/dex/callback",
+		MetadataURL:  srv.URL,
+	}
+	conn, err := c.openConnector(slog.New(slog.DiscardHandler))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := conn
+	p.refreshInterval = 50 * time.Millisecond
+
+	now, err := time.Parse(timeFormat, "2017-04-04T04:34:59.330Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.now = func() time.Time { return now }
+
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	signingCerts := func() int {
+		st := p.stateSnapshot()
+		if st.validator == nil {
+			return 0
+		}
+		certs, _ := st.validator.CertificateStore.Certificates()
+		return len(certs)
+	}
+
+	scopes := connector.Scopes{Groups: true}
+	handle := func(respFile string) error {
+		resp, err := os.ReadFile(respFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = p.HandlePOST(scopes, base64.StdEncoding.EncodeToString(resp), "6zmm5mguyebwvajyf2sdwwcw6m")
+		return err
+	}
+
+	// Login signed by the original key succeeds.
+	if err := handle("testdata/good-resp.xml"); err != nil {
+		t.Fatalf("login signed by original key failed: %v", err)
+	}
+
+	// Rotate: the IdP publishes its new key alongside the old one.
+	current.Store([]byte(metadataXMLWithEntity(t, entityID, keyDescriptor(ca)+keyDescriptor(okta), ssoServices)))
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if signingCerts() == 2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if n := signingCerts(); n != 2 {
+		t.Fatalf("expected poller to pick up both certs after rotation, got %d", n)
+	}
+
+	// Login signed by the rotated key is accepted.
+	if err := handle("testdata/okta-resp.xml"); err != nil {
+		t.Fatalf("login signed by rotated key failed: %v", err)
+	}
+}
+
+// TestApplyMetadataUnionsManualAndDiscoveredCerts verifies that the validator
+// uses the union of manually configured certs and certs discovered from
+// metadata.
+func TestApplyMetadataUnionsManualAndDiscoveredCerts(t *testing.T) {
+	ca, err := os.ReadFile("testdata/ca.crt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	okta, err := os.ReadFile("testdata/okta-ca.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	loadCert := func(pemData []byte) *x509.Certificate {
+		block, _ := pem.Decode(pemData)
+		if block == nil {
+			t.Fatal("no PEM block")
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return cert
+	}
+
+	p := &provider{
+		manualCerts: []*x509.Certificate{loadCert(ca)},
+		logger:      slog.New(slog.DiscardHandler),
+	}
+	meta := &IdPMetadata{
+		EntityID: "https://idp.example.com",
+		SSOEndpoints: []SSOEndpoint{
+			{Binding: bindingPOST, Location: "https://idp.example.com/sso"},
+		},
+		SigningCerts: []*x509.Certificate{loadCert(okta)},
+	}
+	if err := p.applyMetadata(meta); err != nil {
+		t.Fatal(err)
+	}
+
+	certs, _ := p.stateSnapshot().validator.CertificateStore.Certificates()
+	if len(certs) != 2 {
+		t.Fatalf("expected manual + discovered certs to be unioned, got %d certs", len(certs))
+	}
+}
+
 func TestMetadataPollerFirstFetchFailsWithoutFallback(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "boom", http.StatusInternalServerError)

--- a/server/apiserver/connectors_test.go
+++ b/server/apiserver/connectors_test.go
@@ -20,7 +20,7 @@ func TestConnectorCacheInvalidation(t *testing.T) {
 
 	// Only the connector type this test creates needs to resolve; the config map
 	// is injected, so the API's tests need none of dex's real connectors.
-	conns := connectors.NewCache(s, connectors.Resolver(s, logger, map[string]func() connectors.ConnectorConfig{
+	conns := connectors.NewCache(t.Context(), s, connectors.Resolver(s, logger, map[string]func() connectors.ConnectorConfig{
 		"mockPassword": func() connectors.ConnectorConfig { return new(mock.PasswordConfig) },
 	}))
 

--- a/server/authflow/handler_test.go
+++ b/server/authflow/handler_test.go
@@ -103,7 +103,7 @@ func newTestHandler(t *testing.T, updateConfig func(c *testFlowConfig)) (*httpte
 	require.NoError(t, err)
 
 	now := func() time.Time { return time.Now() }
-	conns := connectors.NewCache(store, testResolveConnector)
+	conns := connectors.NewCache(ctx, store, testResolveConnector)
 	issuer := tokens.NewIssuer(store, sig, *issuerURL, 24*time.Hour, now, logger)
 
 	tc := testFlowConfig{

--- a/server/authflow/sessionlogin_test.go
+++ b/server/authflow/sessionlogin_test.go
@@ -48,7 +48,7 @@ func newTestSessionServer(t *testing.T) *sessionTestServer {
 		Logger:    slog.Default(),
 		IssuerURL: oauth2.IssuerURL{URL: *issuerURL},
 	}
-	h.Connectors = connectors.NewCache(h.Storage, testResolveConnector)
+	h.Connectors = connectors.NewCache(t.Context(), h.Storage, testResolveConnector)
 	h.Sessions = &session.Manager{Storage: h.Storage, Config: sessionCfg, Now: h.Now, Logger: slog.Default(), IssuerURL: oauth2.IssuerURL{URL: *issuerURL}}
 	return &sessionTestServer{Handler: h}
 }

--- a/server/connectors/connectors.go
+++ b/server/connectors/connectors.go
@@ -31,22 +31,58 @@ type Cache struct {
 	storage storage.Storage
 	resolve ResolveFunc
 	ctx     context.Context
+
+	// openLocks serializes Open calls per connector ID so concurrent misses for
+	// the same ID resolve and start a single lifecycle-managed instance rather
+	// than leaking one. Entries are created on first use and never removed; the
+	// number of connector IDs is small and bounded.
+	openLocks map[string]*sync.Mutex
 }
 
 // NewCache returns an empty cache backed by the given storage and resolver.
 // ctx bounds the lifetime of any connector background work started via Open.
 func NewCache(ctx context.Context, storage storage.Storage, resolve ResolveFunc) *Cache {
 	return &Cache{
-		conns:   make(map[string]Connector),
-		storage: storage,
-		resolve: resolve,
-		ctx:     ctx,
+		conns:     make(map[string]Connector),
+		storage:   storage,
+		resolve:   resolve,
+		ctx:       ctx,
+		openLocks: make(map[string]*sync.Mutex),
 	}
+}
+
+// openLock returns the per-ID mutex that serializes Open calls for connID.
+func (c *Cache) openLock(connID string) *sync.Mutex {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	l, ok := c.openLocks[connID]
+	if !ok {
+		l = &sync.Mutex{}
+		c.openLocks[connID] = l
+	}
+	return l
 }
 
 // Open builds the connector for the given stored connector and records it in the
 // cache, replacing any existing entry for the same ID.
 func (c *Cache) Open(conn storage.Connector) (Connector, error) {
+	// Serialize per ID so concurrent opens of the same connector resolve and
+	// start a single instance; otherwise the loser of a concurrent race would
+	// leak its started background work with no handle to stop it.
+	lock := c.openLock(conn.ID)
+	lock.Lock()
+	defer lock.Unlock()
+
+	// Re-check under the per-ID lock: a concurrent opener may have already
+	// built and cached exactly this connector. Return it rather than starting
+	// a second lifecycle instance.
+	c.mu.Lock()
+	existing, ok := c.conns[conn.ID]
+	c.mu.Unlock()
+	if ok && existing.ResourceVersion == conn.ResourceVersion && existing.Type == conn.Type {
+		return existing, nil
+	}
+
 	impl, err := c.resolve(conn)
 	if err != nil {
 		return Connector{}, fmt.Errorf("failed to open connector: %v", err)

--- a/server/connectors/connectors.go
+++ b/server/connectors/connectors.go
@@ -30,14 +30,17 @@ type Cache struct {
 	conns   map[string]Connector
 	storage storage.Storage
 	resolve ResolveFunc
+	ctx     context.Context
 }
 
 // NewCache returns an empty cache backed by the given storage and resolver.
-func NewCache(storage storage.Storage, resolve ResolveFunc) *Cache {
+// ctx bounds the lifetime of any connector background work started via Open.
+func NewCache(ctx context.Context, storage storage.Storage, resolve ResolveFunc) *Cache {
 	return &Cache{
 		conns:   make(map[string]Connector),
 		storage: storage,
 		resolve: resolve,
+		ctx:     ctx,
 	}
 }
 
@@ -47,6 +50,22 @@ func (c *Cache) Open(conn storage.Connector) (Connector, error) {
 	impl, err := c.resolve(conn)
 	if err != nil {
 		return Connector{}, fmt.Errorf("failed to open connector: %v", err)
+	}
+
+	// Stop any lifecycle-managed instance previously cached under this ID.
+	c.mu.Lock()
+	prev, hadPrev := c.conns[conn.ID]
+	c.mu.Unlock()
+	if hadPrev {
+		if lc, ok := prev.Connector.(connector.LifecycleConnector); ok {
+			lc.Close()
+		}
+	}
+
+	if lc, ok := impl.(connector.LifecycleConnector); ok {
+		if err := lc.Start(c.ctx); err != nil {
+			return Connector{}, fmt.Errorf("failed to start connector %s: %v", conn.ID, err)
+		}
 	}
 
 	opened := Connector{
@@ -87,11 +106,21 @@ func (c *Cache) Len() int {
 	return len(c.conns)
 }
 
-// Close removes the connector from the in-memory cache.
+// Close stops any lifecycle-managed work and removes the connector from the
+// in-memory cache.
 func (c *Cache) Close(id string) {
 	c.mu.Lock()
-	delete(c.conns, id)
+	conn, ok := c.conns[id]
+	if ok {
+		delete(c.conns, id)
+	}
 	c.mu.Unlock()
+
+	if ok {
+		if lc, ok := conn.Connector.(connector.LifecycleConnector); ok {
+			lc.Close()
+		}
+	}
 }
 
 // Get returns the connector with the given id, opening (or reopening) it when it

--- a/server/connectors/connectors_test.go
+++ b/server/connectors/connectors_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -177,4 +178,71 @@ func TestLifecycleNotRequired(t *testing.T) {
 	// stubConn does not implement LifecycleConnector; Open/Close must not panic.
 	cache.Set("c1", Connector{Type: "mock", Connector: stubConn{version: "1"}})
 	cache.Close("c1")
+}
+
+// TestLifecycleConcurrentOpenSameID verifies that concurrent opens of the same
+// connector ID start a single lifecycle instance: the losing goroutine must not
+// leak a started instance that nothing will ever close.
+func TestLifecycleConcurrentOpenSameID(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New(slog.New(slog.DiscardHandler))
+
+	var (
+		mu        sync.Mutex
+		instances []*lifecycleStub
+	)
+	cache := NewCache(ctx, store, func(c storage.Connector) (connector.Connector, error) {
+		inst := &lifecycleStub{version: c.ResourceVersion}
+		mu.Lock()
+		instances = append(instances, inst)
+		mu.Unlock()
+		return inst, nil
+	})
+
+	conn := storage.Connector{ID: "c1", Type: "mock", ResourceVersion: "1"}
+
+	const n = 8
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = cache.Open(conn)
+		}()
+	}
+	wg.Wait()
+
+	// Exactly one instance may have been started; every started instance that is
+	// not the cached one must have been closed.
+	cached, ok := cache.Cached("c1")
+	require.True(t, ok)
+	cachedLifecycle, ok := cached.Connector.(*lifecycleStub)
+	require.True(t, ok)
+
+	mu.Lock()
+	created := append([]*lifecycleStub(nil), instances...)
+	mu.Unlock()
+
+	var started, unclosed int
+	for _, inst := range created {
+		if inst.started == 1 {
+			started++
+		}
+		if inst.started > inst.closed {
+			unclosed++
+		}
+	}
+
+	// Serialization guarantees only the winner is live.
+	require.Equal(t, 1, started, "expected exactly one started instance")
+	require.Equal(t, 1, unclosed, "expected exactly one live (started, unclosed) instance")
+	require.Same(t, cachedLifecycle, func() *lifecycleStub {
+		for _, inst := range created {
+			if inst.started == 1 && inst.closed == 0 {
+				return inst
+			}
+		}
+		return nil
+	}())
+	require.Equal(t, 1, cachedLifecycle.started)
 }

--- a/server/connectors/connectors_test.go
+++ b/server/connectors/connectors_test.go
@@ -17,7 +17,23 @@ import (
 // the version it was resolved from, so tests can tell reopens apart.
 type stubConn struct{ version string }
 
-func newTestCache(t *testing.T) (*Cache, storage.Storage, *int) {
+// lifecycleStub records lifecycle callbacks so tests can assert they fired.
+type lifecycleStub struct {
+	version string
+	started int
+	closed  int
+}
+
+func (l *lifecycleStub) Start(ctx context.Context) error {
+	l.started++
+	return nil
+}
+
+func (l *lifecycleStub) Close() {
+	l.closed++
+}
+
+func newTestCache(t *testing.T, ctx context.Context) (*Cache, storage.Storage, *int) {
 	t.Helper()
 	store := memory.New(slog.New(slog.DiscardHandler))
 	calls := 0
@@ -25,12 +41,12 @@ func newTestCache(t *testing.T) (*Cache, storage.Storage, *int) {
 		calls++
 		return stubConn{version: c.ResourceVersion}, nil
 	}
-	return NewCache(store, resolve), store, &calls
+	return NewCache(ctx, store, resolve), store, &calls
 }
 
 func TestGetOpensAndCaches(t *testing.T) {
 	ctx := context.Background()
-	cache, store, calls := newTestCache(t)
+	cache, store, calls := newTestCache(t, ctx)
 
 	require.NoError(t, store.CreateConnector(ctx, storage.Connector{
 		ID: "c1", Type: "mock", ResourceVersion: "1", GrantTypes: []string{"authorization_code"},
@@ -53,7 +69,7 @@ func TestGetOpensAndCaches(t *testing.T) {
 
 func TestGetReopensOnVersionChange(t *testing.T) {
 	ctx := context.Background()
-	cache, store, calls := newTestCache(t)
+	cache, store, calls := newTestCache(t, ctx)
 
 	require.NoError(t, store.CreateConnector(ctx, storage.Connector{ID: "c1", Type: "mock", ResourceVersion: "1"}))
 	_, err := cache.Get(ctx, "c1")
@@ -75,7 +91,7 @@ func TestGetReopensOnVersionChange(t *testing.T) {
 
 func TestGetNotFound(t *testing.T) {
 	ctx := context.Background()
-	cache, _, calls := newTestCache(t)
+	cache, _, calls := newTestCache(t, ctx)
 
 	_, err := cache.Get(ctx, "missing")
 	require.Error(t, err)
@@ -83,8 +99,9 @@ func TestGetNotFound(t *testing.T) {
 }
 
 func TestOpenResolveErrorNotCached(t *testing.T) {
+	ctx := context.Background()
 	store := memory.New(slog.New(slog.DiscardHandler))
-	cache := NewCache(store, func(storage.Connector) (connector.Connector, error) {
+	cache := NewCache(ctx, store, func(storage.Connector) (connector.Connector, error) {
 		return nil, errors.New("boom")
 	})
 
@@ -97,7 +114,8 @@ func TestOpenResolveErrorNotCached(t *testing.T) {
 }
 
 func TestSetCachedCloseLen(t *testing.T) {
-	cache, _, _ := newTestCache(t)
+	ctx := context.Background()
+	cache, _, _ := newTestCache(t, ctx)
 
 	require.Equal(t, 0, cache.Len())
 	_, ok := cache.Cached("c1")
@@ -119,4 +137,44 @@ func TestSetCachedCloseLen(t *testing.T) {
 	// Closing an unknown id is a no-op.
 	cache.Close("nope")
 	require.Equal(t, 1, cache.Len())
+}
+
+func TestLifecycleStartAndClose(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New(slog.New(slog.DiscardHandler))
+
+	var current *lifecycleStub
+	cache := NewCache(ctx, store, func(c storage.Connector) (connector.Connector, error) {
+		current = &lifecycleStub{version: c.ResourceVersion}
+		return current, nil
+	})
+
+	require.NoError(t, store.CreateConnector(ctx, storage.Connector{ID: "c1", Type: "mock", ResourceVersion: "1"}))
+
+	// Open starts the lifecycle.
+	_, err := cache.Open(storage.Connector{ID: "c1", Type: "mock", ResourceVersion: "1"})
+	require.NoError(t, err)
+	require.Equal(t, 1, current.started)
+	require.Equal(t, 0, current.closed)
+
+	// Reopening the same ID stops the previous instance and starts the new one.
+	first := current
+	_, err = cache.Open(storage.Connector{ID: "c1", Type: "mock", ResourceVersion: "2"})
+	require.NoError(t, err)
+	require.Equal(t, 1, first.closed)
+	require.NotSame(t, first, current)
+	require.Equal(t, 1, current.started)
+
+	// Cache.Close stops the lifecycle.
+	cache.Close("c1")
+	require.Equal(t, 1, current.closed)
+}
+
+func TestLifecycleNotRequired(t *testing.T) {
+	ctx := context.Background()
+	cache, _, _ := newTestCache(t, ctx)
+
+	// stubConn does not implement LifecycleConnector; Open/Close must not panic.
+	cache.Set("c1", Connector{Type: "mock", Connector: stubConn{version: "1"}})
+	cache.Close("c1")
 }

--- a/server/mfa/handler_test.go
+++ b/server/mfa/handler_test.go
@@ -58,7 +58,7 @@ func newTestHandler(t *testing.T, providers map[string]Provider, defaultChain []
 	issuerURL, err := url.Parse("http://127.0.0.1")
 	require.NoError(t, err)
 
-	conns := connectors.NewCache(store, resolveTestConnector)
+	conns := connectors.NewCache(t.Context(), store, resolveTestConnector)
 	require.NoError(t, store.CreateConnector(t.Context(), storage.Connector{
 		ID: "mock", Type: "mockCallback", Name: "Mock", ResourceVersion: "1",
 	}))

--- a/server/server.go
+++ b/server/server.go
@@ -104,7 +104,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		IssuerURL: s.issuerURL,
 	}
 	s.issuer = tokens.NewIssuer(s.storage, c.Signer, s.issuerURL.URL, rc.idTokensValidFor, rc.now, s.logger)
-	s.connectors = connectors.NewCache(s.storage, connectors.Resolver(s.storage, s.logger, ConnectorsConfig))
+	s.connectors = connectors.NewCache(ctx, s.storage, connectors.Resolver(s.storage, s.logger, ConnectorsConfig))
 	s.backchannel = &backchannel.Notifier{
 		Storage:   s.storage,
 		Signer:    c.Signer,


### PR DESCRIPTION
## Summary

Add SAML IdP metadata discovery to the SAML connector so that IdPs which rotate their signing keys no longer break dex logins.

Before this change, the SAML connector was configured with a hardcoded CA (file path or data) that was read **once** when the connector was opened. When an IdP rotated its signing key (publishing the new certificate in its SAML metadata), dex had no way to learn about it and every new login failed signature verification until an operator manually updated the config and restarted.

This PR lets the connector fetch and poll an IdP's SAML metadata URL to discover signing certificates, the SSO endpoint, and the issuer — automatically. Closes #983.

## What this PR does / why we need it

- New optional config field `metadataURL`: when set, dex fetches the IdP's SAML metadata over HTTPS, parses it, and uses the discovered signing certificates to verify SAML responses.
- The metadata is re-fetched on an interval (`metadataRefreshInterval`, default 1 hour), so signing-key rotation is picked up **without operator intervention or restarts**.
- When signing keys rotate, the metadata typically contains both the old and new keys during the rotation window; dex uses **all** signing certificates present in the metadata, so old keys remain valid until the IdP removes them.
- SSO endpoint and issuer are also discovered from metadata, filling in config values that were previously required by hand.

## New configuration fields

Added to the SAML connector config (`connector/saml/saml.go`):

```yaml
connectors:
  - type: saml
    id: saml
    name: SAML
    config:
      # Optional. When set, dex fetches and polls this URL to discover the IdP's
      # SSO endpoint, issuer, and signing certificates.
      metadataURL: https://idp.example.com/metadata

      # Optional. How often the metadata URL is re-fetched. A Go duration string
      # (e.g. "1h", "30m"). Defaults to 1 hour. Must be >= 1 minute when set.
      metadataRefreshInterval: 1h
```

## Backward compatibility

- When `metadataURL` is **not** set, behavior is exactly as before: `ssoURL` and `ca`/`caData` remain required, and the connector verifies against only the configured CA. Existing configs keep working unchanged.
- When `metadataURL` **is** set, `ssoURL` and `ca`/`caData` become optional (supplied from metadata). Explicitly configured fields still win over discovered values:
  - `ca`/`caData` certs and discovered signing certs are **unioned** for signature verification.
  - `ssoURL` is used as-is if set; otherwise the first HTTP-POST (then HTTP-Redirect) SingleSignOnService from the metadata is used.
  - `ssoIssuer` is used as-is if set; otherwise the discovered entityID is used as the expected issuer.
  - `entityIssuer` is unaffected.
- `InsecureSkipSignatureValidation` continues to disable signature validation entirely.

## How rotation and failures are handled

- **First fetch is critical**: if the very first metadata fetch fails and no manual certificates are configured (and validation is not skipped), the connector fails to open — so the server doesn't start with a connector that can't verify anything. This honors the existing `continueOnConnectorFailure` option.
- **Later fetch failures are tolerant**: after a successful initial fetch, a failed poll logs a warning and keeps the last known certificates/values. A brief network blip or IdP outage does not break logins.
- **No SSO endpoint / no certificates**: a metadata document with no signing certs and no SSO endpoints is rejected; a document with certs but no usable SSO endpoint (and no manual `ssoURL`) fails the merge and keeps the previous state.

## Implementation notes

- `connector/saml/metadata.go` is a pure `encoding/xml` parser for the subset of SAML IdP metadata dex consumes (entityID, `<IDPSSODescriptor>` signing `<KeyDescriptor>`s, `<SingleSignOnService>` endpoints). **No new dependencies** were added.
- The provider now reads its active validator/SSO URL/issuer from a mutex-protected, atomically-swapped state, so a metadata refresh can never tear a login in progress.
- A new optional `connector.LifecycleConnector` interface (`Start(ctx) error` / `Close()`) lets the server start and stop connector background work. The connector cache invokes it: `Start` is called when a connector is opened, `Close` when it is replaced or removed. Only the SAML connector implements it — the local password connector and all other connectors are unaffected.
- Metadata fetches use a 10s-timeout HTTP client and read at most 1 MiB of body.

## Testing

- **Parser unit tests** (`metadata_test.go`): redirect + POST bindings, signing vs encryption key descriptors, key descriptors without a `use` attribute, entityID, wrapped/multi-line base64 certs, malformed XML, missing sections, and documents with no certs/endpoints.
- **Poller tests** (`saml_test.go`): certificate rotation is picked up by the poller; a failed poll keeps the last known state; a failing first fetch fails the connector open (both with and without manual cert fallback).
- **End-to-end rotation test** (`TestMetadataPollerHandlesKeyRotation`): a login signed by the original key succeeds, then after the IdP publishes a second key in its metadata, a login signed by the new key succeeds — proving the feature's core promise.
- **Lifecycle tests** (`server/connectors`): `Start` fires on open, `Close` on replace/remove, non-lifecycle connectors are untouched, and concurrent opens of the same connector ID start a single instance (no leaked poller goroutine).
- Full suite (`go test ./connector/... ./server/...`), `-race`, `go vet`, and `golangci-lint` all pass.

## Special notes for your reviewer

- The `duration` type follows the server config's existing string-duration style; it marshals back to a string so config round-trips (yaml → json → storage → json) stay stable.
- The `samlExperimental` connector type is an alias for `saml.Config` and inherits this behavior automatically.
- User-facing docs for the new fields live in the separate [dexidp/website](https://github.com/dexidp/website) repo; the config comment in `connector/saml/saml.go` is the in-repo reference.
- This PR intentionally does **not** implement issue #968 (publishing/versioning dex's config format) or auto-provisioning dex's own SP metadata; those remain out of scope.
