### PR TITLE
Add configurable ID token subject claim format and order

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ ID Tokens contains standard claims assert which client app logged the user in, w
 }
 ```
 
+By default, Dex emits `sub` in a protobuf+base64url format. To use a
+wildcard-friendly string subject (for example in AWS IAM trust policies), set
+`oauth2.subjectClaim: plain` in Dex configuration.
+For plain subjects, you can also control order with
+`oauth2.subjectClaimOrder`: `user-connector` (default) or `connector-user`.
+
 Because these tokens are signed by dex and [contain standard-based claims][standard-claims] other services can consume them as service-to-service credentials. Systems that can already consume OpenID Connect ID Tokens issued by dex include:
 
 * [Kubernetes][kubernetes]

--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dexidp/dex/server"
 	"github.com/dexidp/dex/server/connectors"
 	"github.com/dexidp/dex/server/signer"
+	"github.com/dexidp/dex/server/tokens"
 	"github.com/dexidp/dex/storage"
 	"github.com/dexidp/dex/storage/ent"
 	"github.com/dexidp/dex/storage/etcd"
@@ -129,6 +130,12 @@ func (c Config) Validate() error {
 
 	if err := c.validateMFA(); err != nil {
 		return err
+	}
+	if _, err := tokens.ParseSubjectFormat(c.OAuth2.SubjectClaim); err != nil {
+		return fmt.Errorf("invalid oauth2.subjectClaim value %q: %w", c.OAuth2.SubjectClaim, err)
+	}
+	if _, err := tokens.ParseSubjectOrder(c.OAuth2.SubjectClaimOrder); err != nil {
+		return fmt.Errorf("invalid oauth2.subjectClaimOrder value %q: %w", c.OAuth2.SubjectClaimOrder, err)
 	}
 
 	for _, client := range c.StaticClients {
@@ -252,6 +259,13 @@ type OAuth2 struct {
 	PasswordConnector string `json:"passwordConnector"`
 	// PKCE configuration
 	PKCE PKCE `json:"pkce"`
+
+	// SubjectClaim controls how Dex formats the ID token "sub" claim.
+	// Supported values are "base64" (default) and "plain".
+	SubjectClaim string `json:"subjectClaim"`
+	// SubjectClaimOrder controls field order for plain subject claims.
+	// Supported values are "user-connector" (default) and "connector-user".
+	SubjectClaimOrder string `json:"subjectClaimOrder"`
 }
 
 // PKCE holds the PKCE (Proof Key for Code Exchange) configuration.

--- a/cmd/dex/config_test.go
+++ b/cmd/dex/config_test.go
@@ -80,10 +80,60 @@ func TestInvalidRefreshTokenLifetime(t *testing.T) {
 			{ID: "proxy", RefreshTokenLifetime: "sessions"},
 		},
 	}
-
 	err := configuration.Validate()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `client "proxy"`)
+}
+
+func TestInvalidSubjectClaimConfiguration(t *testing.T) {
+	configuration := Config{
+		Issuer: "http://127.0.0.1:5556/dex",
+		Storage: Storage{
+			Type: "sqlite3",
+			Config: &sql.SQLite3{
+				File: "examples/dex.db",
+			},
+		},
+		Web: Web{
+			HTTP: "127.0.0.1:5556",
+		},
+		OAuth2: OAuth2{
+			SubjectClaim: "nope",
+		},
+	}
+	err := configuration.Validate()
+	if err == nil {
+		t.Fatal("this configuration should be invalid")
+	}
+	if !strings.Contains(err.Error(), `invalid oauth2.subjectClaim value "nope"`) {
+		t.Fatalf("expected subject claim validation error, got %q", err.Error())
+	}
+}
+
+func TestInvalidSubjectClaimOrderConfiguration(t *testing.T) {
+	configuration := Config{
+		Issuer: "http://127.0.0.1:5556/dex",
+		Storage: Storage{
+			Type: "sqlite3",
+			Config: &sql.SQLite3{
+				File: "examples/dex.db",
+			},
+		},
+		Web: Web{
+			HTTP: "127.0.0.1:5556",
+		},
+		OAuth2: OAuth2{
+			SubjectClaimOrder: "backwards",
+		},
+	}
+
+	err := configuration.Validate()
+	if err == nil {
+		t.Fatal("this configuration should be invalid")
+	}
+	if !strings.Contains(err.Error(), `invalid oauth2.subjectClaimOrder value "backwards"`) {
+		t.Fatalf("expected subject claim order validation error, got %q", err.Error())
+	}
 }
 
 func TestUnmarshalConfig(t *testing.T) {
@@ -119,6 +169,8 @@ staticClients:
 
 oauth2:
   alwaysShowLoginScreen: true
+  subjectClaim: plain
+  subjectClaimOrder: connector-user
   grantTypes:
   - refresh_token
   - "urn:ietf:params:oauth:grant-type:token-exchange"
@@ -214,6 +266,8 @@ additionalFeatures: [
 		},
 		OAuth2: OAuth2{
 			AlwaysShowLoginScreen: true,
+			SubjectClaim:          "plain",
+			SubjectClaimOrder:     "connector-user",
 			GrantTypes: []string{
 				"refresh_token",
 				"urn:ietf:params:oauth:grant-type:token-exchange",

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -394,6 +394,16 @@ func runServe(options serveOptions) error {
 		MFAProviders:               buildMFAProviders(c.MFA.Authenticators, c.Issuer, logger),
 		DefaultMFAChain:            c.MFA.DefaultMFAChain,
 	}
+	subjectClaimFormat, err := tokens.ParseSubjectFormat(c.OAuth2.SubjectClaim)
+	if err != nil {
+		return fmt.Errorf("invalid config value %q for oauth2.subjectClaim: %v", c.OAuth2.SubjectClaim, err)
+	}
+	serverConfig.SubjectClaimFormat = subjectClaimFormat
+	subjectClaimOrder, err := tokens.ParseSubjectOrder(c.OAuth2.SubjectClaimOrder)
+	if err != nil {
+		return fmt.Errorf("invalid config value %q for oauth2.subjectClaimOrder: %v", c.OAuth2.SubjectClaimOrder, err)
+	}
+	serverConfig.SubjectClaimOrder = subjectClaimOrder
 
 	if c.Expiry.AuthRequests != "" {
 		authRequests, err := time.ParseDuration(c.Expiry.AuthRequests)
@@ -614,7 +624,7 @@ func runServe(options serveOptions) error {
 		}
 
 		grpcSrv := grpc.NewServer(grpcOptions...)
-		api.RegisterDexServer(grpcSrv, apiserver.NewAPI(serverConfig.Storage, logger, version, serv.Connectors(), serv.Discovery(), serv.Backchannel()))
+		api.RegisterDexServer(grpcSrv, apiserver.NewAPI(serverConfig.Storage, logger, version, serv.Connectors(), serv.Discovery(), serv.Backchannel(), serverConfig.SubjectClaimOrder))
 
 		grpcMetrics.InitializeMetrics(grpcSrv)
 		if c.GRPC.Reflection {

--- a/config.docker.yaml
+++ b/config.docker.yaml
@@ -39,6 +39,8 @@ oauth2:
   responseTypes: {{ getenv "DEX_OAUTH2_RESPONSE_TYPES" "[code]" }}
   skipApprovalScreen: {{ getenv "DEX_OAUTH2_SKIP_APPROVAL_SCREEN" "false" }}
   alwaysShowLoginScreen: {{ getenv "DEX_OAUTH2_ALWAYS_SHOW_LOGIN_SCREEN" "false" }}
+  subjectClaim: {{ getenv "DEX_OAUTH2_SUBJECT_CLAIM" "base64" }}
+  subjectClaimOrder: {{ getenv "DEX_OAUTH2_SUBJECT_CLAIM_ORDER" "user-connector" }}
 {{- if getenv "DEX_OAUTH2_PASSWORD_CONNECTOR" "" }}
   passwordConnector: {{ .Env.DEX_OAUTH2_PASSWORD_CONNECTOR }}
 {{- end }}

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -132,6 +132,15 @@ web:
 #   # Uncomment to use a specific connector for password grants
 #   passwordConnector: local
 #
+#   # Format of the ID token "sub" claim.
+#   # "base64" (default): protobuf+base64url encoded subject.
+#   # "plain": url-escaped "<userID>|<connectorID>".
+#   subjectClaim: base64
+#   # Field order for "plain" subject claims.
+#   # "user-connector" (default): "<userID>|<connectorID>"
+#   # "connector-user": "<connectorID>|<userID>"
+#   subjectClaimOrder: user-connector
+#
 #   # PKCE (Proof Key for Code Exchange) configuration
 #   pkce:
 #     # If true, PKCE is required for all authorization code flows (OAuth 2.1).

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -134,6 +134,14 @@ oauth2:
   # The password grant is refused without this: dex needs to know which
   # connector checks the password.
   passwordConnector: local
+  # Format of the ID token "sub" claim.
+  # "base64" (default): protobuf+base64url encoded subject.
+  # "plain": url-escaped "<userID>|<connectorID>".
+  # subjectClaim: base64
+  # Field order for "plain" subject claims.
+  # "user-connector" (default): "<userID>|<connectorID>"
+  # "connector-user": "<connectorID>|<userID>"
+  # subjectClaimOrder: user-connector
 
 # Default values shown below
 # oauth2:
@@ -158,6 +166,14 @@ oauth2:
 #   alwaysShowLoginScreen: false
 #   # Uncomment the passwordConnector to use a specific connector for password grants
 #   passwordConnector: local
+#   # Format of the ID token "sub" claim.
+#   # "base64" (default): protobuf+base64url encoded subject.
+#   # "plain": url-escaped "<userID>|<connectorID>".
+#   # subjectClaim: base64
+#   # Field order for "plain" subject claims.
+#   # "user-connector" (default): "<userID>|<connectorID>"
+#   # "connector-user": "<connectorID>|<userID>"
+#   # subjectClaimOrder: user-connector
 #   # PKCE (Proof Key for Code Exchange) configuration
 #   pkce:
 #     # If true, PKCE is required for all authorization code flows (OAuth 2.1).

--- a/server/apiserver/api.go
+++ b/server/apiserver/api.go
@@ -24,29 +24,31 @@ const apiVersion = 4
 // connector CRUD, the discovery handler to serve the same document as HTTP, and
 // the back-channel notifier to tell relying parties about the sessions it ends —
 // rather than the whole Server.
-func NewAPI(s storage.Storage, logger *slog.Logger, version string, conns *connectors.Cache, disc *discovery.Handler, bc *backchannel.Notifier) api.DexServer {
+func NewAPI(s storage.Storage, logger *slog.Logger, version string, conns *connectors.Cache, disc *discovery.Handler, bc *backchannel.Notifier, subjectOrder tokens.SubjectOrder) api.DexServer {
 	apiLogger := logger.With("component", "api")
 	return dexAPI{
-		s:           s,
-		logger:      apiLogger,
-		version:     version,
-		connectors:  conns,
-		discovery:   disc,
-		backchannel: bc,
-		refresh:     tokens.NewRefreshStore(s, time.Now, apiLogger),
+		s:            s,
+		logger:       apiLogger,
+		version:      version,
+		connectors:   conns,
+		discovery:    disc,
+		backchannel:  bc,
+		refresh:      tokens.NewRefreshStore(s, time.Now, apiLogger),
+		subjectOrder: subjectOrder,
 	}
 }
 
 type dexAPI struct {
 	api.UnimplementedDexServer
 
-	s           storage.Storage
-	logger      *slog.Logger
-	version     string
-	connectors  *connectors.Cache
-	discovery   *discovery.Handler
-	backchannel *backchannel.Notifier
-	refresh     *tokens.RefreshStore
+	s            storage.Storage
+	logger       *slog.Logger
+	version      string
+	connectors   *connectors.Cache
+	discovery    *discovery.Handler
+	backchannel  *backchannel.Notifier
+	refresh      *tokens.RefreshStore
+	subjectOrder tokens.SubjectOrder
 }
 
 func (d dexAPI) GetVersion(ctx context.Context, req *api.VersionReq) (*api.VersionResp, error) {

--- a/server/apiserver/api_test.go
+++ b/server/apiserver/api_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/dexidp/dex/api/v2"
 	"github.com/dexidp/dex/server/internal"
+	"github.com/dexidp/dex/server/tokens"
 	"github.com/dexidp/dex/storage"
 	"github.com/dexidp/dex/storage/memory"
 )
@@ -41,7 +42,7 @@ func newAPI(t *testing.T, s storage.Storage, logger *slog.Logger) *apiClient {
 	}
 
 	serv := grpc.NewServer()
-	api.RegisterDexServer(serv, NewAPI(s, logger, "test", nil, nil, nil))
+	api.RegisterDexServer(serv, NewAPI(s, logger, "test", nil, nil, nil, tokens.SubjectOrderUserConnector))
 	go serv.Serve(l)
 
 	// NewClient will retry automatically if the serv.Serve() goroutine

--- a/server/apiserver/connectors_test.go
+++ b/server/apiserver/connectors_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dexidp/dex/connector"
 	"github.com/dexidp/dex/connector/mock"
 	"github.com/dexidp/dex/server/connectors"
+	"github.com/dexidp/dex/server/tokens"
 	"github.com/dexidp/dex/storage/memory"
 )
 
@@ -26,7 +27,7 @@ func TestConnectorCacheInvalidation(t *testing.T) {
 
 	// This test exercises connector-cache invalidation, not discovery, so no
 	// discovery handler is wired (GetDiscovery guards against nil).
-	apiServer := NewAPI(s, logger, "test", conns, nil, nil)
+	apiServer := NewAPI(s, logger, "test", conns, nil, nil, tokens.SubjectOrderUserConnector)
 	ctx := context.Background()
 
 	connID := "mock-conn"

--- a/server/apiserver/refresh.go
+++ b/server/apiserver/refresh.go
@@ -4,18 +4,18 @@ import (
 	"context"
 
 	"github.com/dexidp/dex/api/v2"
-	"github.com/dexidp/dex/server/internal"
+	"github.com/dexidp/dex/server/tokens"
 	"github.com/dexidp/dex/storage"
 )
 
 func (d dexAPI) ListRefresh(ctx context.Context, req *api.ListRefreshReq) (*api.ListRefreshResp, error) {
-	id := new(internal.IDTokenSubject)
-	if err := internal.Unmarshal(req.UserId, id); err != nil {
+	userID, connectorID, err := tokens.ParseSubjectWithOrder(req.UserId, d.subjectOrder)
+	if err != nil {
 		d.logger.Error("failed to unmarshal ID Token subject", "err", err)
 		return nil, err
 	}
 
-	offlineSessions, err := d.s.GetOfflineSessions(ctx, id.UserId, id.ConnId)
+	offlineSessions, err := d.s.GetOfflineSessions(ctx, userID, connectorID)
 	if err != nil {
 		if err == storage.ErrNotFound {
 			// This means that this user-client pair does not have a refresh token yet.
@@ -43,8 +43,8 @@ func (d dexAPI) ListRefresh(ctx context.Context, req *api.ListRefreshReq) (*api.
 }
 
 func (d dexAPI) RevokeRefresh(ctx context.Context, req *api.RevokeRefreshReq) (*api.RevokeRefreshResp, error) {
-	id := new(internal.IDTokenSubject)
-	if err := internal.Unmarshal(req.UserId, id); err != nil {
+	userID, connectorID, err := tokens.ParseSubjectWithOrder(req.UserId, d.subjectOrder)
+	if err != nil {
 		d.logger.Error("failed to unmarshal ID Token subject", "err", err)
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (d dexAPI) RevokeRefresh(ctx context.Context, req *api.RevokeRefreshReq) (*
 	updater := func(old storage.OfflineSessions) (storage.OfflineSessions, error) {
 		refreshRef := old.Refresh[req.ClientId]
 		if refreshRef == nil || refreshRef.ID == "" {
-			d.logger.Error("refresh token issued to client not found for deletion", "client_id", req.ClientId, "user_id", id.UserId)
+			d.logger.Error("refresh token issued to client not found for deletion", "client_id", req.ClientId, "user_id", userID)
 			notFound = true
 			return old, storage.ErrNotFound
 		}
@@ -69,7 +69,7 @@ func (d dexAPI) RevokeRefresh(ctx context.Context, req *api.RevokeRefreshReq) (*
 		return old, nil
 	}
 
-	if err := d.s.UpdateOfflineSessions(ctx, id.UserId, id.ConnId, updater); err != nil {
+	if err := d.s.UpdateOfflineSessions(ctx, userID, connectorID, updater); err != nil {
 		if err == storage.ErrNotFound {
 			return &api.RevokeRefreshResp{NotFound: true}, nil
 		}

--- a/server/apiserver/sessions_test.go
+++ b/server/apiserver/sessions_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dexidp/dex/server/backchannel"
 	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/signer"
+	subjecttokens "github.com/dexidp/dex/server/tokens"
 	"github.com/dexidp/dex/storage"
 	"github.com/dexidp/dex/storage/memory"
 )
@@ -83,7 +84,7 @@ func TestTerminateSessionNotifiesRelyingParties(t *testing.T) {
 
 			d := NewAPI(s, logger, "test", nil, nil, &backchannel.Notifier{
 				Storage: s, Signer: sign, IssuerURL: issuerURL(t), Logger: logger,
-			})
+			}, subjecttokens.SubjectOrderUserConnector)
 
 			require.NoError(t, tc.call(ctx, d))
 

--- a/server/authflow/handler.go
+++ b/server/authflow/handler.go
@@ -40,6 +40,8 @@ type Handler struct {
 	Sessions *session.Manager
 	// Issuer mints tokens for the authorization response (see response.go).
 	Issuer *tokens.Issuer
+	// SubjectOrder is used to parse plain id_token_hint subjects.
+	SubjectOrder tokens.SubjectOrder
 
 	// MFAEnabled reports whether any authenticator is configured; DefaultMFAChain
 	// is the chain applied to clients that set none. Together they let the

--- a/server/authflow/handler_test.go
+++ b/server/authflow/handler_test.go
@@ -104,7 +104,7 @@ func newTestHandler(t *testing.T, updateConfig func(c *testFlowConfig)) (*httpte
 
 	now := func() time.Time { return time.Now() }
 	conns := connectors.NewCache(store, testResolveConnector)
-	issuer := tokens.NewIssuer(store, sig, *issuerURL, 24*time.Hour, now, logger)
+	issuer := tokens.NewIssuer(store, sig, *issuerURL, 24*time.Hour, tokens.SubjectFormatBase64, now, logger)
 
 	tc := testFlowConfig{
 		Handler: Handler{

--- a/server/authflow/login.go
+++ b/server/authflow/login.go
@@ -107,7 +107,7 @@ func (h *Handler) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 		// id_token_hint logic (OIDC Core 1.0 3.1.2.1):
 		// When a hint is provided, verify that the session user matches.
 		if hintSubject != "" {
-			if !sessionMatchesHint(session, hintSubject) {
+			if !sessionMatchesHint(session, hintSubject, h.SubjectOrder) {
 				// Clear the session if the user is different from the hint.
 				session = nil
 			}

--- a/server/authflow/request.go
+++ b/server/authflow/request.go
@@ -136,17 +136,16 @@ func validateConnectorID(connectors []storage.Connector, connectorID string) boo
 }
 
 // sessionMatchesHint checks whether the session's user identity matches the
-// subject from an id_token_hint by encoding the session's (userID, connectorID)
-// via GenSubject and doing a string comparison.
-func sessionMatchesHint(session *storage.AuthSession, hintSubject string) bool {
+// subject from an id_token_hint.
+func sessionMatchesHint(session *storage.AuthSession, hintSubject string, order tokens.SubjectOrder) bool {
 	if session == nil {
 		return false
 	}
-	encoded, err := tokens.GenSubject(session.UserID, session.ConnectorID)
+	userID, connectorID, err := tokens.ParseSubjectWithOrder(hintSubject, order)
 	if err != nil {
 		return false
 	}
-	return encoded == hintSubject
+	return session.UserID == userID && session.ConnectorID == connectorID
 }
 
 // PKCEConfig holds PKCE (Proof Key for Code Exchange) settings.

--- a/server/authflow/request_test.go
+++ b/server/authflow/request_test.go
@@ -842,10 +842,10 @@ func TestValidateIDTokenHint(t *testing.T) {
 
 func TestSessionMatchesHint(t *testing.T) {
 	// tokens.GenSubject("foo", "bar") == "CgNmb28SA2Jhcg" (from TestGetSubject)
-	assert.True(t, sessionMatchesHint(&storage.AuthSession{UserID: "foo", ConnectorID: "bar"}, "CgNmb28SA2Jhcg"))
-	assert.False(t, sessionMatchesHint(&storage.AuthSession{UserID: "other", ConnectorID: "bar"}, "CgNmb28SA2Jhcg"))
-	assert.False(t, sessionMatchesHint(&storage.AuthSession{UserID: "foo", ConnectorID: "other"}, "CgNmb28SA2Jhcg"))
-	assert.False(t, sessionMatchesHint(nil, "CgNmb28SA2Jhcg"))
+	assert.True(t, sessionMatchesHint(&storage.AuthSession{UserID: "foo", ConnectorID: "bar"}, "CgNmb28SA2Jhcg", tokens.SubjectOrderUserConnector))
+	assert.False(t, sessionMatchesHint(&storage.AuthSession{UserID: "other", ConnectorID: "bar"}, "CgNmb28SA2Jhcg", tokens.SubjectOrderUserConnector))
+	assert.False(t, sessionMatchesHint(&storage.AuthSession{UserID: "foo", ConnectorID: "other"}, "CgNmb28SA2Jhcg", tokens.SubjectOrderUserConnector))
+	assert.False(t, sessionMatchesHint(nil, "CgNmb28SA2Jhcg", tokens.SubjectOrderUserConnector))
 }
 
 func TestParseAuthorizationRequest_IDTokenHint(t *testing.T) {

--- a/server/authflow/sessionlogin_test.go
+++ b/server/authflow/sessionlogin_test.go
@@ -817,7 +817,7 @@ func TestTrySessionLoginWithSession_IDTokenHint(t *testing.T) {
 		require.NotNil(t, session)
 
 		// Verify hint matches.
-		assert.True(t, sessionMatchesHint(session, hintSubjectForUser1Mock))
+		assert.True(t, sessionMatchesHint(session, hintSubjectForUser1Mock, tokens.SubjectOrderUserConnector))
 
 		r := sessionCookieRequest("test-nonce")
 		w := httptest.NewRecorder()
@@ -835,7 +835,7 @@ func TestTrySessionLoginWithSession_IDTokenHint(t *testing.T) {
 		require.NotNil(t, session)
 
 		// Verify hint does NOT match.
-		assert.False(t, sessionMatchesHint(session, hintSubjectOther))
+		assert.False(t, sessionMatchesHint(session, hintSubjectOther, tokens.SubjectOrderUserConnector))
 
 		// Simulating the hint mismatch logic from handleConnectorLogin:
 		// when hint doesn't match and prompt is not none, session is set to nil.

--- a/server/backchannel/backchannel.go
+++ b/server/backchannel/backchannel.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/dexidp/dex/server/internal"
 	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/signer"
+	"github.com/dexidp/dex/server/tokens"
 	"github.com/dexidp/dex/storage"
 )
 
@@ -40,10 +40,12 @@ const (
 // It lives outside server/logout because a session also ends by an operator's hand
 // over the gRPC API, and every path that ends one goes through here.
 type Notifier struct {
-	Storage   storage.Storage
-	Signer    signer.Signer
-	IssuerURL oauth2.IssuerURL
-	Logger    *slog.Logger
+	Storage       storage.Storage
+	Signer        signer.Signer
+	IssuerURL     oauth2.IssuerURL
+	Logger        *slog.Logger
+	SubjectFormat tokens.SubjectFormat
+	SubjectOrder  tokens.SubjectOrder
 
 	// Now is the clock, for tests. Defaults to time.Now.
 	Now func() time.Time
@@ -82,10 +84,7 @@ func (n *Notifier) Notify(ctx context.Context, authSession *storage.AuthSession)
 		return
 	}
 
-	subject, err := internal.Marshal(&internal.IDTokenSubject{
-		UserId: authSession.UserID,
-		ConnId: authSession.ConnectorID,
-	})
+	subject, err := tokens.GenSubjectWithFormatAndOrder(authSession.UserID, authSession.ConnectorID, n.SubjectFormat, n.SubjectOrder)
 	if err != nil {
 		n.Logger.ErrorContext(ctx, "logout: failed to marshal backchannel subject", "err", err)
 		return

--- a/server/config.go
+++ b/server/config.go
@@ -88,6 +88,13 @@ type Config struct {
 	// Signer is used to sign tokens.
 	Signer signer.Signer
 
+	// SubjectClaimFormat configures how Dex formats the ID token "sub" claim.
+	// Defaults to "base64".
+	SubjectClaimFormat tokens.SubjectFormat
+	// SubjectClaimOrder configures the field order for plain subject claims.
+	// Defaults to "user-connector".
+	SubjectClaimOrder tokens.SubjectOrder
+
 	PrometheusRegistry *prometheus.Registry
 
 	HealthChecker gosundheit.Health
@@ -188,6 +195,16 @@ func normalizeConfig(c *Config) (resolvedConfig, error) {
 	if len(c.PKCE.CodeChallengeMethodsSupported) == 0 {
 		c.PKCE.CodeChallengeMethodsSupported = []string{oauth2.PKCEMethodS256, oauth2.PKCEMethodPlain}
 	}
+	subjectClaimFormat, err := tokens.ParseSubjectFormat(string(c.SubjectClaimFormat))
+	if err != nil {
+		return resolvedConfig{}, fmt.Errorf("unsupported subject claim format %q", c.SubjectClaimFormat)
+	}
+	c.SubjectClaimFormat = subjectClaimFormat
+	subjectClaimOrder, err := tokens.ParseSubjectOrder(string(c.SubjectClaimOrder))
+	if err != nil {
+		return resolvedConfig{}, fmt.Errorf("unsupported subject claim order %q", c.SubjectClaimOrder)
+	}
+	c.SubjectClaimOrder = subjectClaimOrder
 	for _, m := range c.PKCE.CodeChallengeMethodsSupported {
 		if m != oauth2.PKCEMethodS256 && m != oauth2.PKCEMethodPlain {
 			return resolvedConfig{}, fmt.Errorf("unsupported PKCE challenge method %q", m)

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dexidp/dex/server/oauth2"
+	"github.com/dexidp/dex/server/tokens"
 	"github.com/dexidp/dex/storage/memory"
 )
 
@@ -28,6 +29,8 @@ func TestNormalizeConfigDefaults(t *testing.T) {
 	require.Equal(t, []string{oauth2.ResponseTypeCode}, c.SupportedResponseTypes)
 	require.Equal(t, []string{"Authorization"}, c.AllowedHeaders)
 	require.Equal(t, []string{oauth2.PKCEMethodS256, oauth2.PKCEMethodPlain}, c.PKCE.CodeChallengeMethodsSupported)
+	require.Equal(t, tokens.SubjectFormatBase64, c.SubjectClaimFormat)
+	require.Equal(t, tokens.SubjectOrderUserConnector, c.SubjectClaimOrder)
 
 	require.Equal(t, "https://dex.example.com", rc.issuerURL.String())
 	require.NotNil(t, rc.now)
@@ -102,6 +105,20 @@ func TestNormalizeConfigRejects(t *testing.T) {
 				c.PKCE.CodeChallengeMethodsSupported = []string{"S512"}
 			},
 			errMsg: `unsupported PKCE challenge method "S512"`,
+		},
+		{
+			name: "unknown subject claim format",
+			mutate: func(c *Config) {
+				c.SubjectClaimFormat = "unsupported"
+			},
+			errMsg: `unsupported subject claim format "unsupported"`,
+		},
+		{
+			name: "unknown subject claim order",
+			mutate: func(c *Config) {
+				c.SubjectClaimOrder = "backwards"
+			},
+			errMsg: `unsupported subject claim order "backwards"`,
 		},
 	}
 

--- a/server/introspection/introspection.go
+++ b/server/introspection/introspection.go
@@ -168,6 +168,8 @@ type Handler struct {
 	Storage       storage.Storage
 	Logger        *slog.Logger
 	RefreshPolicy *tokens.RefreshStrategy
+	SubjectFormat tokens.SubjectFormat
+	SubjectOrder  tokens.SubjectOrder
 
 	// Sessions resolves whether the browser session a token was issued under is
 	// still alive. Nil when sessions are disabled, in which case no token carries
@@ -254,7 +256,7 @@ func (h *Handler) introspectRefreshToken(ctx context.Context, token string) (*In
 		return nil, newIntrospectInternalServerError()
 	}
 
-	subjectString, sErr := tokens.GenSubject(refresh.Claims.UserID, refresh.ConnectorID)
+	subjectString, sErr := tokens.GenSubjectWithFormatAndOrder(refresh.Claims.UserID, refresh.ConnectorID, h.SubjectFormat, h.SubjectOrder)
 	if sErr != nil {
 		h.Logger.ErrorContext(ctx, "failed to marshal offline session ID", "err", sErr)
 		return nil, newIntrospectInternalServerError()

--- a/server/introspection/introspection_test.go
+++ b/server/introspection/introspection_test.go
@@ -46,7 +46,7 @@ func testAccessToken(t *testing.T) string {
 	issURL, err := url.Parse(testIssuer)
 	require.NoError(t, err)
 
-	issuer := tokens.NewIssuer(memory.New(logger), sig, *issURL, time.Hour, time.Now, logger)
+	issuer := tokens.NewIssuer(memory.New(logger), sig, *issURL, time.Hour, tokens.SubjectFormatBase64, time.Now, logger)
 	token, _, err := issuer.SignIDToken(ctx, tokens.Authorization{
 		Client:      storage.Client{ID: "test"},
 		Claims:      storage.Claims{UserID: "1", Username: "jane"},

--- a/server/logout/logout.go
+++ b/server/logout/logout.go
@@ -16,7 +16,6 @@ import (
 	"github.com/dexidp/dex/connector"
 	"github.com/dexidp/dex/server/backchannel"
 	"github.com/dexidp/dex/server/connectors"
-	"github.com/dexidp/dex/server/internal"
 	"github.com/dexidp/dex/server/oauth2"
 	"github.com/dexidp/dex/server/router"
 	"github.com/dexidp/dex/server/session"
@@ -30,15 +29,16 @@ import (
 // (sessions, storage, connectors, the token issuer), so it carries no login-flow
 // code.
 type Handler struct {
-	Storage    storage.Storage
-	Templates  *templates.Templates
-	Logger     *slog.Logger
-	Sessions   *session.Manager
-	Connectors *connectors.Cache
-	Issuer     *tokens.Issuer
-	Signer     signer.Signer
-	IssuerURL  oauth2.IssuerURL
-	Now        func() time.Time
+	Storage      storage.Storage
+	Templates    *templates.Templates
+	Logger       *slog.Logger
+	Sessions     *session.Manager
+	Connectors   *connectors.Cache
+	Issuer       *tokens.Issuer
+	Signer       signer.Signer
+	IssuerURL    oauth2.IssuerURL
+	SubjectOrder tokens.SubjectOrder
+	Now          func() time.Time
 
 	// Backchannel tells the session's relying parties that it ended. The same
 	// notifier serves the gRPC API, which ends sessions too.
@@ -255,8 +255,8 @@ func (h *Handler) parseIDTokenHint(ctx context.Context, raw string) (idTokenHint
 		return idTokenHint{}, err
 	}
 
-	sub := new(internal.IDTokenSubject)
-	if err := internal.Unmarshal(idToken.Subject, sub); err != nil {
+	userID, connectorID, err := tokens.ParseSubjectWithOrder(idToken.Subject, h.SubjectOrder)
+	if err != nil {
 		return idTokenHint{}, fmt.Errorf("unmarshal subject: %w", err)
 	}
 
@@ -271,8 +271,8 @@ func (h *Handler) parseIDTokenHint(ctx context.Context, raw string) (idTokenHint
 	}
 
 	hint := idTokenHint{
-		userID:      sub.UserId,
-		connectorID: sub.ConnId,
+		userID:      userID,
+		connectorID: connectorID,
 		sessionID:   claims.SessionID,
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -103,14 +103,17 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		Logger:    s.logger,
 		IssuerURL: s.issuerURL,
 	}
-	s.issuer = tokens.NewIssuer(s.storage, c.Signer, s.issuerURL.URL, rc.idTokensValidFor, rc.now, s.logger)
+	s.issuer = tokens.NewIssuer(s.storage, c.Signer, s.issuerURL.URL, rc.idTokensValidFor, c.SubjectClaimFormat, rc.now, s.logger)
+	s.issuer.SetSubjectOrder(c.SubjectClaimOrder)
 	s.connectors = connectors.NewCache(s.storage, connectors.Resolver(s.storage, s.logger, ConnectorsConfig))
 	s.backchannel = &backchannel.Notifier{
-		Storage:   s.storage,
-		Signer:    c.Signer,
-		IssuerURL: s.issuerURL,
-		Logger:    s.logger,
-		Now:       rc.now,
+		Storage:       s.storage,
+		Signer:        c.Signer,
+		IssuerURL:     s.issuerURL,
+		Logger:        s.logger,
+		SubjectFormat: c.SubjectClaimFormat,
+		SubjectOrder:  c.SubjectClaimOrder,
+		Now:           rc.now,
 	}
 	// Build the discovery handler once from config; both the mounted HTTP route
 	// and the gRPC API (via Discovery) serve this same handler.
@@ -258,6 +261,8 @@ func (s *Server) mount(routes router.Mux, c Config, rc resolvedConfig) {
 			Storage:       s.storage,
 			Logger:        s.logger,
 			RefreshPolicy: c.RefreshTokenPolicy,
+			SubjectFormat: c.SubjectClaimFormat,
+			SubjectOrder:  c.SubjectClaimOrder,
 			Sessions:      sessions,
 		},
 		&device.Handler{
@@ -291,6 +296,7 @@ func (s *Server) mount(routes router.Mux, c Config, rc resolvedConfig) {
 			AuthRequestsValidFor:   rc.authRequestsValidFor,
 			Sessions:               sessions,
 			Issuer:                 s.issuer,
+			SubjectOrder:           c.SubjectClaimOrder,
 			MFAEnabled:             len(c.MFAProviders) > 0,
 			DefaultMFAChain:        c.DefaultMFAChain,
 			SkipApproval:           c.SkipApprovalScreen,
@@ -314,16 +320,17 @@ func (s *Server) mount(routes router.Mux, c Config, rc resolvedConfig) {
 			SkipApproval: c.SkipApprovalScreen,
 		},
 		&logout.Handler{
-			Storage:     s.storage,
-			Templates:   s.templates,
-			Logger:      s.logger,
-			Sessions:    sessions,
-			Connectors:  s.connectors,
-			Issuer:      s.issuer,
-			Signer:      c.Signer,
-			IssuerURL:   s.issuerURL,
-			Now:         rc.now,
-			Backchannel: s.backchannel,
+			Storage:      s.storage,
+			Templates:    s.templates,
+			Logger:       s.logger,
+			Sessions:     sessions,
+			Connectors:   s.connectors,
+			Issuer:       s.issuer,
+			Signer:       c.Signer,
+			IssuerURL:    s.issuerURL,
+			Now:          rc.now,
+			Backchannel:  s.backchannel,
+			SubjectOrder: c.SubjectClaimOrder,
 		},
 	} {
 		h.Mount(routes)

--- a/server/server_oauth2_test.go
+++ b/server/server_oauth2_test.go
@@ -180,7 +180,7 @@ func TestNewIDTokenUsesStoredAlgorithmUntilNextRotation(t *testing.T) {
 	issuerURL, err := url.Parse("https://issuer.example.com")
 	require.NoError(t, err)
 
-	issuer := tokens.NewIssuer(store, sig, *issuerURL, time.Hour, func() time.Time { return now }, logger)
+	issuer := tokens.NewIssuer(store, sig, *issuerURL, time.Hour, tokens.SubjectFormatBase64, func() time.Time { return now }, logger)
 
 	accessToken := "test-access-token"
 	code := "test-auth-code"
@@ -259,7 +259,7 @@ func TestNewIDTokenContainsJTI(t *testing.T) {
 	issuerURL, err := url.Parse("https://issuer.example.com")
 	require.NoError(t, err)
 
-	issuer := tokens.NewIssuer(store, sig, *issuerURL, time.Hour, func() time.Time { return now }, logger)
+	issuer := tokens.NewIssuer(store, sig, *issuerURL, time.Hour, tokens.SubjectFormatBase64, func() time.Time { return now }, logger)
 
 	keys, err := sig.ValidationKeys(ctx)
 	require.NoError(t, err)

--- a/server/tokens/claims.go
+++ b/server/tokens/claims.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"net/url"
+	"strings"
 
 	jose "github.com/go-jose/go-jose/v4"
 
@@ -97,6 +99,20 @@ type FederatedIDClaims struct {
 	UserID      string `json:"user_id,omitempty"`
 }
 
+type SubjectFormat string
+
+const (
+	SubjectFormatBase64 SubjectFormat = "base64"
+	SubjectFormatPlain  SubjectFormat = "plain"
+)
+
+type SubjectOrder string
+
+const (
+	SubjectOrderUserConnector SubjectOrder = "user-connector"
+	SubjectOrderConnectorUser SubjectOrder = "connector-user"
+)
+
 // GetClientID resolves the requesting client from an audience and azp: the single
 // audience entry, or the azp when the audience holds several clients.
 func GetClientID(aud Audience, azp string) (string, error) {
@@ -137,10 +153,106 @@ func GetAudience(clientID string, scopes []string) Audience {
 
 // GenSubject encodes a (userID, connectorID) pair into an ID token subject.
 func GenSubject(userID string, connID string) (string, error) {
-	sub := &internal.IDTokenSubject{
-		UserId: userID,
-		ConnId: connID,
+	return GenSubjectWithFormatAndOrder(userID, connID, SubjectFormatBase64, SubjectOrderUserConnector)
+}
+
+func ParseSubjectFormat(raw string) (SubjectFormat, error) {
+	format := SubjectFormat(raw)
+	if format == "" {
+		return SubjectFormatBase64, nil
+	}
+	switch format {
+	case SubjectFormatBase64, SubjectFormatPlain:
+		return format, nil
+	case "legacy":
+		return SubjectFormatBase64, nil
+	case "pair":
+		return SubjectFormatPlain, nil
+	default:
+		return "", fmt.Errorf("unsupported subject format %q", raw)
+	}
+}
+
+func GenSubjectWithFormat(userID string, connID string, format SubjectFormat) (string, error) {
+	return GenSubjectWithFormatAndOrder(userID, connID, format, SubjectOrderUserConnector)
+}
+
+func ParseSubjectOrder(raw string) (SubjectOrder, error) {
+	order := SubjectOrder(raw)
+	if order == "" {
+		return SubjectOrderUserConnector, nil
+	}
+	switch order {
+	case SubjectOrderUserConnector, SubjectOrderConnectorUser:
+		return order, nil
+	case "userID,connectorID", "default":
+		return SubjectOrderUserConnector, nil
+	case "connectorID,userID", "reversed":
+		return SubjectOrderConnectorUser, nil
+	default:
+		return "", fmt.Errorf("unsupported subject order %q", raw)
+	}
+}
+
+func GenSubjectWithFormatAndOrder(userID string, connID string, format SubjectFormat, order SubjectOrder) (string, error) {
+	switch format {
+	case "", SubjectFormatBase64:
+		sub := &internal.IDTokenSubject{
+			UserId: userID,
+			ConnId: connID,
+		}
+
+		return internal.Marshal(sub)
+	case SubjectFormatPlain:
+		o, err := ParseSubjectOrder(string(order))
+		if err != nil {
+			return "", err
+		}
+		if o == SubjectOrderConnectorUser {
+			return url.QueryEscape(connID) + "|" + url.QueryEscape(userID), nil
+		}
+		return url.QueryEscape(userID) + "|" + url.QueryEscape(connID), nil
+	default:
+		return "", fmt.Errorf("unsupported subject format %q", format)
+	}
+}
+
+// ParseSubject decodes an ID token subject into (userID, connectorID).
+func ParseSubject(subject string) (string, string, error) {
+	return ParseSubjectWithOrder(subject, SubjectOrderUserConnector)
+}
+
+// ParseSubjectWithOrder decodes an ID token subject into (userID, connectorID).
+func ParseSubjectWithOrder(subject string, order SubjectOrder) (string, string, error) {
+	if strings.Contains(subject, "|") {
+		o, err := ParseSubjectOrder(string(order))
+		if err != nil {
+			return "", "", err
+		}
+		parts := strings.SplitN(subject, "|", 2)
+		if len(parts) != 2 {
+			return "", "", fmt.Errorf("invalid plain subject")
+		}
+		first, err := url.QueryUnescape(parts[0])
+		if err != nil {
+			return "", "", fmt.Errorf("invalid plain subject first segment: %w", err)
+		}
+		second, err := url.QueryUnescape(parts[1])
+		if err != nil {
+			return "", "", fmt.Errorf("invalid plain subject second segment: %w", err)
+		}
+		if o == SubjectOrderConnectorUser {
+			return second, first, nil
+		}
+		return first, second, nil
 	}
 
-	return internal.Marshal(sub)
+	sub := &internal.IDTokenSubject{
+		UserId: "",
+		ConnId: "",
+	}
+	if err := internal.Unmarshal(subject, sub); err != nil {
+		return "", "", err
+	}
+	return sub.UserId, sub.ConnId, nil
 }

--- a/server/tokens/claims_test.go
+++ b/server/tokens/claims_test.go
@@ -34,6 +34,77 @@ func TestGenSubject(t *testing.T) {
 	require.Equal(t, "CgNmb28SA2Jhcg", sub)
 }
 
+func TestGenAndParseSubjectPlainFormat(t *testing.T) {
+	sub, err := GenSubjectWithFormat("user:one@example.com", "oidc|github", SubjectFormatPlain)
+	require.NoError(t, err)
+	require.Equal(t, "user%3Aone%40example.com|oidc%7Cgithub", sub)
+
+	userID, connectorID, err := ParseSubject(sub)
+	require.NoError(t, err)
+	require.Equal(t, "user:one@example.com", userID)
+	require.Equal(t, "oidc|github", connectorID)
+}
+
+func TestGenAndParseSubjectPlainFormatWithReversedOrder(t *testing.T) {
+	sub, err := GenSubjectWithFormatAndOrder("user:one@example.com", "oidc|github", SubjectFormatPlain, SubjectOrderConnectorUser)
+	require.NoError(t, err)
+	require.Equal(t, "oidc%7Cgithub|user%3Aone%40example.com", sub)
+
+	userID, connectorID, err := ParseSubjectWithOrder(sub, SubjectOrderConnectorUser)
+	require.NoError(t, err)
+	require.Equal(t, "user:one@example.com", userID)
+	require.Equal(t, "oidc|github", connectorID)
+}
+
+func TestParseSubjectLegacyFormat(t *testing.T) {
+	userID, connectorID, err := ParseSubject("CgNmb28SA2Jhcg")
+	require.NoError(t, err)
+	require.Equal(t, "foo", userID)
+	require.Equal(t, "bar", connectorID)
+}
+
+func TestParseSubjectFormat(t *testing.T) {
+	format, err := ParseSubjectFormat("")
+	require.NoError(t, err)
+	require.Equal(t, SubjectFormatBase64, format)
+
+	format, err = ParseSubjectFormat("plain")
+	require.NoError(t, err)
+	require.Equal(t, SubjectFormatPlain, format)
+
+	format, err = ParseSubjectFormat("legacy")
+	require.NoError(t, err)
+	require.Equal(t, SubjectFormatBase64, format)
+
+	format, err = ParseSubjectFormat("pair")
+	require.NoError(t, err)
+	require.Equal(t, SubjectFormatPlain, format)
+
+	_, err = ParseSubjectFormat("something-else")
+	require.ErrorContains(t, err, `unsupported subject format "something-else"`)
+}
+
+func TestParseSubjectOrder(t *testing.T) {
+	order, err := ParseSubjectOrder("")
+	require.NoError(t, err)
+	require.Equal(t, SubjectOrderUserConnector, order)
+
+	order, err = ParseSubjectOrder("user-connector")
+	require.NoError(t, err)
+	require.Equal(t, SubjectOrderUserConnector, order)
+
+	order, err = ParseSubjectOrder("connector-user")
+	require.NoError(t, err)
+	require.Equal(t, SubjectOrderConnectorUser, order)
+
+	order, err = ParseSubjectOrder("reversed")
+	require.NoError(t, err)
+	require.Equal(t, SubjectOrderConnectorUser, order)
+
+	_, err = ParseSubjectOrder("something-else")
+	require.ErrorContains(t, err, `unsupported subject order "something-else"`)
+}
+
 func TestAccessTokenHash(t *testing.T) {
 	// at_hash value and access_token returned by Google.
 	const (

--- a/server/tokens/issuer.go
+++ b/server/tokens/issuer.go
@@ -22,6 +22,8 @@ type Issuer struct {
 	signer           signer.Signer
 	issuerURL        url.URL
 	idTokensValidFor time.Duration
+	subjectFormat    SubjectFormat
+	subjectOrder     SubjectOrder
 	now              func() time.Time
 	logger           *slog.Logger
 
@@ -30,12 +32,17 @@ type Issuer struct {
 }
 
 // NewIssuer wires an issuer from the shared dependencies.
-func NewIssuer(storage storage.Storage, sig signer.Signer, issuerURL url.URL, idTokensValidFor time.Duration, now func() time.Time, logger *slog.Logger) *Issuer {
+func NewIssuer(storage storage.Storage, sig signer.Signer, issuerURL url.URL, idTokensValidFor time.Duration, subjectFormat SubjectFormat, now func() time.Time, logger *slog.Logger) *Issuer {
+	if subjectFormat == "" {
+		subjectFormat = SubjectFormatBase64
+	}
 	return &Issuer{
 		storage:          storage,
 		signer:           sig,
 		issuerURL:        issuerURL,
 		idTokensValidFor: idTokensValidFor,
+		subjectFormat:    subjectFormat,
+		subjectOrder:     SubjectOrderUserConnector,
 		now:              now,
 		logger:           logger,
 		Refresh:          NewRefreshStore(storage, now, logger),
@@ -83,6 +90,18 @@ func (i *Issuer) IssueResponse(ctx context.Context, auth Authorization, code str
 	return ts.Response(i.now()), nil
 }
 
+func (i *Issuer) Subject(userID, connectorID string) (string, error) {
+	return GenSubjectWithFormatAndOrder(userID, connectorID, i.subjectFormat, i.subjectOrder)
+}
+
+func (i *Issuer) SetSubjectOrder(order SubjectOrder) {
+	if order == "" {
+		i.subjectOrder = SubjectOrderUserConnector
+		return
+	}
+	i.subjectOrder = order
+}
+
 // SignAccessToken mints an opaque-looking JWT access token. Dex's access token is
 // an ID token bound to a random value, so each access token is unique.
 func (i *Issuer) SignAccessToken(ctx context.Context, auth Authorization) (string, time.Time, error) {
@@ -95,7 +114,7 @@ func (i *Issuer) SignIDToken(ctx context.Context, auth Authorization, accessToke
 	issuedAt := i.now()
 	expiry := issuedAt.Add(i.idTokensValidFor)
 
-	subjectString, err := GenSubject(auth.Claims.UserID, auth.ConnectorID)
+	subjectString, err := GenSubjectWithFormatAndOrder(auth.Claims.UserID, auth.ConnectorID, i.subjectFormat, i.subjectOrder)
 	if err != nil {
 		i.logger.ErrorContext(ctx, "failed to marshal offline session ID", "err", err)
 		return "", expiry, fmt.Errorf("failed to marshal offline session ID: %v", err)

--- a/server/tokens/issuer_test.go
+++ b/server/tokens/issuer_test.go
@@ -29,7 +29,7 @@ func newTestIssuer(t *testing.T) (*Issuer, storage.Storage) {
 	issuerURL, err := url.Parse("https://issuer.example.com")
 	require.NoError(t, err)
 
-	return NewIssuer(store, sig, *issuerURL, time.Hour, time.Now, logger), store
+	return NewIssuer(store, sig, *issuerURL, time.Hour, SubjectFormatBase64, time.Now, logger), store
 }
 
 func testAuthorization() Authorization {


### PR DESCRIPTION
#### Overview

Add configurable formats and field ordering for Dex OAuth2/OIDC `sub` claims.

#### What this PR does / why we need it

- Preserve the existing base64-encoded protobuf subject claim as the default.
- Add a URL-escaped plain subject format suitable for AWS IAM trust policies and wildcard matching.
- Add configurable `user-connector` and `connector-user` ordering.
- Preserve compatibility when parsing existing subjects across logout, introspection, auth flow, and refresh-token API paths.
- Document the new `oauth2.subjectClaim` and `oauth2.subjectClaimOrder` options and add coverage for configuration, encoding, parsing, and integration paths.

The plain format avoids protobuf length-prefix bytes in the claim, allowing AWS `StringLike` conditions to match meaningful subject components.

#### Special notes for your reviewer

- Default behavior remains unchanged: base64 format with user ID before connector ID.
- Compatibility aliases for the previous terminology remain accepted.
- Validation: `go test ./...` passes.
