### PR TITLE
feature(ldap): Adds objectSid and objectUUID formatting when using Active Directory

### DIFF
--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/go-ldap/ldap/v3"
+	"github.com/google/uuid"
 
 	"github.com/dexidp/dex/connector"
 )
@@ -241,6 +242,48 @@ func parseScope(s string) (int, bool) {
 		return ldap.ScopeSingleLevel, true
 	}
 	return 0, false
+}
+
+// formatSidAttr converts the objectSid byte array returned from
+// Active Directory into a readable string format like S-1-5-21...
+func formatSidAttr(b []byte) (string, error) {
+	minbytes := 1 + 1 + 6
+	maxSubAuthorities := 15
+	maxBytes := 1 + 1 + 6 + 4*maxSubAuthorities
+
+	if (len(b) < minbytes) || (len(b) > maxBytes) {
+		return "", fmt.Errorf("Out of Range, length for SID expected to between: %d and %d bytes", minbytes, maxBytes)
+	}
+
+	revision := int(b[0])
+	if revision != 1 {
+		return "", fmt.Errorf("SIDs with revision other than '1' are not supported.")
+	}
+
+	subAuthoritiesLength := int(b[1])
+	if subAuthoritiesLength > maxSubAuthorities {
+		return "", fmt.Errorf("The number of sub-authorities must not exceed %d", maxSubAuthorities)
+	}
+
+	totalLength := 1 + 1 + 6 + 4*subAuthoritiesLength
+	if len(b) < totalLength {
+		return "", fmt.Errorf("Out of Range: Length of bytes mismatch")
+	}
+
+	var iav int
+	for i, x := range b[2:8] {
+		iav = iav | int(x)<<(8*(5-i))
+	}
+	s := fmt.Sprintf("S-%d-%d", revision, iav)
+
+	for i := range subAuthoritiesLength {
+		var sub int
+		for i, x := range b[8+4*i : 12+4*i] {
+			sub = sub | int(x)<<(8*i)
+		}
+		s += fmt.Sprintf("-%d", sub)
+	}
+	return s, nil
 }
 
 // Build a list of group attr name to user attr value matchers.
@@ -493,6 +536,23 @@ func (c *ldapConnector) getAttrs(e ldap.Entry, name string) []string {
 
 func (c *ldapConnector) getAttr(e ldap.Entry, name string) string {
 	if a := c.getAttrs(e, name); len(a) > 0 {
+		if name == "objectSid" {
+			sid, err := formatSidAttr([]byte(a[0]))
+			if err != nil {
+				c.logger.Error("ldap: attribute failed to be formatted as objectSid", "attribute", a[0])
+				return ""
+			}
+			return sid
+		}
+
+		if name == "objectGUID" {
+			uuid_string, err := uuid.FromBytes([]byte(a[0]))
+			if err != nil {
+				c.logger.Error("ldap: attribute failed to be formatted as objectGUID", "attribute", a[0])
+				return ""
+			}
+			return uuid_string.String()
+		}
 		return a[0]
 	}
 	return ""

--- a/connector/ldap/ldap_test.go
+++ b/connector/ldap/ldap_test.go
@@ -642,6 +642,85 @@ func TestNestedGroups(t *testing.T) {
 	runTests(t, connectLDAP, c, tests)
 }
 
+func TestFormatSid(t *testing.T) {
+	tests := []struct {
+		name    string
+		bytes   []byte
+		want    string
+		wantErr bool
+	}{
+		{name: "Contoso\\Jane", bytes: []byte{1, 5, 0, 0, 0, 0, 0, 5, 21, 0, 0, 0, 220, 244, 220, 59, 131, 61, 43, 70, 130, 139, 166, 40, 210, 4, 0, 0}, want: "S-1-5-21-1004336348-1177238915-682003330-1234"},
+		{name: "null sid", bytes: []byte{1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, want: "S-1-0-0"},
+		{name: "world", bytes: []byte{1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0}, want: "S-1-1-0"},
+		{name: "empty string", bytes: nil, wantErr: true},
+		{name: "invalid sid", bytes: []byte{}, wantErr: true},
+		{name: "invalid revision", bytes: []byte{2, 1, 0, 0, 0, 0, 0, 0}, wantErr: true},
+		{name: "too many sub auth", bytes: []byte{1, 100, 0, 0, 0, 0, 0, 0}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sid, err := formatSidAttr(tt.bytes)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("formatSidAttr() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				if actual := sid; actual != tt.want {
+					t.Errorf("expected %v, got %v", tt.want, actual)
+				}
+			}
+		})
+	}
+}
+
+func TestObjectSID(t *testing.T) {
+	c := &Config{}
+	c.UserSearch.BaseDN = "ou=People,ou=TestObjectSid,dc=example,dc=org"
+	c.UserSearch.NameAttr = "cn"
+	c.UserSearch.EmailAttr = "mail"
+	c.UserSearch.IDAttr = "objectSid"
+	c.UserSearch.Username = UsernameAttributes{"cn"}
+
+	tests := []subtest{
+		{
+			name:     "validpassword",
+			username: "jane",
+			password: "foo",
+			want: connector.Identity{
+				UserID:        "S-1-5-21-1004336348-1177238915-682003330-1234",
+				Username:      "jane",
+				Email:         "janedoe@example.com",
+				EmailVerified: true,
+			},
+		},
+	}
+	runTests(t, connectLDAP, c, tests)
+}
+
+func TestObjectGUID(t *testing.T) {
+	c := &Config{}
+	c.UserSearch.BaseDN = "ou=People,ou=TestAdObjects,dc=example,dc=org"
+	c.UserSearch.NameAttr = "cn"
+	c.UserSearch.EmailAttr = "mail"
+	c.UserSearch.IDAttr = "objectGUID"
+	c.UserSearch.Username = UsernameAttributes{"cn"}
+
+	tests := []subtest{
+		{
+			name:     "validpassword",
+			username: "jane",
+			password: "foo",
+			want: connector.Identity{
+				UserID:        "123e4567-e89b-12d3-a456-426614174000",
+				Username:      "jane",
+				Email:         "janedoe@example.com",
+				EmailVerified: true,
+			},
+		},
+	}
+	runTests(t, connectLDAP, c, tests)
+}
+
 func getenv(key, defaultVal string) string {
 	if val := os.Getenv(key); val != "" {
 		return val

--- a/connector/ldap/testdata/schema.ldif
+++ b/connector/ldap/testdata/schema.ldif
@@ -527,3 +527,49 @@ sn: doe
 cn: jane
 mail: janedoe@example.com
 userpassword: foo
+
+########################################################################
+
+# Mock AD Attrs: objectGUID & objectSid
+
+dn: cn=mock_ad_attributes,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: mock_ad_attributes
+olcAttributeTypes: ( 1.2.840.113556.1.4.2
+  NAME 'objectGUID'
+  DESC 'Microsoft Active Directory uuid'
+  EQUALITY octetStringMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.2.840.113556.1.4.146
+  NAME 'objectSid'
+  DESC 'Microsoft Active Directory SID'
+  EQUALITY octetStringMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+  SINGLE-VALUE )
+olcObjectClasses: ( 1.2.3.4.56789.1.0.200
+  NAME 'mockAdAttributes'
+  SUP inetOrgPerson
+  STRUCTURAL
+  MAY ( objectGUID $ objectSid ) )
+
+
+dn: ou=TestAdObjects,dc=example,dc=org
+objectClass: organizationalUnit
+ou: TestAdObjects
+
+dn: ou=People,ou=TestAdObjects,dc=example,dc=org
+objectClass: organizationalUnit
+ou: People
+
+dn: cn=jane,ou=People,ou=TestAdObjects,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: top
+objectClass: mockAdAttributes
+sn: doe
+cn: jane
+mail: janedoe@example.com
+userpassword: foo
+objectSid:: AQUAAAAAAAUVAAAA3PTcO4M9K0aCi6Yo0gQAAA==
+objectGUID:: Ej5FZ+ibEtOkVkJmFBdAAA==


### PR DESCRIPTION
#### Overview

Adds support for formatting `objectSid` and `objectGUID` for use with the ldap connector and Active Directory.

#### What this PR does / why we need it

Active Directory stores these two attributes as byte arrays. This change converts them to strings, allowing them to be used for any `*Attr` but intended for `idAttr`.

I believe that the Subject Claim within a JWT is intended to be a static non-changing value. In the context of AD `objectGUID` never changes and `objectSid` only changes in certain circumstances. Whereas a `DN` could change for a user either via a name change or if the object is moved to a new OU.

Prior to this change using either attribute would result in an error like so:
```
{"time":"2025-02-21T15:29:54.427305352Z","level":"ERROR","msg":"failed to marshal offline session ID","err":"string field contains invalid UTF-8","request_id":"6485c460-48ca-46bd-b1f1-30a4b9d14c6d"}
{"time":"2025-02-21T15:29:54.427340003Z","level":"ERROR","msg":"failed to create new access token","err":"failed to marshal offline session ID: string field contains invalid UTF-8","request_id":"6485c460-48ca-46bd-b1f1-30a4b9d14c6d"}
```
Closes: #3128

Implementation of `formatSidAttr` is inspired by: https://github.com/dotnet/runtime/blob/1f0e9eadd29b9c15dae9313234abf486f1c4ef96/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs#L395

#### Special notes for your reviewer
Test config:
```
connectors:
  - type: ldap
    id: ldap
    name: AD
    config:
      host: ad.example.com:636

      bindDN: uid=serviceaccount,cn=users,dc=example,dc=com
      bindPW: password

      userSearch:
        baseDN: OU=Users,DC=example,DC=com
        filter: "(objectClass=person)"
        username: sAMAccountName
        idAttr: objectSid
        emailAttr: mail
        nameAttr: cn
        preferredUsernameAttr: sAMAccountName

      groupSearch:
        baseDN: OU=Groups,DC=example,DC=com
        filter: "(objectClass=group)"
        userMatchers:
          - userAttr: DN
            groupAttr: "member:1.2.840.113556.1.4.1941:"
        nameAttr: cn
```