### PR TITLE
feat(server): log the client id on successful login

### DIFF
--- a/server/authflow/finalize.go
+++ b/server/authflow/finalize.go
@@ -64,7 +64,8 @@ func (h *Handler) finalizeLogin(ctx context.Context, identity connector.Identity
 	}
 
 	h.Logger.InfoContext(ctx, "login successful",
-		"connector_id", authReq.ConnectorID, "user_id", claims.UserID,
+		"connector_id", authReq.ConnectorID, "client_id", authReq.ClientID,
+		"user_id", claims.UserID,
 		"username", claims.Username, "preferred_username", claims.PreferredUsername,
 		"email", email, "groups", claims.Groups)
 

--- a/server/authflow/finalize_test.go
+++ b/server/authflow/finalize_test.go
@@ -1,6 +1,10 @@
 package authflow
 
 import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -57,4 +61,41 @@ func TestFinalizeLoginBlockedAccount(t *testing.T) {
 	}))
 	_, err = server.finalizeLogin(ctx, ident, authReq, nil)
 	require.NoError(t, err)
+}
+
+// The authorization code flow's success line is the only record of a login that
+// operators get, and without the client it cannot answer which application was
+// signed in to when several share a connector.
+func TestFinalizeLoginLogsClientID(t *testing.T) {
+	var logBuf bytes.Buffer
+	httpServer, server := newTestHandler(t, func(c *testFlowConfig) {
+		c.Logger = slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	})
+	defer httpServer.Close()
+
+	ctx := t.Context()
+
+	authReq := storage.AuthRequest{
+		ID:          "login-req",
+		ClientID:    "example-app",
+		Expiry:      time.Now().Add(time.Hour),
+		ConnectorID: "mock",
+	}
+	require.NoError(t, server.Storage.CreateAuthRequest(ctx, authReq))
+
+	ident := connector.Identity{UserID: "user-1", Email: "user@example.com"}
+	_, err := server.finalizeLogin(ctx, ident, authReq, nil)
+	require.NoError(t, err)
+
+	var logged bool
+	for _, line := range strings.Split(strings.TrimSpace(logBuf.String()), "\n") {
+		var record map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &record))
+		if record["msg"] != "login successful" {
+			continue
+		}
+		logged = true
+		require.Equal(t, "example-app", record["client_id"])
+	}
+	require.True(t, logged, "finalizeLogin did not log a successful login")
 }


### PR DESCRIPTION
#### Overview

Adds `client_id` to the `"login successful"` line `finalizeLogin` emits.

#### What this PR does / why we need it

Where several clients share one connector — an SSO broker fanning a single upstream IdP out to a client per service — this line is the only record of an authorization code login, and it cannot say which application was signed in to.

Every other line carrying `client_id` is an error path (`invalid client_id provided`, `unregistered redirect_uri`), so correlating on `request_id` does not recover it either. `authReq.ClientID` is already in scope.

This mirrors #4780, which added the same field to the token exchange success line for the same reason.

#### Special notes for your reviewer

- `TestFinalizeLoginLogsClientID` follows #4780's pattern (JSON `slog` handler injected via the test config); it fails on master.
- Observability only — no API, storage or behaviour change.
