### PR TITLE
expose TOTP setup key during enrollment

### DIFF
--- a/server/mfa/totp.go
+++ b/server/mfa/totp.go
@@ -231,8 +231,16 @@ func (h *Handler) renderTOTPPage(secret *storage.MFASecret, lastFail bool, issue
 	// Prevent browser from caching the TOTP page (contains QR code with secret).
 	w.Header().Set("Cache-Control", "no-store")
 	var qrCode string
+	var totpKey string
 	if !secret.Confirmed {
 		var err error
+		totpKey, err = totpManualSecret(secret.Secret)
+		if err != nil {
+			h.Logger.ErrorContext(r.Context(), "failed to load TOTP key", "err", err)
+			h.renderError(r, w, http.StatusInternalServerError, "Internal server error.")
+			return
+		}
+
 		qrCode, err = generateTOTPQRCode(secret.Secret)
 		if err != nil {
 			h.Logger.ErrorContext(r.Context(), "failed to generate QR code", "err", err)
@@ -240,9 +248,17 @@ func (h *Handler) renderTOTPPage(secret *storage.MFASecret, lastFail bool, issue
 			return
 		}
 	}
-	if err := h.Templates.TOTPVerify(r, w, r.URL.String(), issuer, connectorID, qrCode, lastFail); err != nil {
+	if err := h.Templates.TOTPVerifyWithKey(r, w, r.URL.String(), issuer, connectorID, qrCode, totpKey, lastFail); err != nil {
 		h.Logger.ErrorContext(r.Context(), "server template error", "err", err)
 	}
+}
+
+func totpManualSecret(keyURL string) (string, error) {
+	generated, err := otp.NewKeyFromURL(keyURL)
+	if err != nil {
+		return "", fmt.Errorf("load TOTP key: %w", err)
+	}
+	return generated.Secret(), nil
 }
 
 func generateTOTPQRCode(keyURL string) (string, error) {

--- a/server/mfa/totp_test.go
+++ b/server/mfa/totp_test.go
@@ -45,3 +45,15 @@ func TestValidateTOTPCode(t *testing.T) {
 	require.True(t, ok)
 	require.Greater(t, nextCounter, counter)
 }
+
+func TestTOTPManualSecret(t *testing.T) {
+	key, err := totp.Generate(totp.GenerateOpts{Issuer: "example", AccountName: "user@example.com"})
+	require.NoError(t, err)
+
+	manualSecret, err := totpManualSecret(key.String())
+	require.NoError(t, err)
+	require.Equal(t, key.Secret(), manualSecret)
+
+	_, err = totpManualSecret("otpauth://totp/%ZZ")
+	require.Error(t, err)
+}

--- a/server/templates/templates.go
+++ b/server/templates/templates.go
@@ -369,6 +369,10 @@ func (t *Templates) Approval(r *http.Request, w http.ResponseWriter, authReqID, 
 }
 
 func (t *Templates) TOTPVerify(r *http.Request, w http.ResponseWriter, postURL, issuer, connector, qrCode string, lastWasInvalid bool) error {
+	return t.TOTPVerifyWithKey(r, w, postURL, issuer, connector, qrCode, "", lastWasInvalid)
+}
+
+func (t *Templates) TOTPVerifyWithKey(r *http.Request, w http.ResponseWriter, postURL, issuer, connector, qrCode, totpKey string, lastWasInvalid bool) error {
 	if lastWasInvalid {
 		w.WriteHeader(http.StatusUnauthorized)
 	}
@@ -378,8 +382,9 @@ func (t *Templates) TOTPVerify(r *http.Request, w http.ResponseWriter, postURL, 
 		Issuer    string
 		Connector string
 		QRCode    string
+		TotpKey   string
 		ReqPath   string
-	}{postURL, lastWasInvalid, issuer, connector, qrCode, r.URL.Path}
+	}{postURL, lastWasInvalid, issuer, connector, qrCode, totpKey, r.URL.Path}
 	return renderTemplate(w, t.totpVerifyTmpl, data)
 }
 


### PR DESCRIPTION
#### Overview

Expose TOPT key during enrollment

#### What this PR does / why we need it

The idea is to allow showing TOTP code for users whom are not able to scan qr code or prefer to use the code in password managers.  

I’m not changing the templates because downstream consumers such as NetBird provide their own web templates and own the presentation layer. This change only exposes the setup secret as TotpKey during unconfirmed TOTP enrollment, allowing those consumers to render a manual setup option alongside the QR code.

