### PR TITLE
fix(storage): support pagination in Kubernetes storage GC (#4979)

### DIFF
--- a/storage/kubernetes/client.go
+++ b/storage/kubernetes/client.go
@@ -229,8 +229,15 @@ func (cli *client) getResource(apiVersion, namespace, resource, name string, v i
 }
 
 func (cli *client) listN(resource string, v interface{}, n int) error { //nolint:unparam // In practice, n is the gcResultLimit constant.
+	return cli.listNWithContinue(resource, v, n, "")
+}
+
+func (cli *client) listNWithContinue(resource string, v interface{}, n int, continueToken string) error {
 	params := url.Values{}
 	params.Add("limit", fmt.Sprintf("%d", n))
+	if continueToken != "" {
+		params.Add("continue", continueToken)
+	}
 	u, err := cli.urlForWithParams(cli.apiVersion, cli.namespace, resource, "", params)
 	if err != nil {
 		return err

--- a/storage/kubernetes/k8sapi/unversioned.go
+++ b/storage/kubernetes/k8sapi/unversioned.go
@@ -49,4 +49,10 @@ type ListMeta struct {
 	// Read-only.
 	// More info: http://releases.k8s.io/release-1.3/docs/devel/api-conventions.md#concurrency-control-and-consistency
 	ResourceVersion string `json:"resourceVersion,omitempty" protobuf:"bytes,2,opt,name=resourceVersion"`
+
+	// Continue may be set if the user set a limit on the number of items returned, and indicates that
+	// the server has more data available. The value is opaque and may be used as the 'continue' parameter
+	// to retrieve the next set of results.
+	// Read-only.
+	Continue string `json:"continue,omitempty" protobuf:"bytes,3,opt,name=continue"`
 }

--- a/storage/kubernetes/storage.go
+++ b/storage/kubernetes/storage.go
@@ -630,90 +630,145 @@ func (cli *client) UpdateConnector(ctx context.Context, id string, updater func(
 }
 
 func (cli *client) GarbageCollect(ctx context.Context, now time.Time) (result storage.GCResult, err error) {
-	var authRequests AuthRequestList
-	if err := cli.listN(resourceAuthRequest, &authRequests, gcResultLimit); err != nil {
-		return result, fmt.Errorf("failed to list auth requests: %v", err)
-	}
-
 	var delErr error
-	for _, authRequest := range authRequests.AuthRequests {
-		if now.After(authRequest.Expiry) {
-			if err := cli.delete(resourceAuthRequest, authRequest.ObjectMeta.Name); err != nil {
-				cli.logger.Error("failed to delete auth request", "err", err)
-				delErr = fmt.Errorf("failed to delete auth request: %v", err)
-			}
-			result.AuthRequests++
+
+	// Process AuthRequests with pagination support
+	continueToken := ""
+	for {
+		var authRequests AuthRequestList
+		if err := cli.listNWithContinue(resourceAuthRequest, &authRequests, gcResultLimit, continueToken); err != nil {
+			return result, fmt.Errorf("failed to list auth requests: %v", err)
 		}
-	}
-	if delErr != nil {
-		return result, delErr
-	}
 
-	var authCodes AuthCodeList
-	if err := cli.listN(resourceAuthCode, &authCodes, gcResultLimit); err != nil {
-		return result, fmt.Errorf("failed to list auth codes: %v", err)
-	}
-
-	for _, authCode := range authCodes.AuthCodes {
-		if now.After(authCode.Expiry) {
-			if err := cli.delete(resourceAuthCode, authCode.ObjectMeta.Name); err != nil {
-				cli.logger.Error("failed to delete auth code", "err", err)
-				delErr = fmt.Errorf("failed to delete auth code: %v", err)
-			}
-			result.AuthCodes++
-		}
-	}
-
-	var deviceRequests DeviceRequestList
-	if err := cli.listN(resourceDeviceRequest, &deviceRequests, gcResultLimit); err != nil {
-		return result, fmt.Errorf("failed to list device requests: %v", err)
-	}
-
-	for _, deviceRequest := range deviceRequests.DeviceRequests {
-		if now.After(deviceRequest.Expiry) {
-			if err := cli.delete(resourceDeviceRequest, deviceRequest.ObjectMeta.Name); err != nil {
-				cli.logger.Error("failed to delete device request", "err", err)
-				delErr = fmt.Errorf("failed to delete device request: %v", err)
-			}
-			result.DeviceRequests++
-		}
-	}
-
-	var deviceTokens DeviceTokenList
-	if err := cli.listN(resourceDeviceToken, &deviceTokens, gcResultLimit); err != nil {
-		return result, fmt.Errorf("failed to list device tokens: %v", err)
-	}
-
-	for _, deviceToken := range deviceTokens.DeviceTokens {
-		if now.After(deviceToken.Expiry) {
-			if err := cli.delete(resourceDeviceToken, deviceToken.ObjectMeta.Name); err != nil {
-				cli.logger.Error("failed to delete device token", "err", err)
-				delErr = fmt.Errorf("failed to delete device token: %v", err)
-			}
-			result.DeviceTokens++
-		}
-	}
-
-	var authSessions AuthSessionList
-	if err := cli.listN(resourceAuthSession, &authSessions, gcResultLimit); err != nil {
-		return result, fmt.Errorf("failed to list auth sessions: %v", err)
-	}
-
-	for _, authSession := range authSessions.AuthSessions {
-		if now.After(authSession.AbsoluteExpiry) || now.After(authSession.IdleExpiry) {
-			if err := cli.delete(resourceAuthSession, authSession.ObjectMeta.Name); err != nil {
-				cli.logger.Error("failed to delete auth session", "err", err)
-				delErr = fmt.Errorf("failed to delete auth session: %v", err)
-			} else {
-				result.AuthSessions++
+		for _, authRequest := range authRequests.AuthRequests {
+			if now.After(authRequest.Expiry) {
+				if err := cli.delete(resourceAuthRequest, authRequest.ObjectMeta.Name); err != nil {
+					cli.logger.Error("failed to delete auth request", "err", err)
+					delErr = fmt.Errorf("failed to delete auth request: %v", err)
+				}
+				result.AuthRequests++
 			}
 		}
+		if delErr != nil {
+			return result, delErr
+		}
+
+		if authRequests.ListMeta.Continue == "" {
+			break
+		}
+		continueToken = authRequests.ListMeta.Continue
 	}
 
-	if delErr != nil {
-		return result, delErr
+	// Process AuthCodes with pagination support
+	continueToken = ""
+	for {
+		var authCodes AuthCodeList
+		if err := cli.listNWithContinue(resourceAuthCode, &authCodes, gcResultLimit, continueToken); err != nil {
+			return result, fmt.Errorf("failed to list auth codes: %v", err)
+		}
+
+		for _, authCode := range authCodes.AuthCodes {
+			if now.After(authCode.Expiry) {
+				if err := cli.delete(resourceAuthCode, authCode.ObjectMeta.Name); err != nil {
+					cli.logger.Error("failed to delete auth code", "err", err)
+					delErr = fmt.Errorf("failed to delete auth code: %v", err)
+				}
+				result.AuthCodes++
+			}
+		}
+		if delErr != nil {
+			return result, delErr
+		}
+
+		if authCodes.ListMeta.Continue == "" {
+			break
+		}
+		continueToken = authCodes.ListMeta.Continue
 	}
-	return result, delErr
+
+	// Process DeviceRequests with pagination support
+	continueToken = ""
+	for {
+		var deviceRequests DeviceRequestList
+		if err := cli.listNWithContinue(resourceDeviceRequest, &deviceRequests, gcResultLimit, continueToken); err != nil {
+			return result, fmt.Errorf("failed to list device requests: %v", err)
+		}
+
+		for _, deviceRequest := range deviceRequests.DeviceRequests {
+			if now.After(deviceRequest.Expiry) {
+				if err := cli.delete(resourceDeviceRequest, deviceRequest.ObjectMeta.Name); err != nil {
+					cli.logger.Error("failed to delete device request", "err", err)
+					delErr = fmt.Errorf("failed to delete device request: %v", err)
+				}
+				result.DeviceRequests++
+			}
+		}
+		if delErr != nil {
+			return result, delErr
+		}
+
+		if deviceRequests.ListMeta.Continue == "" {
+			break
+		}
+		continueToken = deviceRequests.ListMeta.Continue
+	}
+
+	// Process DeviceTokens with pagination support
+	continueToken = ""
+	for {
+		var deviceTokens DeviceTokenList
+		if err := cli.listNWithContinue(resourceDeviceToken, &deviceTokens, gcResultLimit, continueToken); err != nil {
+			return result, fmt.Errorf("failed to list device tokens: %v", err)
+		}
+
+		for _, deviceToken := range deviceTokens.DeviceTokens {
+			if now.After(deviceToken.Expiry) {
+				if err := cli.delete(resourceDeviceToken, deviceToken.ObjectMeta.Name); err != nil {
+					cli.logger.Error("failed to delete device token", "err", err)
+					delErr = fmt.Errorf("failed to delete device token: %v", err)
+				}
+				result.DeviceTokens++
+			}
+		}
+		if delErr != nil {
+			return result, delErr
+		}
+
+		if deviceTokens.ListMeta.Continue == "" {
+			break
+		}
+		continueToken = deviceTokens.ListMeta.Continue
+	}
+
+	// Process AuthSessions with pagination support
+	continueToken = ""
+	for {
+		var authSessions AuthSessionList
+		if err := cli.listNWithContinue(resourceAuthSession, &authSessions, gcResultLimit, continueToken); err != nil {
+			return result, fmt.Errorf("failed to list auth sessions: %v", err)
+		}
+
+		for _, authSession := range authSessions.AuthSessions {
+			if now.After(authSession.AbsoluteExpiry) || now.After(authSession.IdleExpiry) {
+				if err := cli.delete(resourceAuthSession, authSession.ObjectMeta.Name); err != nil {
+					cli.logger.Error("failed to delete auth session", "err", err)
+					delErr = fmt.Errorf("failed to delete auth session: %v", err)
+				} else {
+					result.AuthSessions++
+				}
+			}
+		}
+		if delErr != nil {
+			return result, delErr
+		}
+
+		if authSessions.ListMeta.Continue == "" {
+			break
+		}
+		continueToken = authSessions.ListMeta.Continue
+	}
+
+	return result, nil
 }
 
 func (cli *client) CreateDeviceRequest(ctx context.Context, d storage.DeviceRequest) error {


### PR DESCRIPTION
Fixes incomplete garbage collection in Kubernetes storage backend when deployments have more than 500 expired objects.

**Problem:** The Kubernetes API enforces a 500-item hard limit per list request. The GC function was not handling pagination, so it only processed the first 500 objects.

**Solution:** Add pagination support by capturing and using continuation tokens in the GarbageCollect function for all resource types.

**Changes:** Added Continue field to ListMeta, new listNWithContinue() method, and pagination loops in GarbageCollect().

Fixes #4979