### PR TITLE
fix(health): bound health checks that perform I/O

### DIFF
--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/dexidp/dex/api/v2"
 	"github.com/dexidp/dex/pkg/featureflags"
+	"github.com/dexidp/dex/pkg/health"
 	"github.com/dexidp/dex/server"
 	"github.com/dexidp/dex/server/apiserver"
 	"github.com/dexidp/dex/server/authflow"
@@ -471,7 +472,12 @@ func runServe(options serveOptions) error {
 	healthChecker.RegisterCheck(
 		&checks.CustomCheck{
 			CheckName: "storage",
-			CheckFunc: storage.NewCustomHealthCheckFunc(serverConfig.Storage, serverConfig.Now),
+			// The check performs I/O; wrapped so that an unresponsive backend
+			// cannot leave it hanging. See health.NewTimeoutCheckFunc.
+			CheckFunc: health.NewTimeoutCheckFunc(
+				storage.NewCustomHealthCheckFunc(serverConfig.Storage, serverConfig.Now),
+				health.DefaultTimeout,
+			),
 		},
 		gosundheit.ExecutionPeriod(15*time.Second),
 		gosundheit.InitiallyPassing(true),

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -1,0 +1,151 @@
+// Package health bounds health checks that perform I/O, so that a check
+// blocked on an unresponsive dependency reports a failure rather than nothing.
+package health
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// DefaultTimeout bounds a single execution of a health check.
+// Generous by design: it bounds a stall, it does not police latency. Keep it
+// below the check's execution period.
+const DefaultTimeout = 10 * time.Second
+
+var (
+	// errTimeout is returned when an execution overruns the timeout.
+	errTimeout = errors.New("health check did not return within the timeout")
+
+	// errInFlight is returned when an earlier execution has still
+	// not returned, so this one was not started.
+	errInFlight = errors.New("a previous health check execution is still running")
+)
+
+// NewTimeoutCheckFunc wraps a health check so that an execution which overruns
+// is reported as a failure.
+//
+// A check that performs I/O is only as responsive as the dependency it probes.
+// A blocked check reports nothing rather than an error, and schedulers record a
+// result only when a check returns, so the last recorded result - a passing one
+// - stands for the whole outage while the process reports itself healthy.
+//
+// Cancellation cannot fix this alone, being cooperative: a check may be blocked
+// where it is not observed, such as on a connection pool, in a driver that takes
+// no context, in a syscall or in cgo. The call is therefore made on its own
+// goroutine, which the caller stops waiting on once it overruns.
+//
+// Returning early lets the scheduler proceed to the next tick, so executions are
+// single-flight: while one is outstanding, later ones report the failure without
+// starting another.
+//
+// An execution that never returns therefore holds the slot for the life of the
+// process, and the check keeps failing even if the dependency recovers; recovery
+// is then by restart, which the caller is responsible for arranging. One that
+// returns late releases the slot and the check recovers by itself.
+func NewTimeoutCheckFunc(
+	check func(context.Context) (details interface{}, err error),
+	timeout time.Duration,
+) func(context.Context) (details interface{}, err error) {
+	return newTimeoutCheck(check, timeout, time.Now).execute
+}
+
+// now is a parameter here, rather than on the exported constructor, because it
+// only dates the in-flight message: the timeout itself runs on real time.
+func newTimeoutCheck(
+	check func(context.Context) (details interface{}, err error),
+	timeout time.Duration,
+	now func() time.Time,
+) *timeoutCheck {
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+	return &timeoutCheck{check: check, timeout: timeout, now: now}
+}
+
+type timeoutCheck struct {
+	check   func(context.Context) (interface{}, error)
+	timeout time.Duration
+	now     func() time.Time
+
+	mu sync.Mutex
+	// nil when no execution is in flight.
+	outstanding *execution
+}
+
+type execution struct {
+	started time.Time
+	cancel  context.CancelFunc
+	// Buffered, so an abandoned goroutine can still deliver and exit.
+	done chan result
+}
+
+type result struct {
+	details interface{}
+	err     error
+}
+
+func (c *timeoutCheck) execute(ctx context.Context) (interface{}, error) {
+	ex, err := c.start(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	timer := time.NewTimer(c.timeout)
+	defer timer.Stop()
+
+	select {
+	case res := <-ex.done:
+		ex.cancel()
+		return res.details, res.err
+
+	case <-timer.C:
+		ex.cancel()
+		return nil, fmt.Errorf("%w (%s)", errTimeout, c.timeout)
+	case <-ctx.Done():
+		ex.cancel()
+		return nil, ctx.Err()
+	}
+}
+
+// start begins an execution, unless a previous one is still outstanding.
+func (c *timeoutCheck) start(parent context.Context) (*execution, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// The goroutine clears this itself on the way out, so a non-nil value here
+	// means the previous execution genuinely has not returned. Deciding it from
+	// the result channel instead would race with the execute that is waiting on
+	// it, and report a check that had just succeeded as still running.
+	if prev := c.outstanding; prev != nil {
+		// Not truncated: collisions are routinely sub-second, and "0s" would
+		// tell an operator nothing.
+		return nil, fmt.Errorf("%w (started %s ago)",
+			errInFlight, c.now().Sub(prev.started))
+	}
+
+	// Derived from the caller's context, so shutdown still propagates.
+	ctx, cancel := context.WithCancel(parent)
+	ex := &execution{
+		started: c.now(),
+		cancel:  cancel,
+		done:    make(chan result, 1),
+	}
+	c.outstanding = ex
+
+	go func() {
+		details, err := c.check(ctx)
+
+		c.mu.Lock()
+		if c.outstanding == ex {
+			c.outstanding = nil
+		}
+		c.mu.Unlock()
+
+		ex.done <- result{details: details, err: err}
+	}()
+
+	return ex, nil
+}

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -1,0 +1,383 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// A check that never returns must be reported as a failure.
+func TestTimeoutCheckReportsHungCheck(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+
+	check := NewTimeoutCheckFunc(
+		func(ctx context.Context) (interface{}, error) {
+			<-release // ignores ctx entirely
+			return nil, nil
+		},
+		50*time.Millisecond)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := check(context.Background())
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected a hung check to be reported as a failure")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the wrapper itself hung; a hung check must not block the caller")
+	}
+}
+
+// Executions are single-flight, so a blocked check cannot accumulate a
+// goroutine per execution for the length of an outage.
+func TestTimeoutCheckIsSingleFlight(t *testing.T) {
+	var starts atomic.Int32
+	release := make(chan struct{})
+	defer close(release)
+
+	// Closed by the first execution, so the count below is read only once the
+	// goroutine has provably run - it is not assumed to have been scheduled
+	// within the timeout.
+	entered := make(chan struct{})
+
+	check := NewTimeoutCheckFunc(
+		func(ctx context.Context) (interface{}, error) {
+			if starts.Add(1) == 1 {
+				close(entered)
+			}
+			<-release
+			return nil, nil
+		},
+		20*time.Millisecond)
+
+	for i := 0; i < 5; i++ {
+		if _, err := check(context.Background()); !errors.Is(err, errTimeout) &&
+			!errors.Is(err, errInFlight) {
+			t.Fatalf("execution %d: expected a failure while the check is blocked, got %v", i, err)
+		}
+	}
+
+	<-entered
+
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 execution of the wrapped check, got %d", got)
+	}
+}
+
+// The check recovers once the outstanding execution returns.
+func TestTimeoutCheckRecovers(t *testing.T) {
+	release := make(chan struct{})
+	var starts atomic.Int32
+
+	check := NewTimeoutCheckFunc(
+		func(ctx context.Context) (interface{}, error) {
+			if starts.Add(1) == 1 {
+				<-release
+			}
+			return nil, nil
+		},
+		20*time.Millisecond)
+
+	if _, err := check(context.Background()); err == nil {
+		t.Fatal("expected the blocked execution to fail")
+	}
+
+	close(release)
+
+	// The blocked execution returns, its result is discarded, and a fresh
+	// execution runs. Poll: the goroutine needs a moment to deliver.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		_, err := check(context.Background())
+		if err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("check did not recover after the blocked execution returned: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// A check that observes cancellation is canceled on overrun, freeing the slot
+// without waiting for the check's goodwill.
+func TestTimeoutCheckCancelsContext(t *testing.T) {
+	canceled := make(chan struct{}, 1)
+
+	check := NewTimeoutCheckFunc(
+		func(ctx context.Context) (interface{}, error) {
+			<-ctx.Done()
+			canceled <- struct{}{}
+			return nil, ctx.Err()
+		},
+		20*time.Millisecond)
+
+	if _, err := check(context.Background()); err == nil {
+		t.Fatal("expected a failure on overrun")
+	}
+
+	select {
+	case <-canceled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the wrapped check was not canceled when it overran")
+	}
+}
+
+// Details and errors pass through untouched.
+func TestTimeoutCheckPassesThrough(t *testing.T) {
+	sentinel := errors.New("dependency unavailable")
+
+	ok := NewTimeoutCheckFunc(
+		func(ctx context.Context) (interface{}, error) { return "details", nil },
+		time.Second)
+
+	details, err := ok(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details != "details" {
+		t.Fatalf("details not propagated, got %v", details)
+	}
+
+	failing := NewTimeoutCheckFunc(
+		func(ctx context.Context) (interface{}, error) { return nil, sentinel },
+		time.Second)
+
+	if _, err := failing(context.Background()); !errors.Is(err, sentinel) {
+		t.Fatalf("error not propagated, got %v", err)
+	}
+}
+
+// A completed execution leaves nothing behind that would block the next.
+func TestTimeoutCheckRepeatedRuns(t *testing.T) {
+	var starts atomic.Int32
+	check := NewTimeoutCheckFunc(
+		func(ctx context.Context) (interface{}, error) {
+			starts.Add(1)
+			return nil, nil
+		},
+		time.Second)
+
+	for i := 0; i < 20; i++ {
+		if _, err := check(context.Background()); err != nil {
+			t.Fatalf("execution %d failed: %v", i, err)
+		}
+	}
+	if got := starts.Load(); got != 20 {
+		t.Fatalf("expected 20 executions, got %d", got)
+	}
+}
+
+// A completed execution must never be reported as still running. The
+// bookkeeping is shared between the waiting caller and the goroutine it
+// started, so hammer both paths together under -race.
+func TestTimeoutCheckConcurrentExecutions(t *testing.T) {
+	check := NewTimeoutCheckFunc(
+		func(ctx context.Context) (interface{}, error) { return nil, nil },
+		time.Second)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 200)
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				if _, err := check(context.Background()); err != nil {
+					errs <- err
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	// Concurrent callers may legitimately collide with an execution that is
+	// genuinely in flight, so failures are permitted - but only that one.
+	for err := range errs {
+		if !errors.Is(err, errInFlight) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+// Canceling the caller's context releases the caller, so a scheduler shutting
+// down is not held up by a check that has stopped returning.
+func TestTimeoutCheckHonorsCallerCancellation(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+
+	check := NewTimeoutCheckFunc(
+		func(ctx context.Context) (interface{}, error) {
+			<-release
+			return nil, nil
+		},
+		time.Hour) // long enough that only cancellation can end it
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := check(ctx)
+		done <- err
+	}()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("caller was not released when its context was canceled")
+	}
+}
+
+// A result produced by an execution the caller already gave up on must never be
+// handed to a later caller: health is a statement about now.
+func TestTimeoutCheckDiscardsStaleResult(t *testing.T) {
+	release := make(chan struct{})
+	var n atomic.Int32
+
+	check := NewTimeoutCheckFunc(
+		func(ctx context.Context) (interface{}, error) {
+			if n.Add(1) == 1 {
+				<-release
+				return "stale", nil
+			}
+			return "fresh", nil
+		},
+		20*time.Millisecond)
+
+	if _, err := check(context.Background()); err == nil {
+		t.Fatal("expected the first execution to overrun")
+	}
+
+	close(release)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		details, err := check(context.Background())
+		if err == nil {
+			if details != "fresh" {
+				t.Fatalf("stale result leaked to a later caller: %v", details)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("check did not recover: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// A non-positive timeout falls back to the default. Asserted on the value
+// rather than on the absence of a panic: a timeout of zero that stayed zero
+// would fire on every execution.
+func TestTimeoutCheckDefaults(t *testing.T) {
+	nop := func(ctx context.Context) (interface{}, error) { return nil, nil }
+
+	for _, timeout := range []time.Duration{0, -time.Second} {
+		c := newTimeoutCheck(nop, timeout, time.Now)
+		if c.timeout != DefaultTimeout {
+			t.Fatalf("timeout %s: got %s, want %s", timeout, c.timeout, DefaultTimeout)
+		}
+		if _, err := c.execute(context.Background()); err != nil {
+			t.Fatalf("timeout %s: unexpected error: %v", timeout, err)
+		}
+	}
+}
+
+// The goroutine must release the slot itself, rather than leaving it to
+// whichever execute is waiting on the result.
+//
+// Deciding it from the result channel instead - a non-blocking receive in start
+// - races with the execute waiting on that same channel: whichever arrives
+// first consumes the value, and the other concludes the execution is still
+// running, reporting a check that had just succeeded as in flight.
+//
+// The slot is observed with no execute consuming the result, which sequential
+// calls to execute cannot do: they release it on the way out either way. This
+// does not pin the ordering of the release against the send on done, which is
+// buffered and so cannot be observed from outside.
+func TestTimeoutCheckGoroutineReleasesSlot(t *testing.T) {
+	ran := make(chan struct{})
+	c := newTimeoutCheck(
+		func(ctx context.Context) (interface{}, error) {
+			close(ran)
+			return nil, nil
+		},
+		time.Hour, time.Now)
+
+	if _, err := c.start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	<-ran
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		c.mu.Lock()
+		outstanding := c.outstanding
+		c.mu.Unlock()
+		if outstanding == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the goroutine did not release the slot; only a waiting " +
+				"execute does, which reports a completed check as still running")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// An execution that never returns holds the slot for the life of the process,
+// so the check keeps failing from then on. This is deliberate - see
+// NewTimeoutCheckFunc - and is pinned here because it is a behavior an
+// operator will meet: recovery is by restart, not by the dependency coming
+// back.
+func TestTimeoutCheckStaysFailedWhileExecutionIsStuck(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+
+	var starts atomic.Int32
+	entered := make(chan struct{})
+
+	check := NewTimeoutCheckFunc(
+		func(ctx context.Context) (interface{}, error) {
+			if starts.Add(1) == 1 {
+				close(entered)
+			}
+			<-release // never observes cancellation
+			return nil, nil
+		},
+		20*time.Millisecond)
+
+	if _, err := check(context.Background()); !errors.Is(err, errTimeout) {
+		t.Fatalf("expected a timeout, got %v", err)
+	}
+	<-entered
+
+	// Every later execution keeps failing, and none of them starts the check
+	// again, for as long as the stuck execution holds the slot.
+	for i := 0; i < 10; i++ {
+		_, err := check(context.Background())
+		if !errors.Is(err, errInFlight) {
+			t.Fatalf("execution %d: expected errInFlight, got %v", i, err)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("the stuck execution was restarted: %d executions", got)
+	}
+}

--- a/pkg/health/scheduler_test.go
+++ b/pkg/health/scheduler_test.go
@@ -1,0 +1,77 @@
+package health_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gosundheit "github.com/AppsFlyer/go-sundheit"
+	"github.com/AppsFlyer/go-sundheit/checks"
+
+	"github.com/dexidp/dex/pkg/health"
+)
+
+// Exercises the wrapper through the health scheduler itself: a check that stops
+// returning must still flip the scheduler unhealthy, rather than leaving the
+// last recorded result standing. See health.NewTimeoutCheckFunc.
+func TestHealthCheckerReportsUnresponsiveDependency(t *testing.T) {
+	stall := make(chan struct{})
+	defer close(stall)
+
+	healthy := make(chan struct{})
+	blocked := make(chan struct{})
+
+	// Healthy until blocked is closed, then never returns, ignoring context.
+	check := func(ctx context.Context) (interface{}, error) {
+		select {
+		case <-blocked:
+			<-stall
+			return nil, nil
+		default:
+			select {
+			case healthy <- struct{}{}:
+			default:
+			}
+			return nil, nil
+		}
+	}
+
+	h := gosundheit.New()
+	err := h.RegisterCheck(
+		&checks.CustomCheck{
+			CheckName: "storage",
+			CheckFunc: health.NewTimeoutCheckFunc(check, 50*time.Millisecond),
+		},
+		gosundheit.ExecutionPeriod(100*time.Millisecond),
+		gosundheit.InitiallyPassing(true),
+	)
+	if err != nil {
+		t.Fatalf("register check: %v", err)
+	}
+	defer h.DeregisterAll()
+
+	// Establish healthy first, so the assertion below is a transition.
+	select {
+	case <-healthy:
+	case <-time.After(5 * time.Second):
+		t.Fatal("check never ran while healthy")
+	}
+	if !h.IsHealthy() {
+		t.Fatal("expected healthy before the dependency becomes unresponsive")
+	}
+
+	close(blocked)
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if !h.IsHealthy() {
+			return // reported unhealthy
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("health checker still reports healthy after the dependency " +
+				"stopped responding: a check that never returns must not leave " +
+				"the last passing result standing")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
#### Overview

Health checks that perform I/O can be blocked indefinitely by the very dependency
they are checking. When that happens the check does not fail — it stops returning,
and the scheduler goes on serving the last result it recorded, which is a passing
one. Dex then reports itself healthy for the whole outage.

This wraps the check so that an execution which overruns is reported as a failure,
and applies it to the storage check.

#### What this PR does / motivation

We hit this in production. A dex instance became unable to serve any storage
operation and stayed that way for over 13 hours, reporting healthy throughout:
`/healthz/ready` answered `200` in 8ms and the load balancer kept it in rotation.
The storage check is a real round trip, so it was blocked by the same condition it
exists to detect — it did not fail, it stopped returning, and a check that never
returns records nothing.

The triggering bug is separate and fixed separately. This PR is about the health
check being unable to report it, or the next one.

**Why the existing timeout option is not sufficient**

`go-sundheit` records a result when a check returns. `checkTask.execute` invokes
the check synchronously, so a check that never returns records nothing and the
previously recorded (passing) result stands.

Setting `gosundheit.ExecutionTimeout` does not address this: it only cancels the
context, and cancellation is cooperative. A check blocked where cancellation is
not observed — waiting on a `database/sql` connection pool, inside a driver that
takes no context, in a syscall, in cgo — never returns regardless. In our case the
check was parked in a pool wait, and the SQL storage layer does not propagate
context to `database/sql` at all, so there was nothing to cancel.

**What this changes**

`storage.NewTimeoutHealthCheckFunc` wraps a check function so that:

- the check runs on its own goroutine, and the caller stops waiting once it
  overruns, reporting the overrun as a failure;
- the context is canceled on overrun, so checks that do observe cancellation
  unblock promptly;
- executions are single-flight.

Single-flight matters because Go cannot stop a goroutine: one that is blocked keeps
running and completes only if the dependency recovers. Starting a fresh one per
scheduler tick would accumulate one goroutine per tick for the length of the outage
(thousands, over hours), each still holding whatever it had acquired. Instead,
while an execution is outstanding, later ones report the failure without starting
another.

One consequence, deliberate: **an execution that never returns holds the slot for
the life of the process**, so the check reports a failure from then on
even if the dependency later recovers. An execution that cannot be completed
attests to nothing, and a process holding resources it may never release is not
one to report as healthy. Recovery is by restart, which is the outcome such a
process needs anyway. This is documented on the exported function and pinned by a
test.

This bounds the cost of an outage and makes it visible. It does not make the
process any healthier, and is not a substitute for fixing the underlying faults.

Applied to the storage check in `cmd/dex/serve.go` — currently the only registered
check, and the only one that performs I/O. (`/healthz/live` is static;
`server.go`'s `/healthz` reads the same cached verdict and is fixed by the same
change.)

**Tests**

`storage/health_test.go` (12 tests) — a check that never returns is reported as a
failure; single-flight is enforced; the check recovers once the outstanding
execution returns; a stuck execution keeps the check failing and is never
restarted; the goroutine releases the slot before delivering its result; the
context is canceled on overrun; caller cancellation releases the caller; a stale
result is never handed to a later caller; details and errors pass through; defaults
are applied; concurrent executions under `-race`.

`storage/health_scheduler_test.go` — drives the real `go-sundheit` scheduler and
asserts it goes unhealthy when the check stops returning. Pointed at the unwrapped
check this test fails, reproducing the symptom above: the scheduler keeps reporting
healthy.

Statement coverage of the wrapper is 100%.

#### Special notes for reviewers

- **Defaults.** `DefaultHealthCheckTimeout` is 10s against the existing 15s
  execution period, so a stalled execution is reported before the next is due. It is
  deliberately generous: it bounds a stall, it does not police latency. It is not
  currently configurable — happy to expose it in config if you would prefer that
  before merge, particularly for larger SQL or etcd deployments where 10s might be
  tight under load.

- **`InitiallyPassing(true)` is unchanged.** It means dex reports healthy for up to
  one period before the first check completes. Arguably wrong for a readiness probe,
  but it is existing behavior and changing it affects every deployment, so it seemed
  out of scope here.

- **Placement.** The wrapper makes no assumptions about the check it is given, so
  `pkg/` may be a better home than `storage`. It is in `storage` because that is
  where the only check that needs it lives. Happy to move it.

- **Wrapping is applied at the registration site**, not inside the check, so a future
  check that performs I/O must be wrapped explicitly. Wrapping inside `RegisterCheck`
  is not possible without vendoring `go-sundheit`. With one check this is fine; at
  two it is probably worth a small register-and-wrap helper.

- **Panics are not recovered.** `go-sundheit` has no `recover()`, so a panicking
  check crashes the process both before and after this change. Behavior is unchanged;
  converting a panic to a check failure would be a reasonable follow-up but is a
  behavior change beyond "do not hang".

- **Upstream alternative.** The cleanest long-term home for this is `go-sundheit`
  itself — `checkTask.execute` could run the check on a goroutine and record a
  timeout result on overrun, fixing it for every consumer. Happy to raise that
  upstream. This wrapper would still be wanted in the interim, and dex would keep
  control of the single-flight policy.

- **The behavior change to be aware of:** a check that correctly starts failing will
  now cycle a container configured with a health-gated restart policy, where
  previously the outage was silent. That is the intent, but it is a visible
  difference for operators.
