### PR TITLE
test(oidc): publish a real signing alg in the test JWKS

### DIFF
--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -880,7 +880,7 @@ func setupServer(tok map[string]interface{}, idTokenDesired bool) (*httptest.Ser
 	jwk := jose.JSONWebKey{
 		Key:       key,
 		KeyID:     "keyId",
-		Algorithm: "RSA",
+		Algorithm: "RS256",
 	}
 
 	mux := http.NewServeMux()
@@ -889,7 +889,7 @@ func setupServer(tok map[string]interface{}, idTokenDesired bool) (*httptest.Ser
 		json.NewEncoder(w).Encode(&map[string]interface{}{
 			"keys": []map[string]interface{}{{
 				"alg": jwk.Algorithm,
-				"kty": jwk.Algorithm,
+				"kty": "RSA",
 				"kid": jwk.KeyID,
 				"n":   n(&key.PublicKey),
 				"e":   e(&key.PublicKey),


### PR DESCRIPTION
## What

The OIDC connector's test key set publishes `"RSA"` as both `alg` and `kty`:

```go
jwk := jose.JSONWebKey{
    Key:       key,
    KeyID:     "keyId",
    Algorithm: "RSA",
}
...
"alg": jwk.Algorithm,
"kty": jwk.Algorithm,
```

`RSA` is a key type, not a signing algorithm, and `newToken` signs with `jose.RS256`, so the advertised `alg` is simply wrong.

## Why it matters now

go-oidc tolerated the mismatch until v3.20.0, which [ignores JWKs with unknown signing algorithms rather than failing](https://github.com/coreos/go-oidc/pull/491). A key advertising `alg: "RSA"` is no longer an error — it is silently skipped, which leaves the verifier with no usable key at all:

```
--- FAIL: TestHandleCallback/simpleCase
    oidc_test.go:580: handle callback failed oidc: failed to verify ID Token: failed to verify signature: failed to verify id token signature
--- FAIL: TestRefresh
--- FAIL: TestTokenIdentity
```

Reproduced on current master with `go get github.com/coreos/go-oidc/v3@v3.20.0`. This will land the moment the go-oidc bump does.

## The change

Publish `RS256` as the algorithm and `RSA` as the key type. Test-only, no production code touched.

Verified passing on both go-oidc v3.19.0 (current pin) and v3.20.0.