### PR TITLE
fix(apiserver): refuse an identity purge that cannot finish

### DIFF
--- a/server/apiserver/identities.go
+++ b/server/apiserver/identities.go
@@ -83,6 +83,14 @@ func (d dexAPI) ListUserIdentities(ctx context.Context, req *api.ListUserIdentit
 	}, nil
 }
 
+// readOnlyPasswords is implemented by the storage wrapper that serves static
+// passwords from the config file. It is an assertion rather than part of the
+// Storage interface because only the purge needs to ask the question, and only
+// to refuse rather than to act.
+type readOnlyPasswords interface {
+	IsStaticPassword(email string) bool
+}
+
 func (d dexAPI) DeleteUserIdentity(ctx context.Context, req *api.DeleteUserIdentityReq) (*api.DeleteUserIdentityResp, error) {
 	if !featureflags.APISessionsIdentitiesCRUD.Enabled() {
 		return nil, fmt.Errorf("%s feature flag is not enabled", featureflags.APISessionsIdentitiesCRUD.Name)
@@ -104,6 +112,19 @@ func (d dexAPI) DeleteUserIdentity(ctx context.Context, req *api.DeleteUserIdent
 		}
 		d.logger.Error("api: failed to get user identity during purge", "err", err)
 		return nil, fmt.Errorf("delete user identity: %v", err)
+	}
+
+	// The cascade spans several stores and dex has no transaction across them, so
+	// the one step that fails for a predictable reason is checked before anything
+	// is destroyed. A password served from the config file cannot be deleted
+	// through the API; discovering that at the password step would leave the user
+	// signed out everywhere, their tokens revoked, and their account still there,
+	// with no way to finish from here.
+	if email := identity.Claims.Email; email != "" {
+		if ro, ok := d.s.(readOnlyPasswords); ok && ro.IsStaticPassword(email) {
+			return nil, fmt.Errorf("purge user identity: the password for %q comes from dex's configuration file "+
+				"and cannot be deleted through the API; remove the user from the config file first. Nothing was deleted", email)
+		}
 	}
 
 	// Cascade deletes. A real (non-not-found) failure aborts the purge and returns

--- a/server/apiserver/identities_test.go
+++ b/server/apiserver/identities_test.go
@@ -1,0 +1,109 @@
+package apiserver
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dexidp/dex/api/v2"
+	"github.com/dexidp/dex/pkg/featureflags"
+	"github.com/dexidp/dex/storage"
+	"github.com/dexidp/dex/storage/memory"
+)
+
+// The GDPR purge cascades over several stores with no transaction across them,
+// so the one step that fails for a predictable reason has to be settled before
+// anything is destroyed. A password that comes from the config file cannot be
+// deleted through the API: reaching it halfway through leaves the user signed
+// out everywhere and their account still standing, with no way to finish.
+func TestPurgeRefusesBeforeTouchingAnythingWhenThePasswordIsConfigBacked(t *testing.T) {
+	t.Setenv("DEX_"+strings.ToUpper(featureflags.APISessionsIdentitiesCRUD.Name), "true")
+
+	const userID, connID, sessionID = "u1", "local", "s1"
+
+	tests := []struct {
+		name        string
+		email       string
+		staticEmail string
+		wantRefused bool
+	}{
+		{
+			name:        "config-backed password",
+			email:       "jane@example.com",
+			staticEmail: "jane@example.com",
+			wantRefused: true,
+		},
+		{
+			// The same address in a different case is the same account to dex,
+			// so it has to be the same answer here.
+			name:        "config-backed password, different case",
+			email:       "Jane@Example.com",
+			staticEmail: "jane@example.com",
+			wantRefused: true,
+		},
+		{
+			name:        "password lives in storage",
+			email:       "jane@example.com",
+			staticEmail: "someone-else@example.com",
+			wantRefused: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			logger := newLogger(t)
+
+			// Wrapped the way serve.go wraps it. Nesting is the whole difficulty:
+			// the wrappers embed Storage as an interface, so a check that only
+			// works when the password wrapper is outermost passes here and does
+			// nothing in a real dex.
+			var s storage.Storage = memory.New(logger)
+			s = storage.WithStaticClients(s, nil)
+			s = storage.WithStaticPasswords(s, []storage.Password{{
+				Email: tc.staticEmail, UserID: "static-user", Hash: []byte("hash"),
+			}}, logger)
+			s = storage.WithStaticConnectors(s, nil)
+
+			require.NoError(t, s.CreateUserIdentity(ctx, storage.UserIdentity{
+				UserID: userID, ConnectorID: connID,
+				Claims:    storage.Claims{UserID: userID, Email: tc.email},
+				CreatedAt: time.Now(), LastLogin: time.Now(),
+			}))
+			require.NoError(t, s.CreateAuthSession(ctx, storage.AuthSession{
+				ID: sessionID, Secret: "session-secret",
+				UserID: userID, ConnectorID: connID,
+				CreatedAt: time.Now(), LastActivity: time.Now(),
+			}))
+
+			d := NewAPI(s, logger, "test", nil, nil, nil)
+			_, err := d.DeleteUserIdentity(ctx, &api.DeleteUserIdentityReq{
+				UserId: userID, ConnectorId: connID,
+			})
+
+			if !tc.wantRefused {
+				require.NoError(t, err)
+				_, err = s.GetAuthSession(ctx, sessionID)
+				require.ErrorIs(t, err, storage.ErrNotFound, "a purge that succeeds takes the sessions with it")
+				return
+			}
+
+			require.Error(t, err)
+			message := err.Error()
+
+			// Asserted before the wording, because this is the actual defect:
+			// the cascade must never have started.
+			_, err = s.GetAuthSession(ctx, sessionID)
+			require.NoError(t, err, "the session was ended by a purge that could not finish")
+			_, err = s.GetUserIdentity(ctx, userID, connID)
+			require.NoError(t, err, "the identity was deleted by a purge that could not finish")
+
+			// And the caller has to be told what to do about it, not handed the
+			// storage layer's own words.
+			require.Contains(t, message, "configuration file")
+			require.Contains(t, message, "Nothing was deleted")
+		})
+	}
+}

--- a/storage/static.go
+++ b/storage/static.go
@@ -31,6 +31,13 @@ func WithStaticClients(s Storage, staticClients []Client) Storage {
 	return staticClientsStorage{s, staticClients, clientsByID}
 }
 
+// IsStaticPassword forwards the question inwards. These wrappers embed Storage
+// as an interface, so they do not promote the password wrapper's own methods:
+// without this the answer would depend on which wrapper happens to be outermost.
+func (s staticClientsStorage) IsStaticPassword(email string) bool {
+	return isStaticPassword(s.Storage, email)
+}
+
 func (s staticClientsStorage) GetClient(ctx context.Context, id string) (Client, error) {
 	if client, ok := s.clientsByID[id]; ok {
 		return client, nil
@@ -112,6 +119,21 @@ func (s staticPasswordsStorage) isStatic(email string) bool {
 	return ok
 }
 
+// IsStaticPassword reports whether an email is served from the config file
+// rather than from storage. Deleting one is refused, so a caller that is about
+// to cascade several deletes needs to know before it starts: finding out
+// halfway leaves the earlier steps done and no way to finish.
+func (s staticPasswordsStorage) IsStaticPassword(email string) bool {
+	return s.isStatic(email)
+}
+
+// isStaticPassword asks a storage the same question without caring which
+// wrapper answers it.
+func isStaticPassword(s Storage, email string) bool {
+	ro, ok := s.(interface{ IsStaticPassword(string) bool })
+	return ok && ro.IsStaticPassword(email)
+}
+
 func (s staticPasswordsStorage) GetPassword(ctx context.Context, email string) (Password, error) {
 	// TODO(ericchiang): BLAH. We really need to figure out how to handle
 	// lower cased emails better.
@@ -183,6 +205,13 @@ func WithStaticConnectors(s Storage, staticConnectors []Connector) Storage {
 func (s staticConnectorsStorage) isStatic(id string) bool {
 	_, ok := s.connectorsByID[id]
 	return ok
+}
+
+// IsStaticPassword forwards the question inwards. These wrappers embed Storage
+// as an interface, so they do not promote the password wrapper's own methods:
+// without this the answer would depend on which wrapper happens to be outermost.
+func (s staticConnectorsStorage) IsStaticPassword(email string) bool {
+	return isStaticPassword(s.Storage, email)
 }
 
 func (s staticConnectorsStorage) GetConnector(ctx context.Context, id string) (Connector, error) {


### PR DESCRIPTION
#### Overview

`DeleteUserIdentity` can destroy half a user's data and then fail, with no way to finish the job from the API. This checks the step that predictably fails before anything is deleted.

#### What this PR does / why we need it

The purge cascades over several stores — auth sessions, refresh tokens, offline sessions, the password record, the identity — and dex has no transaction across them. The password record is deleted near the end, and a password that comes from the config file **cannot** be deleted through the API at all.

So purging a static user today:

1. ends every session (notifying relying parties over back-channel logout),
2. revokes every refresh token,
3. deletes the offline sessions,
4. fails at `purge password: static passwords: read-only cannot delete password`.

The caller gets an error, but the account is still there, the user is signed out everywhere, and there is nothing they can do from the API to complete or undo it. For an endpoint whose documented purpose is a GDPR erasure, "half done and not repeatable" is the worst outcome available.

This checks first and refuses:

```
purge user identity: the password for "jane@example.com" comes from dex's configuration
file and cannot be deleted through the API; remove the user from the config file first.
Nothing was deleted
```

#### Special notes for your reviewer

Asking the question needs the static wrapper to answer it, hence `IsStaticPassword` on `staticPasswordsStorage`. It is a type assertion in the apiserver rather than a method on `storage.Storage`, because only the purge needs to ask, and only in order to refuse.

The subtle part is the forwarding. The three static wrappers embed `Storage` as an *interface*, so they do not promote each other's methods: a check that only works when the password wrapper is outermost passes its test and does nothing in a real dex, where `serve.go` stacks clients → passwords → connectors. Each wrapper forwards the question inwards, and the test stacks them the same way `serve.go` does.

The test asserts the session and the identity survive *before* it asserts the wording, so reverting the fix fails it on the defect rather than on the message.

Reordering the cascade to attempt the password first was the smaller diff, but it moves the partial state rather than removing it: a non-static user would then lose their password and keep their sessions, which is worse than the reverse.

`storage/sql` does not build on master right now (`testing.(*B).Output requires go1.25`, in `postgres_test.go`); unrelated to this change.
